### PR TITLE
Fix Cypress port in config

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
 
             return config;
         },
-        baseUrl: "http://localhost:3200",
+        baseUrl: `http://localhost:3${process.env.MANUAL_TEST ? 1 : 2}00`,
     },
 
     component: {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "npm run build && next start",
     "lint": "next lint --dir src --dir cypress",
     "lint_fix": "next lint --fix --dir src --dir cypress",
-    "open:cypress": "start-server-and-test 'next dev -p 3100' http://localhost:3100 'npx cypress open'",
+    "open:cypress": "start-server-and-test 'next dev -p 3100' http://localhost:3100 'MANUAL_TEST=1 npx cypress open'",
     "test": "start-server-and-test test:runner_server http://localhost:3200 test:runner",
     "test:component": "start-server-and-test test:runner_server http://localhost:3200 test:runner_component",
     "test:e2e": "start-server-and-test test:runner_server http://localhost:3200 test:runner_e2e",


### PR DESCRIPTION
`npm run open:cypress` was querying the wrong port, apologies! forgot I hardcoded it in the config :eyes:
this should work!

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
