### PR TITLE
Change accessibility test for navbar

### DIFF
--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -25,7 +25,6 @@ describe("Accessibility tests in light mode", () => {
     it("Checks clients/add page", () => {
         cy.visit("/clients/add");
 
-        cy.get(".light-button").click();
         cy.checkAccessibility();
     });
 
@@ -69,8 +68,8 @@ describe("Accessibility tests in dark mode", () => {
 
     it("Checks clients/add page", () => {
         cy.visit("/clients/add");
+        cy.get("label[aria-label='Theme Switch']").click();
 
-        cy.get(".dark-button").click();
         cy.checkAccessibility();
     });
 


### PR DESCRIPTION
Change accessibility test because it was overridden when add-clients was merged in main

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
