### PR TITLE
VFB-4 Add components for Icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@cypress/code-coverage": "^3.10.7",
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
+        "@fortawesome/free-regular-svg-icons": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@supabase/auth-helpers-nextjs": "^0.7.2",
         "@supabase/auth-ui-react": "^0.4.2",
@@ -20,6 +24,7 @@
         "@types/node": "20.3.1",
         "@types/react": "18.2.13",
         "@types/react-dom": "18.2.6",
+        "@types/react-fontawesome": "^1.6.5",
         "@types/styled-components": "^5.1.26",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
@@ -2279,6 +2284,63 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+      "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+      "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+      "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -2933,6 +2995,14 @@
       "version": "18.2.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.6.tgz",
       "integrity": "sha512-2et4PDvg6PVCyS7fuTc4gPoksV58bW0RwSxWKcPRcHZf0PRUGq03TKcD/rUHe3azfV6/5/biUBJw+HhCQjaP0A==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-fontawesome": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@types/react-fontawesome/-/react-fontawesome-1.6.5.tgz",
+      "integrity": "sha512-O75ViR81klU7TfVt4TAdEOWzzEf58RM8PVQHUmKsHjhDt/WLMcb+h/k5XxHUv9iYAKI5u81IoMJ20wC+QLe3Dw==",
       "dependencies": {
         "@types/react": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@cypress/code-coverage": "^3.10.7",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
-        "@fortawesome/free-regular-svg-icons": "^6.4.0",
         "@fortawesome/free-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -2297,18 +2296,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
       "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.4.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
-      "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
       "hasInstallScript": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@cypress/code-coverage": "^3.10.7",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
-    "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-
     "start": "npm run build && next start",
     "lint": "next lint --dir src --dir cypress",
     "lint_fix": "next lint --fix --dir src --dir cypress",
@@ -13,7 +12,6 @@
     "test:component": "start-server-and-test dev http://localhost:3000 test:runner_component",
     "test:e2e": "start-server-and-test dev http://localhost:3000 test:runner_e2e",
     "test:coverage": "npm run coverage:generate && npm run coverage:run_tests && npm run coverage:report",
-
     "test:runner": "npm run test:runner_component && npm run test:runner_e2e",
     "test:runner_component": "npx cypress run --component",
     "test:runner_e2e": "npx cypress run",
@@ -28,6 +26,10 @@
   },
   "dependencies": {
     "@cypress/code-coverage": "^3.10.7",
+    "@fortawesome/fontawesome-svg-core": "^6.4.0",
+    "@fortawesome/free-regular-svg-icons": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^6.4.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@supabase/auth-helpers-nextjs": "^0.7.2",
     "@supabase/auth-ui-react": "^0.4.2",
@@ -39,6 +41,7 @@
     "@types/node": "20.3.1",
     "@types/react": "18.2.13",
     "@types/react-dom": "18.2.6",
+    "@types/react-fontawesome": "^1.6.5",
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",

--- a/src/components/Icons/CongestionChargeAppliesIcon.tsx
+++ b/src/components/Icons/CongestionChargeAppliesIcon.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faCopyright } from "@fortawesome/free-solid-svg-icons";
+
+const CongestionChargeAppliedIcon: React.FC = () => {
+    return <Icon icon={faCopyright} onHoverText={"Congestion charge applies"} />;
+};
+
+export default CongestionChargeAppliedIcon;

--- a/src/components/Icons/CongestionChargeAppliesIcon.tsx
+++ b/src/components/Icons/CongestionChargeAppliesIcon.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faCopyright } from "@fortawesome/free-solid-svg-icons";
 
-const CongestionChargeAppliedIcon: React.FC = () => {
-    return <Icon icon={faCopyright} onHoverText={"Congestion charge applies"} />;
+const CongestionChargeAppliedIcon: React.FC<{}> = () => {
+    return <Icon icon={faCopyright} onHoverText={"Congestion charge applies"} color={"red"} />;
 };
 
 export default CongestionChargeAppliedIcon;

--- a/src/components/Icons/CongestionChargeAppliesIcon.tsx
+++ b/src/components/Icons/CongestionChargeAppliesIcon.tsx
@@ -3,7 +3,7 @@ import Icon from "@/components/Icons/Icon";
 import { faCopyright } from "@fortawesome/free-solid-svg-icons";
 
 const CongestionChargeAppliedIcon: React.FC<{}> = () => {
-    return <Icon icon={faCopyright} onHoverText={"Congestion charge applies"} color={"red"} />;
+    return <Icon icon={faCopyright} onHoverText="Congestion charge applies" color="red" />;
 };
 
 export default CongestionChargeAppliedIcon;

--- a/src/components/Icons/FeetIcon.tsx
+++ b/src/components/Icons/FeetIcon.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faShoePrints } from "@fortawesome/free-solid-svg-icons";
+import styled from "styled-components";
+
+interface Props {
+    collectionPoint: string;
+}
+
+const StyledIcon = styled(Icon)`
+    background-color: red;
+`;
+
+const FeetIcon: React.FC<Props> = (props) => {
+    return (
+        <StyledIcon icon={faShoePrints} onHoverText={`Collection at ${props.collectionPoint}`} />
+    );
+};
+
+export default FeetIcon;

--- a/src/components/Icons/FeetIcon.tsx
+++ b/src/components/Icons/FeetIcon.tsx
@@ -11,7 +11,7 @@ const FeetIcon: React.FC<Props> = (props) => {
         <Icon
             icon={faShoePrints}
             onHoverText={`Collection at ${props.collectionPoint}`}
-            color={"black"}
+            color="black"
         />
     );
 };

--- a/src/components/Icons/FeetIcon.tsx
+++ b/src/components/Icons/FeetIcon.tsx
@@ -2,19 +2,17 @@
 import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faShoePrints } from "@fortawesome/free-solid-svg-icons";
-import styled from "styled-components";
 
 interface Props {
     collectionPoint: string;
 }
-
-const StyledIcon = styled(Icon)`
-    background-color: red;
-`;
-
 const FeetIcon: React.FC<Props> = (props) => {
     return (
-        <StyledIcon icon={faShoePrints} onHoverText={`Collection at ${props.collectionPoint}`} />
+        <Icon
+            icon={faShoePrints}
+            onHoverText={`Collection at ${props.collectionPoint}`}
+            color={"black"}
+        />
     );
 };
 

--- a/src/components/Icons/FlagIcon.tsx
+++ b/src/components/Icons/FlagIcon.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faFlag } from "@fortawesome/free-solid-svg-icons";
+import styled from "styled-components";
+
+const StyledSpan = styled.span`
+    color: red;
+`;
+
+const FlagIcon: React.FC = () => {
+    return (
+        <StyledSpan>
+            <Icon icon={faFlag} onHoverText={"Flagged for attention"} />
+        </StyledSpan>
+    );
+};
+
+export default FlagIcon;

--- a/src/components/Icons/FlagIcon.tsx
+++ b/src/components/Icons/FlagIcon.tsx
@@ -5,7 +5,7 @@ import Icon from "@/components/Icons/Icon";
 import { faFlag } from "@fortawesome/free-solid-svg-icons";
 
 const FlagIcon: React.FC<{}> = () => {
-    return <Icon icon={faFlag} onHoverText={"Flagged for attention"} color={"orange"} />;
+    return <Icon icon={faFlag} onHoverText="Flagged for attention" color="orange" />;
 };
 
 export default FlagIcon;

--- a/src/components/Icons/FlagIcon.tsx
+++ b/src/components/Icons/FlagIcon.tsx
@@ -3,18 +3,9 @@
 import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faFlag } from "@fortawesome/free-solid-svg-icons";
-import styled from "styled-components";
 
-const StyledSpan = styled.span`
-    color: red;
-`;
-
-const FlagIcon: React.FC = () => {
-    return (
-        <StyledSpan>
-            <Icon icon={faFlag} onHoverText={"Flagged for attention"} />
-        </StyledSpan>
-    );
+const FlagIcon: React.FC<{}> = () => {
+    return <Icon icon={faFlag} onHoverText={"Flagged for attention"} color={"orange"} />;
 };
 
 export default FlagIcon;

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -7,6 +7,7 @@ import styled from "styled-components";
 
 interface Props {
     icon: IconDefinition;
+    color?: string;
     onHoverText?: string;
 }
 
@@ -14,11 +15,13 @@ const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
     width: 1em;
     height: 1em;
     margin: 0.125em;
-    color: inherit;
+    color: ${(props) => props.color};
 `;
 
 const Icon: React.FC<Props> = (props) => {
-    return <StyledFontAwesomeIcon icon={props.icon} title={props.onHoverText} />;
+    return (
+        <StyledFontAwesomeIcon icon={props.icon} title={props.onHoverText} color={props.color} />
+    );
 };
 
 export default Icon;

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import styled from "styled-components";
+
+interface Props {
+    icon: IconDefinition;
+    onHoverText?: string;
+}
+
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+    width: 1em;
+    height: 1em;
+    margin: 0.125em;
+    color: inherit;
+`;
+
+const Icon: React.FC<Props> = (props) => {
+    return <StyledFontAwesomeIcon icon={props.icon} title={props.onHoverText} />;
+};
+
+export default Icon;

--- a/src/components/Icons/Icons.cy.tsx
+++ b/src/components/Icons/Icons.cy.tsx
@@ -46,4 +46,9 @@ describe("Icons", () => {
         cy.mount(<SpeechBubbleIcon onHoverText={"Text On HoVeR"} />);
         cy.get("svg").find("title").should("have.text", "Text On HoVeR");
     });
+
+    it("Flag icon default colour is set", () => {
+        cy.mount(<FlagIcon />);
+        cy.get("svg").invoke("attr", "color").should("eq", "orange");
+    });
 });

--- a/src/components/Icons/Icons.cy.tsx
+++ b/src/components/Icons/Icons.cy.tsx
@@ -43,8 +43,8 @@ describe("Icons", () => {
     });
 
     it("Speech Bubble icon text is correct", () => {
-        cy.mount(<SpeechBubbleIcon onHoverText={"Text On HoVeR"} />);
-        cy.get("svg").find("title").should("have.text", "Text On HoVeR");
+        cy.mount(<SpeechBubbleIcon onHoverText={"Text On Hover"} />);
+        cy.get("svg").find("title").should("have.text", "Text On Hover");
     });
 
     it("Flag icon default colour is set", () => {

--- a/src/components/Icons/Icons.cy.tsx
+++ b/src/components/Icons/Icons.cy.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import CongestionChargeAppliedIcon from "@/components/Icons/CongestionChargeAppliesIcon";
+import FeetIcon from "@/components/Icons/FeetIcon";
+import FlagIcon from "@/components/Icons/FlagIcon";
+import PhoneIcon from "@/components/Icons/PhoneIcon";
+import SpeechBubbleIcon from "@/components/Icons/SpeechBubbleIcon";
+import TruckIcon from "@/components/Icons/TruckIcon";
+
+describe("Icons", () => {
+    it("All Render", () => {
+        cy.mount(<CongestionChargeAppliedIcon />);
+        cy.mount(<FeetIcon collectionPoint={"Next Door"} />);
+        cy.mount(<FlagIcon />);
+        cy.mount(<PhoneIcon />);
+        cy.mount(<SpeechBubbleIcon onHoverText={"Some Bubble Text"} />);
+        cy.mount(<TruckIcon />);
+    });
+
+    it("Feet icon text is correct", () => {
+        cy.mount(<FeetIcon collectionPoint={"Next Door"} />);
+        cy.get("svg").find("title").should("have.text", "Collection at Next Door");
+    });
+
+    it("Phone icon text is correct", () => {
+        cy.mount(<PhoneIcon />);
+        cy.get("svg").find("title").should("have.text", "Requires follow-up phone call");
+    });
+
+    it("Congestion Charge Applies icon text is correct", () => {
+        cy.mount(<CongestionChargeAppliedIcon />);
+        cy.get("svg").find("title").should("have.text", "Congestion charge applies");
+    });
+
+    it("Flag icon text is correct", () => {
+        cy.mount(<FlagIcon />);
+        cy.get("svg").find("title").should("have.text", "Flagged for attention");
+    });
+
+    it("Truck icon text is correct", () => {
+        cy.mount(<TruckIcon />);
+        cy.get("svg").find("title").should("have.text", "Delivery");
+    });
+
+    it("Speech Bubble icon text is correct", () => {
+        cy.mount(<SpeechBubbleIcon onHoverText={"Text On HoVeR"} />);
+        cy.get("svg").find("title").should("have.text", "Text On HoVeR");
+    });
+});

--- a/src/components/Icons/PhoneIcon.tsx
+++ b/src/components/Icons/PhoneIcon.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faPhone } from "@fortawesome/free-solid-svg-icons";
 
-const PhoneIcon: React.FC = () => {
-    return <Icon icon={faPhone} onHoverText={"Requires follow-up phone call"} />;
+const PhoneIcon: React.FC<{}> = () => {
+    return <Icon icon={faPhone} onHoverText={"Requires follow-up phone call"} color={"black"} />;
 };
 
 export default PhoneIcon;

--- a/src/components/Icons/PhoneIcon.tsx
+++ b/src/components/Icons/PhoneIcon.tsx
@@ -3,7 +3,7 @@ import Icon from "@/components/Icons/Icon";
 import { faPhone } from "@fortawesome/free-solid-svg-icons";
 
 const PhoneIcon: React.FC<{}> = () => {
-    return <Icon icon={faPhone} onHoverText={"Requires follow-up phone call"} color={"black"} />;
+    return <Icon icon={faPhone} onHoverText="Requires follow-up phone call" color="black" />;
 };
 
 export default PhoneIcon;

--- a/src/components/Icons/PhoneIcon.tsx
+++ b/src/components/Icons/PhoneIcon.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faPhone } from "@fortawesome/free-solid-svg-icons";
+
+const PhoneIcon: React.FC = () => {
+    return <Icon icon={faPhone} onHoverText={"Requires follow-up phone call"} />;
+};
+
+export default PhoneIcon;

--- a/src/components/Icons/SpeechBubbleIcon.tsx
+++ b/src/components/Icons/SpeechBubbleIcon.tsx
@@ -6,7 +6,7 @@ interface Props {
     onHoverText?: string;
 }
 const SpeechBubbleIcon: React.FC<Props> = (props) => {
-    return <Icon icon={faComment} onHoverText={props.onHoverText} />;
+    return <Icon icon={faComment} onHoverText={props.onHoverText} color={"blue"} />;
 };
 
 export default SpeechBubbleIcon;

--- a/src/components/Icons/SpeechBubbleIcon.tsx
+++ b/src/components/Icons/SpeechBubbleIcon.tsx
@@ -6,7 +6,7 @@ interface Props {
     onHoverText?: string;
 }
 const SpeechBubbleIcon: React.FC<Props> = (props) => {
-    return <Icon icon={faComment} onHoverText={props.onHoverText} color={"blue"} />;
+    return <Icon icon={faComment} onHoverText={props.onHoverText} color="blue" />;
 };
 
 export default SpeechBubbleIcon;

--- a/src/components/Icons/SpeechBubbleIcon.tsx
+++ b/src/components/Icons/SpeechBubbleIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faComment } from "@fortawesome/free-solid-svg-icons";
+
+interface Props {
+    onHoverText?: string;
+}
+const SpeechBubbleIcon: React.FC<Props> = (props) => {
+    return <Icon icon={faComment} onHoverText={props.onHoverText} />;
+};
+
+export default SpeechBubbleIcon;

--- a/src/components/Icons/TruckIcon.tsx
+++ b/src/components/Icons/TruckIcon.tsx
@@ -3,7 +3,7 @@ import Icon from "@/components/Icons/Icon";
 import { faTruck } from "@fortawesome/free-solid-svg-icons";
 
 const TruckIcon: React.FC<{}> = () => {
-    return <Icon icon={faTruck} onHoverText={"Delivery"} color={"black"} />;
+    return <Icon icon={faTruck} onHoverText="Delivery" color="black" />;
 };
 
 export default TruckIcon;

--- a/src/components/Icons/TruckIcon.tsx
+++ b/src/components/Icons/TruckIcon.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import Icon from "@/components/Icons/Icon";
+import { faTruck } from "@fortawesome/free-solid-svg-icons";
+
+const TruckIcon: React.FC = () => {
+    return <Icon icon={faTruck} onHoverText={"Delivery"} />;
+};
+
+export default TruckIcon;

--- a/src/components/Icons/TruckIcon.tsx
+++ b/src/components/Icons/TruckIcon.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faTruck } from "@fortawesome/free-solid-svg-icons";
 
-const TruckIcon: React.FC = () => {
-    return <Icon icon={faTruck} onHoverText={"Delivery"} />;
+const TruckIcon: React.FC<{}> = () => {
+    return <Icon icon={faTruck} onHoverText={"Delivery"} color={"black"} />;
 };
 
 export default TruckIcon;


### PR DESCRIPTION
Implemented icon components for Flag, Phone, Truck, Congestion Charge Applies, Feet, and Speech Bubble. Each icon has the appropriate on-hover text titles, and have been tested using unit tests for each.

- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've linted via `npm run lint`
    - can run `npm run fix` to try and fix as any mistakes automatically as possible!
- [X] Make sure you've tested via `npm run test`
