### PR TITLE
VFB 2 Reformat Calendar and Calendar Page

### DIFF
--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -60,8 +60,8 @@ describe("Accessibility tests in dark mode", () => {
 
     it("Checks calendar page", () => {
         cy.visit("/calendar");
-        cy.get("table").should("be.visible");
         cy.get("label[aria-label='Theme Switch']").click();
+        cy.get("table").should("be.visible");
 
         cy.checkAccessibility();
     });

--- a/src/app/calendar/ParcelCalendar.tsx
+++ b/src/app/calendar/ParcelCalendar.tsx
@@ -8,11 +8,11 @@ import styled, { RainbowPalette, useTheme } from "styled-components";
 import {
     LocationColorMap,
     parcelsToCollectionEvents,
-    parcelWithClientName,
+    ParcelWithClientName,
 } from "@/app/calendar/parcelCalendarFunctions";
 
 interface ParcelCalendarProps {
-    parcelsWithCollectionDate: parcelWithClientName[];
+    parcelsWithCollectionDate: ParcelWithClientName[];
 }
 
 interface ColorTextProps {
@@ -27,8 +27,8 @@ const Centerer = styled.div`
 `;
 
 const CalendarWrapper = styled.div`
-    width: 100vmin;
-    max-width: 1100px;
+    width: min(100vmin, 1100px);
+    //max-width: 1100px;
     margin: 0 2em 2em;
 `;
 

--- a/src/app/calendar/ParcelCalendar.tsx
+++ b/src/app/calendar/ParcelCalendar.tsx
@@ -27,8 +27,7 @@ const Centerer = styled.div`
 `;
 
 const CalendarWrapper = styled.div`
-    width: min(100vmin, 1100px);
-    //max-width: 1100px;
+    width: min(100vw, 1200px);
     margin: 0 2em 2em;
 `;
 

--- a/src/app/calendar/ParcelCalendar.tsx
+++ b/src/app/calendar/ParcelCalendar.tsx
@@ -6,15 +6,13 @@ import React from "react";
 import styled, { RainbowPalette, useTheme } from "styled-components";
 
 import {
-    ClientMap,
     LocationColorMap,
     parcelsToCollectionEvents,
+    parcelWithClientName,
 } from "@/app/calendar/parcelCalendarFunctions";
-import { Schema } from "@/supabase";
 
 interface ParcelCalendarProps {
-    clientMap: ClientMap;
-    parcelsWithCollectionDate: Schema["parcels"][];
+    parcelsWithCollectionDate: parcelWithClientName[];
 }
 
 interface ColorTextProps {
@@ -30,6 +28,7 @@ const Centerer = styled.div`
 
 const CalendarWrapper = styled.div`
     width: 100vmin;
+    max-width: 1100px;
     margin: 0 2em 2em;
 `;
 
@@ -63,7 +62,6 @@ const ParcelCalendar: React.FC<ParcelCalendarProps> = (props) => {
                     <Calendar
                         initialEvents={parcelsToCollectionEvents(
                             props.parcelsWithCollectionDate,
-                            props.clientMap,
                             colorMap
                         )}
                         editable={false}

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,13 +1,10 @@
 import { Metadata } from "next";
 import React from "react";
 import ParcelCalendar from "@/app/calendar/ParcelCalendar";
-import {
-    getParcelsWithCollectionDate,
-    parcelWithClientName,
-} from "@/app/calendar/parcelCalendarFunctions";
+import { getParcelsWithCollectionDate } from "@/app/calendar/parcelCalendarFunctions";
 
 const CalendarPage = async (): Promise<React.ReactElement> => {
-    const parcelsWithCollectionDate: parcelWithClientName[] = await getParcelsWithCollectionDate();
+    const parcelsWithCollectionDate = await getParcelsWithCollectionDate();
 
     return (
         <main>

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,20 +1,17 @@
 import { Metadata } from "next";
 import React from "react";
 import ParcelCalendar from "@/app/calendar/ParcelCalendar";
-import { getClientMap, getParcelsWithCollectionDate } from "@/app/calendar/parcelCalendarFunctions";
+import {
+    getParcelsWithCollectionDate,
+    parcelWithClientName,
+} from "@/app/calendar/parcelCalendarFunctions";
 
 const CalendarPage = async (): Promise<React.ReactElement> => {
-    const [clientMap, parcelsWithCollectionDate] = await Promise.all([
-        getClientMap(),
-        getParcelsWithCollectionDate(),
-    ]);
+    const parcelsWithCollectionDate: parcelWithClientName[] = await getParcelsWithCollectionDate();
 
     return (
         <main>
-            <ParcelCalendar
-                clientMap={clientMap}
-                parcelsWithCollectionDate={parcelsWithCollectionDate}
-            />
+            <ParcelCalendar parcelsWithCollectionDate={parcelsWithCollectionDate} />
         </main>
     );
 };

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -1,7 +1,7 @@
 import supabase, { Schema } from "@/supabase";
 import { CalendarEvent } from "@/components/Calendar/Calendar";
 
-type ParcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
+export type ParcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
 
 export interface LocationColorMap {
     [location: string]: { color: string; text: string };

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -1,44 +1,28 @@
 import supabase, { Schema } from "@/supabase";
 import { CalendarEvent } from "@/components/Calendar/Calendar";
 
+export type parcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
+
 const COLLECTION_DURATION_MS = 30 * 60 * 1000;
 
 export interface LocationColorMap {
     [location: string]: { color: string; text: string };
 }
 
-export interface ClientMap {
-    [primary_key: string]: Schema["clients"];
-}
-
-export const getClientMap = async (): Promise<ClientMap> => {
-    const response = await supabase.from("clients").select();
-    const clients = response.data ?? [];
-    const clientMap: ClientMap = {};
-
-    clients.forEach((client) => {
-        clientMap[client.primary_key] = client;
-    });
-
-    return clientMap;
-};
-
-export const getParcelsWithCollectionDate = async (): Promise<Schema["parcels"][]> => {
-    const response = await supabase.from("parcels").select().not("collection_datetime", "is", null);
+export const getParcelsWithCollectionDate = async (): Promise<parcelWithClientName[]> => {
+    const response = await supabase
+        .from("parcels")
+        .select("*, clients ( full_name )")
+        .not("collection_datetime", "is", null);
     return response.data ?? [];
 };
 
 export const parcelsToCollectionEvents = (
-    parcels: Schema["parcels"][],
-    clientMap: ClientMap,
+    parcels: parcelWithClientName[],
     colorMap: LocationColorMap
 ): CalendarEvent[] => {
-    if (Object.keys(clientMap).length === 0) {
-        return [];
-    }
-
     return parcels.map((parcel) => {
-        const fullName = clientMap[parcel.client_id].full_name;
+        const fullName = parcel.clients?.full_name ?? "";
 
         const collectionStart = new Date(parcel.collection_datetime!);
         const collectionEnd = new Date(collectionStart.getTime() + COLLECTION_DURATION_MS);

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -1,15 +1,15 @@
 import supabase, { Schema } from "@/supabase";
 import { CalendarEvent } from "@/components/Calendar/Calendar";
 
-export type parcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
-
-const COLLECTION_DURATION_MS = 30 * 60 * 1000;
+type ParcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
 
 export interface LocationColorMap {
     [location: string]: { color: string; text: string };
 }
 
-export const getParcelsWithCollectionDate = async (): Promise<parcelWithClientName[]> => {
+const COLLECTION_DURATION_MS = 30 * 60 * 1000;
+
+export const getParcelsWithCollectionDate = async (): Promise<ParcelWithClientName[]> => {
     const response = await supabase
         .from("parcels")
         .select("*, clients ( full_name )")
@@ -18,7 +18,7 @@ export const getParcelsWithCollectionDate = async (): Promise<parcelWithClientNa
 };
 
 export const parcelsToCollectionEvents = (
-    parcels: parcelWithClientName[],
+    parcels: ParcelWithClientName[],
     colorMap: LocationColorMap
 ): CalendarEvent[] => {
     return parcels.map((parcel) => {

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -10,11 +10,16 @@ export interface LocationColorMap {
 const COLLECTION_DURATION_MS = 30 * 60 * 1000;
 
 export const getParcelsWithCollectionDate = async (): Promise<ParcelWithClientName[]> => {
-    const response = await supabase
+    const { data } = await supabase
         .from("parcels")
         .select("*, clients ( full_name )")
         .not("collection_datetime", "is", null);
-    return response.data ?? [];
+
+    if (data == null) {
+        throw new Error("Database returns null for parcels");
+    }
+
+    return data;
 };
 
 export const parcelsToCollectionEvents = (

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -3,20 +3,20 @@ import { CalendarEvent } from "@/components/Calendar/Calendar";
 
 export type ParcelWithClientName = Schema["parcels"] & { clients: { full_name: string } | null };
 
+const COLLECTION_DURATION_MS = 30 * 60 * 1000;
+
 export interface LocationColorMap {
     [location: string]: { color: string; text: string };
 }
 
-const COLLECTION_DURATION_MS = 30 * 60 * 1000;
-
 export const getParcelsWithCollectionDate = async (): Promise<ParcelWithClientName[]> => {
-    const { data } = await supabase
+    const { data, error } = await supabase
         .from("parcels")
         .select("*, clients ( full_name )")
         .not("collection_datetime", "is", null);
 
-    if (data == null) {
-        throw new Error("Database returns null for parcels");
+    if (error) {
+        throw new Error("Database error");
     }
 
     return data;

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -15,6 +15,10 @@ describe("<Calendar />", () => {
     const dayAfterTestDate = new Date("2021-04-06");
     dayAfterTestDate.setDate(testDate.getDate() + 1);
 
+    beforeEach(() => {
+        // cy.viewport(1366, 768);
+    });
+
     const sampleEvents: CalendarEvent[] = [
         {
             id: "a",

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -32,14 +32,13 @@ describe("<Calendar />", () => {
             description: "a piece of description text",
         },
     ];
-
     it("calendar renders", () => {
         cy.mount(<StyledCalendar initialEvents={[]} />);
     });
 
     it("calendar is set to the current month when rendered in dayGridMonth", () => {
         const currentMonthYear = testDate.toLocaleDateString("en-GB", {
-            month: "long",
+            month: "short",
             year: "numeric",
         });
 
@@ -67,7 +66,10 @@ describe("<Calendar />", () => {
     it("can change view between months in dayGridMonth", () => {
         const prevMonth = new Date(testDate);
         prevMonth.setMonth((testDate.getMonth() + 11) % 12);
-        const prevMonthYear = prevMonth.toLocaleString("en-GB", { month: "long", year: "numeric" });
+        const prevMonthYear = prevMonth.toLocaleString("en-GB", {
+            month: "short",
+            year: "numeric",
+        });
 
         cy.mount(<StyledCalendar initialEvents={[]} initialDate={testDate} />);
         cy.get("button.fc-prev-button").click();
@@ -77,7 +79,7 @@ describe("<Calendar />", () => {
 
     it("can change view between days in timeGridDay", () => {
         const tomorrowDMY = dayAfterTestDate
-            .toLocaleString("en-GB", { day: "numeric", month: "long", year: "numeric" })
+            .toLocaleString("en-GB", { day: "numeric", month: "short", year: "numeric" })
             .split(" ");
 
         cy.mount(<StyledCalendar initialEvents={[]} view="timeGridDay" initialDate={testDate} />);
@@ -150,6 +152,25 @@ describe("<Calendar />", () => {
                 day: "numeric",
                 hour: "numeric",
                 minute: "numeric",
+            })
+        );
+    });
+    it("navigates to day when grid is clicked", () => {
+        cy.mount(<StyledCalendar initialEvents={sampleEvents} initialDate={testDate} />);
+        cy.get(".fc-event-title")
+            .contains("event2")
+            .parent()
+            .parent()
+            .parent()
+            .siblings(".fc-daygrid-day-top")
+            .click();
+        cy.get(".fc-timeGridDay-view").should("be.visible");
+        cy.get(".fc-toolbar-title").should(
+            "have.text",
+            testDate.toLocaleDateString("en-US", {
+                day: "numeric",
+                month: "short",
+                year: "numeric",
             })
         );
     });

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -16,7 +16,7 @@ describe("<Calendar />", () => {
     dayAfterTestDate.setDate(testDate.getDate() + 1);
 
     beforeEach(() => {
-        // cy.viewport(1366, 768);
+        cy.viewport(750, 1400);
     });
 
     const sampleEvents: CalendarEvent[] = [

--- a/src/components/Calendar/Calendar.cy.tsx
+++ b/src/components/Calendar/Calendar.cy.tsx
@@ -156,22 +156,20 @@ describe("<Calendar />", () => {
         );
     });
     it("navigates to day when grid is clicked", () => {
+        const todayShortDMY = testDate
+            .toLocaleString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+            .split(" ");
+
+        const todayLongDMY = testDate
+            .toLocaleString("en-GB", { day: "numeric", month: "long", year: "numeric" })
+            .split(" ");
+
         cy.mount(<StyledCalendar initialEvents={sampleEvents} initialDate={testDate} />);
-        cy.get(".fc-event-title")
-            .contains("event2")
-            .parent()
-            .parent()
-            .parent()
-            .siblings(".fc-daygrid-day-top")
-            .click();
+        cy.get(`[aria-label="${todayLongDMY[1]} ${todayLongDMY[0]}, ${todayLongDMY[2]}"]`).click();
         cy.get(".fc-timeGridDay-view").should("be.visible");
         cy.get(".fc-toolbar-title").should(
             "have.text",
-            testDate.toLocaleDateString("en-US", {
-                day: "numeric",
-                month: "short",
-                year: "numeric",
-            })
+            `${todayShortDMY[1]} ${todayShortDMY[0]}, ${todayShortDMY[2]}`
         );
     });
 });

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -52,21 +52,54 @@ const CalendarStyling = styled.div`
     .fc .fc-toolbar-title {
         font-size: min(5vw, 1.5rem);
     }
+    .fc .fc-icon {
+        font-size: min(4vw, 1.2rem);
+    }
 
     .fc .fc-col-header-cell-cushion,
     .fc .fc-daygrid-day-number,
     .fc .fc-timegrid-axis-cushion,
     .fc .fc-timegrid-slot-label-cushion,
-    .fc .fc-event-title,
     .fc .fc-daygrid-more-link,
+    .fc .fc-event-title,
     .fc .fc-event-time {
         font-size: min(4vw, 1rem);
     }
 
-    .fc .fc-button {
-        font-size: 12px;
-        height: 25px;
-        padding: 0 6px;
+    // month view grid display
+    .fc .fc-daygrid-day-frame {
+        cursor: pointer;
+        min-height: min(20vw, 7rem);
+    }
+
+    // month view events
+    .fc-dayGridMonth-view .fc-daygrid-day-number {
+        font-size: min(3vw, 1rem);
+    }
+    .fc-dayGridMonth-view .fc-event-title,
+    .fc-dayGridMonth-view .fc-event-time,
+    .fc-dayGridMonth-view .fc-daygrid-more-link {
+        font-size: min(2.7vw, 0.9rem);
+    }
+
+    // week view events
+    .fc-timeGridWeek-view .fc-event-title-container {
+        width: 100%;
+        height: 100%;
+    }
+
+    .fc-timeGridWeek-view .fc-event-title,
+    .fc-timeGridWeek-view .fc-event-time {
+        font-size: min(2.5vw, 1rem);
+    }
+
+    // general event display
+    .fc .fc-event-time {
+        overflow: hidden;
+    }
+
+    .fc .fc-event-title-container {
+        flex-shrink: 80;
     }
 
     // group of buttons in the toolbar
@@ -92,25 +125,10 @@ const CalendarStyling = styled.div`
 
     .fc .fc-day-other {
         background-color: ${(props) => props.theme.main.background[1]};
-        color: ${(props) => props.theme.main.lighterForeground};
+        color: ${(props) => props.theme.main.lighterForeground[1]};
     }
 
-    // adjust month view grid display
-    .fc .fc-daygrid-day-frame {
-        cursor: pointer;
-        min-height: 6em;
-    }
-
-    // adjust event display
-    .fc .fc-event-time {
-        overflow: hidden;
-    }
-
-    .fc .fc-event-title {
-        flex-shrink: 99;
-    }
-
-    // adjust background color of headers
+    // background color of headers
     .fc thead {
         background-color: ${(props) => props.theme.main.background[2]};
     }
@@ -174,7 +192,7 @@ const Calendar: React.FC<CalendarProps> = ({
                                 meridiem: "short",
                             },
                             titleFormat: { year: "numeric", month: "short" },
-                            dayMaxEventRows: 4,
+                            dayMaxEventRows: 3,
                             moreLinkClick: "day",
                         },
                         timeGridWeek: {
@@ -192,6 +210,7 @@ const Calendar: React.FC<CalendarProps> = ({
                     }}
                     eventInteractive={true}
                     height="auto"
+                    eventDisplay="block"
                 />
             </CalendarStyling>
         </>

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -157,7 +157,7 @@ const Calendar: React.FC<CalendarProps> = ({
     initialDate,
 }) => {
     const [eventClick, setEventClick] = useState<CalendarEvent | null>(null);
-    const calendarRef = useRef<FullCalendar>(null) as React.MutableRefObject<FullCalendar>;
+    const calendarRef = useRef<FullCalendar>(null);
 
     const handleEventClick = (info: EventClickArg): void => {
         const id = info.event.id;
@@ -165,7 +165,7 @@ const Calendar: React.FC<CalendarProps> = ({
     };
 
     const handleDateClick = (info: DateClickArg): void => {
-        const calendarApi = calendarRef.current.getApi();
+        const calendarApi = calendarRef.current!.getApi();
         calendarApi.changeView("timeGridDay", info.dateStr);
     };
 

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -123,6 +123,13 @@ const CalendarStyling = styled.div`
         color: ${(props) => props.theme.primary.foreground[1]};
     }
 
+    .fc .fc-button-primary:focus,
+    .fc .fc-button:focus,
+    .fc .fc-button-primary:not(:disabled).fc-button-active:focus,
+    .fc .fc-button-primary:not(:disabled):active:focus {
+        box-shadow: none;
+    }
+
     // days in the previous month
     .fc .fc-day-other .fc-daygrid-day-top {
         opacity: 1;

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -82,6 +82,11 @@ const CalendarStyling = styled.div`
         font-size: min(2.7vw, 0.9rem);
     }
 
+    .fc-dayGridMonth-view .fc-event-title {
+        width: 100%;
+        text-align: left;
+    }
+
     // week view events
     .fc-timeGridWeek-view .fc-event-title-container {
         width: 100%;

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -50,7 +50,23 @@ const CalendarStyling = styled.div`
     }
 
     .fc .fc-toolbar-title {
-        font-size: 1.5rem;
+        font-size: min(5vw, 1.5rem);
+    }
+
+    .fc .fc-col-header-cell-cushion,
+    .fc .fc-daygrid-day-number,
+    .fc .fc-timegrid-axis-cushion,
+    .fc .fc-timegrid-slot-label-cushion,
+    .fc .fc-event-title,
+    .fc .fc-daygrid-more-link,
+    .fc .fc-event-time {
+        font-size: min(4vw, 1rem);
+    }
+
+    .fc .fc-button {
+        font-size: 12px;
+        height: 25px;
+        padding: 0 6px;
     }
 
     // group of buttons in the toolbar
@@ -59,21 +75,14 @@ const CalendarStyling = styled.div`
     }
 
     .fc .fc-button {
-        height: max(3vmin, 30px);
-        font-size: max(1.5vmin, 15px);
+        height: min(8.2vw, 2.25rem);
+        font-size: min(4vw, 1.1rem);
+        padding: 0 min(2.5vw, 0.75rem);
         text-align: center;
         vertical-align: middle;
-        padding: 0 10px;
         background-color: ${(props) => props.theme.primary.background[1]};
         border-color: ${(props) => props.theme.primary.background[1]};
         color: ${(props) => props.theme.primary.foreground[1]};
-    }
-
-    // prev and next arrow icons
-    .fc .fc-button {
-        font-size: 15px;
-        height: 32px;
-        padding: 0 10px;
     }
 
     // days in the previous month
@@ -104,45 +113,6 @@ const CalendarStyling = styled.div`
     // adjust background color of headers
     .fc thead {
         background-color: ${(props) => props.theme.main.background[2]};
-    }
-
-    // dynamic sizing of calendar
-    @media only screen and (max-width: 450px) {
-        .fc .fc-toolbar-title {
-            font-size: 20px;
-        }
-
-        .fc .fc-col-header-cell-cushion,
-        .fc .fc-daygrid-day-number,
-        .fc .fc-timegrid-axis-cushion,
-        .fc .fc-timegrid-slot-label-cushion {
-            font-size: 12px;
-        }
-
-        .fc .fc-event-title,
-        .fc .fc-daygrid-more-link,
-        .fc .fc-event-time {
-            font-size: 10px;
-        }
-
-        .fc .fc-button {
-            font-size: 12px;
-            height: 25px;
-            padding: 0 6px;
-        }
-    }
-
-    @media only screen and (max-width: 400px) {
-        .fc .fc-toolbar-title {
-            font-size: 16px;
-        }
-
-        .fc .fc-col-header-cell-cushion,
-        .fc .fc-daygrid-day-number,
-        .fc .fc-timegrid-axis-cushion,
-        .fc .fc-timegrid-slot-label-cushion {
-            font-size: 10px;
-        }
     }
 `;
 const makeAllDayEventsInclusive = (endDateExclusiveEvents: CalendarEvent[]): CalendarEvent[] => {

--- a/src/components/Calendar/EventModal.tsx
+++ b/src/components/Calendar/EventModal.tsx
@@ -23,6 +23,7 @@ const dateFormatOptions: Intl.DateTimeFormatOptions = {
 
 const StyledParagraph = styled.p`
     margin: 1em 0.5em;
+    font-size: 1.1rem;
 `;
 
 const EventModal: React.FC<{

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -10,6 +10,13 @@ interface TitleProps {
 const TitleHeader = styled.h1`
     text-align: center;
     margin: 1em;
+
+    @media only screen and (max-width: 480px) {
+        font-size: 25px;
+    }
+    @media only screen and (max-width: 380px) {
+        font-size: 20px;
+    }
 `;
 
 const Title: React.FC<TitleProps> = (props) => {

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -10,13 +10,7 @@ interface TitleProps {
 const TitleHeader = styled.h1`
     text-align: center;
     margin: 1em;
-
-    @media only screen and (max-width: 480px) {
-        font-size: 25px;
-    }
-    @media only screen and (max-width: 380px) {
-        font-size: 20px;
-    }
+    font-size: min(6.5vw, 2rem);
 `;
 
 const Title: React.FC<TitleProps> = (props) => {


### PR DESCRIPTION
Improved Calendar and Calendar Page display so that it is fully responsive in both mobile and desktop (do test it out!)
Added features - clicking a day will navigate to that day in day view
Refactored Calendar Page client fetching with SQL join

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
