### PR TITLE
VFB-16 Partially disable colour transition on input

### DIFF
--- a/src/app/global_styles.tsx
+++ b/src/app/global_styles.tsx
@@ -79,7 +79,10 @@ const materialTheme = (chosenTheme: DefaultTheme): Theme =>
             },
             MuiInputLabel: {
                 styleOverrides: {
-                    root: { transition: "none" },
+                    root: {
+                        transition:
+                            "color 0ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,transform 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms,max-width 200ms cubic-bezier(0.0, 0, 0.2, 1) 0ms",
+                    },
                 },
             },
             MuiTooltip: {


### PR DESCRIPTION
Hard coded MuiInputLabel to only disable color transition but remain all other motions

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
