### PR TITLE
Fix curly braces added in merge

### DIFF
--- a/src/components/Icons/Icons.cy.tsx
+++ b/src/components/Icons/Icons.cy.tsx
@@ -10,15 +10,15 @@ import TruckIcon from "@/components/Icons/TruckIcon";
 describe("Icons", () => {
     it("All Render", () => {
         cy.mount(<CongestionChargeAppliedIcon />);
-        cy.mount(<FeetIcon collectionPoint={"Next Door"} />);
+        cy.mount(<FeetIcon collectionPoint="Next Door" />);
         cy.mount(<FlagIcon />);
         cy.mount(<PhoneIcon />);
-        cy.mount(<SpeechBubbleIcon onHoverText={"Some Bubble Text"} />);
+        cy.mount(<SpeechBubbleIcon onHoverText="Some Bubble Text" />);
         cy.mount(<TruckIcon />);
     });
 
     it("Feet icon text is correct", () => {
-        cy.mount(<FeetIcon collectionPoint={"Next Door"} />);
+        cy.mount(<FeetIcon collectionPoint="Next Door" />);
         cy.get("svg").find("title").should("have.text", "Collection at Next Door");
     });
 
@@ -43,7 +43,7 @@ describe("Icons", () => {
     });
 
     it("Speech Bubble icon text is correct", () => {
-        cy.mount(<SpeechBubbleIcon onHoverText={"Text On Hover"} />);
+        cy.mount(<SpeechBubbleIcon onHoverText="Text On Hover" />);
         cy.get("svg").find("title").should("have.text", "Text On Hover");
     });
 


### PR DESCRIPTION
Run npm lint_fix to sort extra brackets now effected with the merge.
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [X] Make sure you've tested via `npm run test`
