### PR TITLE
VFB-2 Improve modal display and calendar for full-day event 

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,5 @@
 import { Metadata } from "next";
 import React from "react";
-import SampleCalendar from "./samplePage";
 
 const CalendarPage: React.FC<{}> = () => {
     return (

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -4,7 +4,7 @@ import React from "react";
 const CalendarPage: React.FC<{}> = () => {
     return (
         <main>
-            <h1>Calendar Page </h1>
+            <h1>Calendar Page</h1>
         </main>
     );
 };

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -6,7 +6,6 @@ const CalendarPage: React.FC<{}> = () => {
     return (
         <main>
             <h1>Calendar Page </h1>
-            <SampleCalendar />
         </main>
     );
 };

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from "next";
 import React from "react";
+import SampleCalendar from "./samplePage";
 
 const CalendarPage: React.FC<{}> = () => {
     return (
         <main>
-            <h1>Calendar Page</h1>
+            <h1>Calendar Page </h1>
+            <SampleCalendar />
         </main>
     );
 };

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -14,6 +14,14 @@ describe("<Calendar />", () => {
             end: tomorrow,
             allDay: true,
         },
+        {
+            id: "b",
+            title: "event2",
+            start: today,
+            end: today,
+            allDay: false,
+            description: "a description",
+        },
     ];
 
     it("calendar renders", () => {
@@ -72,9 +80,68 @@ describe("<Calendar />", () => {
         );
     });
 
-    it("shows description when event is clicked", () => {
+    it("shows description when event with description is clicked", () => {
         cy.mount(<Calendar initialEvents={sampleEvents} />);
-        cy.get(".fc-event-title").first().click();
-        cy.get(".MuiDialog-container").should("be.visible");
+        cy.get(".fc-event-title").contains("event2").click();
+        cy.get(".MuiDialog-container").should("include.text", "description");
+    });
+
+    it("does not show description when event without description is clicked", () => {
+        cy.mount(<Calendar initialEvents={sampleEvents} />);
+        cy.get(".fc-event-title").contains("event1").click();
+        cy.get(".MuiDialog-container").should("not.include.text", "description");
+    });
+
+    it("shows correct date for full day event", () => {
+        cy.mount(<Calendar initialEvents={sampleEvents} />);
+        cy.get(".fc-event-title").contains("event1").click();
+        cy.get(".MuiDialog-container").should(
+            "include.text",
+            today.toLocaleDateString("en-GB", {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+            })
+        );
+        cy.get(".MuiDialog-container").should(
+            "include.text",
+            tomorrow.toLocaleDateString("en-GB", {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+            })
+        );
+        cy.get(".MuiDialog-container").should(
+            "not.include.text",
+            today.toLocaleDateString("en-GB", {
+                hour: "numeric",
+                minute: "numeric",
+            })
+        );
+        cy.get(".MuiDialog-container").should(
+            "not.include.text",
+            tomorrow.toLocaleDateString("en-GB", {
+                hour: "numeric",
+                minute: "numeric",
+            })
+        );
+    });
+
+    it("shows correct date for non-full day event", () => {
+        cy.mount(<Calendar initialEvents={sampleEvents} />);
+        cy.get(".fc-event-title").contains("event2").click();
+        cy.get(".MuiDialog-container").should(
+            "include.text",
+            today.toLocaleDateString("en-GB", {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+                hour: "numeric",
+                minute: "numeric",
+            })
+        );
     });
 });

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -115,14 +115,14 @@ describe("<Calendar />", () => {
         );
         cy.get(".MuiDialog-container").should(
             "not.include.text",
-            today.toLocaleDateString("en-GB", {
+            today.toLocaleTimeString("en-GB", {
                 hour: "numeric",
                 minute: "numeric",
             })
         );
         cy.get(".MuiDialog-container").should(
             "not.include.text",
-            tomorrow.toLocaleDateString("en-GB", {
+            tomorrow.toLocaleTimeString("en-GB", {
                 hour: "numeric",
                 minute: "numeric",
             })

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -82,7 +82,7 @@ describe("<Calendar />", () => {
 
     it("shows description when event with description is clicked", () => {
         cy.mount(<Calendar initialEvents={sampleEvents} />);
-        cy.get(".fc-event-title").contains("event2").click();
+        cy.get(".fc-event-title").contains("event2").parent().click();
         cy.get(".MuiDialog-container").should("include.text", "description");
     });
 
@@ -131,7 +131,7 @@ describe("<Calendar />", () => {
 
     it("shows correct date for non-full day event", () => {
         cy.mount(<Calendar initialEvents={sampleEvents} />);
-        cy.get(".fc-event-title").contains("event2").click();
+        cy.get(".fc-event-title").contains("event2").parent().click();
         cy.get(".MuiDialog-container").should(
             "include.text",
             today.toLocaleDateString("en-GB", {

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -20,7 +20,7 @@ describe("<Calendar />", () => {
             start: today,
             end: today,
             allDay: false,
-            description: "a description",
+            description: "a piece of description text",
         },
     ];
 
@@ -83,7 +83,7 @@ describe("<Calendar />", () => {
     it("shows description when event with description is clicked", () => {
         cy.mount(<Calendar initialEvents={sampleEvents} />);
         cy.get(".fc-event-title").contains("event2").parent().click();
-        cy.get(".MuiDialog-container").should("include.text", "description");
+        cy.get(".MuiDialog-container").should("include.text", "a piece of description text");
     });
 
     it("does not show description when event without description is clicked", () => {

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -71,14 +71,15 @@ const CalendarStyling = styled.div`
     }
 `;
 
-const endDateInclusiveEvents = (endDateExclusiveEvents: CalendarEvent[]): CalendarEvent[] => {
+const makeAllDayEventsInclusive = (endDateExclusiveEvents: CalendarEvent[]): CalendarEvent[] => {
     return endDateExclusiveEvents.map((exclusiveEvent: CalendarEvent): CalendarEvent => {
-        const cloneEndDate = new Date(exclusiveEvent.end);
+        const copiedEndDate = new Date(exclusiveEvent.end);
+
         if (exclusiveEvent.allDay) {
-            cloneEndDate.setDate(cloneEndDate.getDate() + 1);
+            copiedEndDate.setDate(copiedEndDate.getDate() + 1);
         }
-        const inclusiveEvent = { ...exclusiveEvent, end: cloneEndDate };
-        return inclusiveEvent;
+
+        return { ...exclusiveEvent, end: copiedEndDate };
     });
 };
 
@@ -107,7 +108,7 @@ const Calendar: React.FC<CalendarProps> = ({
                         center: "title",
                         right: "dayGridMonth,timeGridWeek,timeGridDay",
                     }}
-                    events={endDateInclusiveEvents(initialEvents)}
+                    events={makeAllDayEventsInclusive(initialEvents)}
                     initialView={view}
                     editable={editable}
                     selectable={editable}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import dayGridPlugin from "@fullcalendar/daygrid";
@@ -71,6 +71,17 @@ const CalendarStyling = styled.div`
     }
 `;
 
+const endDateInclusiveEvents = (endDateExclusiveEvents: CalendarEvent[]): CalendarEvent[] => {
+    return endDateExclusiveEvents.map((exclusiveEvent: CalendarEvent) => {
+        const cloneEndDate = new Date(exclusiveEvent.end);
+        if (exclusiveEvent.allDay) {
+            cloneEndDate.setDate(cloneEndDate.getDate() + 1);
+        }
+        const inclusiveEvent: CalendarEvent = { ...exclusiveEvent, end: cloneEndDate };
+        return inclusiveEvent;
+    });
+};
+
 const Calendar: React.FC<CalendarProps> = ({
     initialEvents,
     view = "dayGridMonth",
@@ -84,6 +95,8 @@ const Calendar: React.FC<CalendarProps> = ({
         setEventClick(initialEvents.find((event) => event.id === id) ?? null);
     };
 
+    const displayEvents = useRef(endDateInclusiveEvents(initialEvents));
+
     return (
         <>
             <Modal eventClick={eventClick} setEventClick={setEventClick} />
@@ -96,7 +109,7 @@ const Calendar: React.FC<CalendarProps> = ({
                         center: "title",
                         right: "dayGridMonth,timeGridWeek,timeGridDay",
                     }}
-                    events={initialEvents}
+                    events={displayEvents.current}
                     initialView={view}
                     editable={editable}
                     selectable={editable}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState } from "react";
 import FullCalendar from "@fullcalendar/react";
 import timeGridPlugin from "@fullcalendar/timegrid";
 import dayGridPlugin from "@fullcalendar/daygrid";
@@ -95,8 +95,6 @@ const Calendar: React.FC<CalendarProps> = ({
         setEventClick(initialEvents.find((event) => event.id === id) ?? null);
     };
 
-    const displayEvents = useRef(endDateInclusiveEvents(initialEvents));
-
     return (
         <>
             <Modal eventClick={eventClick} setEventClick={setEventClick} />
@@ -109,7 +107,7 @@ const Calendar: React.FC<CalendarProps> = ({
                         center: "title",
                         right: "dayGridMonth,timeGridWeek,timeGridDay",
                     }}
-                    events={displayEvents.current}
+                    events={endDateInclusiveEvents(initialEvents)}
                     initialView={view}
                     editable={editable}
                     selectable={editable}

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -72,12 +72,12 @@ const CalendarStyling = styled.div`
 `;
 
 const endDateInclusiveEvents = (endDateExclusiveEvents: CalendarEvent[]): CalendarEvent[] => {
-    return endDateExclusiveEvents.map((exclusiveEvent: CalendarEvent) => {
+    return endDateExclusiveEvents.map((exclusiveEvent: CalendarEvent): CalendarEvent => {
         const cloneEndDate = new Date(exclusiveEvent.end);
         if (exclusiveEvent.allDay) {
             cloneEndDate.setDate(cloneEndDate.getDate() + 1);
         }
-        const inclusiveEvent: CalendarEvent = { ...exclusiveEvent, end: cloneEndDate };
+        const inclusiveEvent = { ...exclusiveEvent, end: cloneEndDate };
         return inclusiveEvent;
     });
 };

--- a/src/components/Calendar/Modal.tsx
+++ b/src/components/Calendar/Modal.tsx
@@ -24,13 +24,20 @@ const ModalInner = styled.div`
     row-gap: 1rem;
 `;
 
-const dateFormatOptions: Intl.DateTimeFormatOptions = {
+const dateTimeFormatOptions: Intl.DateTimeFormatOptions = {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
     hour: "numeric",
     minute: "numeric",
+};
+
+const dateFormatOptions: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
 };
 
 const Modal: React.FC<{
@@ -40,6 +47,7 @@ const Modal: React.FC<{
     if (!eventClick) {
         return <></>;
     }
+
     return (
         <StyledDialog open={true} onClose={() => setEventClick(null)}>
             <StyledCloseButton type="button" onClick={() => setEventClick(null)}>
@@ -49,14 +57,22 @@ const Modal: React.FC<{
                 <h2>View Event</h2>
                 <p>Event Title: {eventClick.title}</p>
                 <p>
-                    Start:
-                    {new Date(eventClick.start).toLocaleString("en-GB", dateFormatOptions)}
+                    Start:{" "}
+                    {eventClick.allDay
+                        ? new Date(eventClick.start).toLocaleString("en-GB", dateFormatOptions)
+                        : new Date(eventClick.start).toLocaleString("en-GB", dateTimeFormatOptions)}
                 </p>
                 <p>
-                    End:
-                    {new Date(eventClick.end).toLocaleString("en-GB", dateFormatOptions)}
+                    End:{" "}
+                    {eventClick.allDay
+                        ? new Date(eventClick.end).toLocaleString("en-GB", dateFormatOptions)
+                        : new Date(eventClick.end).toLocaleString("en-GB", dateTimeFormatOptions)}
                 </p>
-                <p>Description: {eventClick.description}</p>
+                {eventClick.description === undefined ? (
+                    <></>
+                ) : (
+                    <p>Description: {eventClick.description}</p>
+                )}
             </ModalInner>
         </StyledDialog>
     );

--- a/src/components/Calendar/Modal.tsx
+++ b/src/components/Calendar/Modal.tsx
@@ -48,6 +48,16 @@ const Modal: React.FC<{
         return <></>;
     }
 
+    const startDate = new Date(eventClick.start).toLocaleString(
+        "en-GB",
+        eventClick.allDay ? dateFormatOptions : dateTimeFormatOptions
+    );
+
+    const endDate = new Date(eventClick.end).toLocaleString(
+        "en-GB",
+        eventClick.allDay ? dateFormatOptions : dateTimeFormatOptions
+    );
+
     return (
         <StyledDialog open={true} onClose={() => setEventClick(null)}>
             <StyledCloseButton type="button" onClick={() => setEventClick(null)}>
@@ -55,23 +65,9 @@ const Modal: React.FC<{
             </StyledCloseButton>
             <ModalInner>
                 <h2>{eventClick.title}</h2>
-                <p>
-                    Start:{" "}
-                    {eventClick.allDay
-                        ? new Date(eventClick.start).toLocaleString("en-GB", dateFormatOptions)
-                        : new Date(eventClick.start).toLocaleString("en-GB", dateTimeFormatOptions)}
-                </p>
-                <p>
-                    End:{" "}
-                    {eventClick.allDay
-                        ? new Date(eventClick.end).toLocaleString("en-GB", dateFormatOptions)
-                        : new Date(eventClick.end).toLocaleString("en-GB", dateTimeFormatOptions)}
-                </p>
-                {eventClick.description === undefined ? (
-                    <></>
-                ) : (
-                    <p>Description: {eventClick.description}</p>
-                )}
+                <p>Start: {startDate}</p>
+                <p>End: {endDate}</p>
+                {eventClick.description ? <p>Description: {eventClick.description}</p> : <></>}
             </ModalInner>
         </StyledDialog>
     );

--- a/src/components/Calendar/Modal.tsx
+++ b/src/components/Calendar/Modal.tsx
@@ -54,8 +54,7 @@ const Modal: React.FC<{
                 close
             </StyledCloseButton>
             <ModalInner>
-                <h2>View Event</h2>
-                <p>Event Title: {eventClick.title}</p>
+                <h2>{eventClick.title}</h2>
                 <p>
                     Start:{" "}
                     {eventClick.allDay

--- a/src/components/DataViewer/DataViewer.tsx
+++ b/src/components/DataViewer/DataViewer.tsx
@@ -65,14 +65,16 @@ const ClearButton: React.FC<ClearButtonProps> = (props) => {
     );
 };
 const JSONContent: React.FC<Data> = (data) => {
-    return Object.entries(data).map(([key, value]) => {
-        return (
-            <EachItem key={key}>
-                <Key>{key.toUpperCase().replace("_", " ")}</Key>
-                <Value>{value ?? ""}</Value>
-            </EachItem>
-        );
-    });
+    return (
+        <>
+            {Object.entries(data).map(([key, value]) => (
+                <EachItem key={key}>
+                    <Key>{key.toUpperCase().replace("_", " ")}</Key>
+                    <Value>{value ?? ""}</Value>
+                </EachItem>
+            ))}
+        </>
+    );
 };
 
 interface DataViewerProps {


### PR DESCRIPTION
The modal will not display "Description: " if the description fed in is undefined. Also, the calendar will display days as inclusive for full day events

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
