### PR TITLE
VFB-8: Add error message functionality to freeform text input

### DIFF
--- a/src/components/DataInput/DataInput.cy.tsx
+++ b/src/components/DataInput/DataInput.cy.tsx
@@ -10,7 +10,7 @@ import {
     getRadioGroupHandler,
     getCheckboxGroupHandler,
 } from "@/components/DataInput/inputHandlerFactories";
-import { SelectChangeEvent } from "@mui/material";
+import { hexToRgb, SelectChangeEvent } from "@mui/material";
 import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
 
 describe("Data Input Components", () => {
@@ -212,6 +212,12 @@ describe("Data Input Components", () => {
 
             cy.get("input[value='c']").click();
             cy.get("@onChangeSpy").should("have.been.calledWith", "c");
+        });
+
+        it("Add error message to form", () => {
+            cy.mount(<FreeFormTextInput label="FreeForm" error={true} helperText="Error" />);
+            cy.get(".Mui-error").contains("Error");
+            cy.get(".Mui-error").should("have.css", "color", hexToRgb("#d32f2f"));
         });
     });
 });

--- a/src/components/DataInput/FreeFormTextInput.tsx
+++ b/src/components/DataInput/FreeFormTextInput.tsx
@@ -1,22 +1,23 @@
 "use client";
-
 import React from "react";
 import { TextField } from "@mui/material";
-
 interface Props {
     label?: string;
     defaultValue?: string;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    error?: boolean;
+    helperText?: string;
 }
 
 const FreeFormTextInput: React.FC<Props> = (props) => {
     return (
         <TextField
+            error={props.error}
+            helperText={props.helperText}
             label={props.label}
             defaultValue={props.defaultValue}
             onChange={props.onChange}
         />
     );
 };
-
 export default FreeFormTextInput;


### PR DESCRIPTION
This is to add error message functionality to FreeFormTextInput in DataInput component. The colour should be red and the message will be shown underneath the box. We added a test case in cypress.

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
