### PR TITLE
VFB-17 Restyle login component

### DIFF
--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -45,19 +45,4 @@ describe("Authentication tests", () => {
 
         cy.url().should("include", "/login");
     });
-
-    it("CSR Redirected to login page", () => {
-        cy.visit("/login");
-
-        // wait for hydration
-        cy.get("[data-loaded='true']", extendedTimeout).should("exist");
-
-        for (const url of buttonReachablePaths) {
-            cy.get("a[href='" + url + "']")
-                .first()
-                .click({ force: true });
-
-            cy.url().should("include", "/login");
-        }
-    });
 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,4 @@
-import LoginPanel from "@/components/LoginPanel";
+import LoginPanel, { LoginMain } from "@/components/LoginPanel";
 import React from "react";
 import Title from "@/components/Title/Title";
 
@@ -7,7 +7,7 @@ const Login: React.FC<{}> = () => {
         <main>
             <Title>Login</Title>
             <LoginPanel />
-        </main>
+        </LoginMain>
     );
 };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,9 @@
 import LoginPanel, { LoginMain } from "@/components/LoginPanel";
 import React from "react";
-import Title from "@/components/Title/Title";
 
 const Login: React.FC<{}> = () => {
     return (
-        <main>
-            <Title>Login</Title>
+        <LoginMain>
             <LoginPanel />
         </LoginMain>
     );

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -18,7 +18,7 @@ const MiddleDiv = styled.div`
     box-shadow: 0 0 15px ${(props) => props.theme.shadow};
     border-radius: 10px;
     padding: 10px 10px;
-    margin: auto 20px;
+    margin: auto 10%;
     background-color: ${(props) => props.theme.main.background[0]};
 
     --fonts-buttonFontFamily: Helvetica, Arial, sans-serif;
@@ -38,12 +38,12 @@ const MiddleDiv = styled.div`
         -webkit-text-fill-color: ${(props) => props.theme.main.foreground[2]} !important;
     }
 
-    @media (min-width: 300px) {
+    @media (min-width: 375px) {
         padding: 25px 25px;
-        margin: auto 40px;
+        margin: auto;
     }
 
-    @media (min-width: 450px) {
+    @media (min-width: 525px) {
         padding: 30px 80px;
         margin: auto;
     }

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -6,12 +6,19 @@ import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import React, { useEffect } from "react";
 import styled, { useTheme } from "styled-components";
+import Title from "@/components/Title/Title";
+import NoSsr from "@mui/material/NoSsr";
+
+export const LoginMain = styled.main`
+    height: 85vh;
+    display: flex;
+`;
 
 const MiddleDiv = styled.div`
     max-width: 400px;
     box-shadow: 0 0 15px ${(props) => props.theme.shadow};
     border-radius: 10px;
-    padding: 50px;
+    padding: 10px 25px;
     margin: auto;
     background-color: ${(props) => props.theme.main.background[0]};
 
@@ -30,6 +37,10 @@ const MiddleDiv = styled.div`
     & input:-webkit-autofill:active {
         -webkit-box-shadow: 0 0 0 9999px ${(props) => props.theme.main.background[2]} inset !important;
         -webkit-text-fill-color: ${(props) => props.theme.main.foreground[2]} !important;
+    }
+
+    @media (min-width: 400px) {
+        padding: 30px 80px;
     }
 `;
 
@@ -64,10 +75,10 @@ const LoginPanel: React.FC<{}> = () => {
                                 messageTextDanger: theme.error,
                             },
                         },
-                    },
-                }}
-                redirectTo="http://localhost:3000/auth/callback"
-            />
+                    }}
+                    redirectTo="http://localhost:3000/auth/callback"
+                />
+            </NoSsr>
         </MiddleDiv>
     );
 };

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -6,7 +6,6 @@ import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import React, { useEffect } from "react";
 import styled, { useTheme } from "styled-components";
-import NoSsr from "@mui/material/NoSsr";
 import Title from "@/components/Title/Title";
 
 export const LoginMain = styled.main`

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -62,29 +62,29 @@ const LoginPanel: React.FC<{}> = () => {
     return (
         <MiddleDiv data-loaded={loaded} id="login-panel">
             <Title>Login</Title>
-                <Auth
-                    supabaseClient={supabase}
-                    providers={[]}
-                    appearance={{
-                        theme: ThemeSupa,
-                        variables: {
-                            default: {
-                                colors: {
-                                    inputText: theme.main.foreground[2],
-                                    inputBackground: theme.main.background[2],
-                                    inputBorder: theme.main.background[2],
-                                    inputLabelText: theme.main.foreground[0],
-                                    anchorTextColor: theme.main.lighterForeground[0],
-                                    brand: theme.primary.background[2],
-                                    brandAccent: theme.primary.background[2],
-                                    brandButtonText: theme.primary.foreground[2],
-                                    messageTextDanger: theme.error,
-                                },
+            <Auth
+                supabaseClient={supabase}
+                providers={[]}
+                appearance={{
+                    theme: ThemeSupa,
+                    variables: {
+                        default: {
+                            colors: {
+                                inputText: theme.main.foreground[2],
+                                inputBackground: theme.main.background[2],
+                                inputBorder: theme.main.background[2],
+                                inputLabelText: theme.main.foreground[0],
+                                anchorTextColor: theme.main.lighterForeground[0],
+                                brand: theme.primary.background[2],
+                                brandAccent: theme.primary.background[2],
+                                brandButtonText: theme.primary.foreground[2],
+                                messageTextDanger: theme.error,
                             },
                         },
-                    }}
-                    redirectTo="http://localhost:3000/auth/callback"
-                />
+                    },
+                }}
+                redirectTo="http://localhost:3000/auth/callback"
+            />
         </MiddleDiv>
     );
 };

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -7,7 +7,7 @@ import { ThemeSupa } from "@supabase/auth-ui-shared";
 import React, { useEffect } from "react";
 import styled, { useTheme } from "styled-components";
 import NoSsr from "@mui/material/NoSsr";
-import Title from "./Title/Title";
+import Title from "@/components/Title/Title";
 
 export const LoginMain = styled.main`
     height: 85vh;

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -7,10 +7,12 @@ import { ThemeSupa } from "@supabase/auth-ui-shared";
 import React, { useEffect } from "react";
 import styled, { useTheme } from "styled-components";
 import Title from "@/components/Title/Title";
+import { NavBarHeight } from "@/components/NavBar/NavigationBar";
 
 export const LoginMain = styled.main`
-    height: 100%;
+    height: calc(100vh - ${NavBarHeight});
     display: flex;
+    align-content: center;
 `;
 
 const MiddleDiv = styled.div`

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -10,7 +10,7 @@ import NoSsr from "@mui/material/NoSsr";
 import Title from "@/components/Title/Title";
 
 export const LoginMain = styled.main`
-    height: 85vh;
+    height: 100%;
     display: flex;
 `;
 
@@ -18,8 +18,8 @@ const MiddleDiv = styled.div`
     max-width: 400px;
     box-shadow: 0 0 15px ${(props) => props.theme.shadow};
     border-radius: 10px;
-    padding: 10px 25px;
-    margin: auto;
+    padding: 10px 10px;
+    margin: auto 20px;
     background-color: ${(props) => props.theme.main.background[0]};
 
     --fonts-buttonFontFamily: Helvetica, Arial, sans-serif;
@@ -39,8 +39,14 @@ const MiddleDiv = styled.div`
         -webkit-text-fill-color: ${(props) => props.theme.main.foreground[2]} !important;
     }
 
-    @media (min-width: 500px) {
+    @media (min-width: 300px) {
+        padding: 25px 25px;
+        margin: auto 40px;
+    }
+
+    @media (min-width: 450px) {
         padding: 30px 80px;
+        margin: auto;
     }
 `;
 
@@ -57,7 +63,6 @@ const LoginPanel: React.FC<{}> = () => {
     return (
         <MiddleDiv data-loaded={loaded} id="login-panel">
             <Title>Login</Title>
-            <NoSsr>
                 <Auth
                     supabaseClient={supabase}
                     providers={[]}
@@ -81,7 +86,6 @@ const LoginPanel: React.FC<{}> = () => {
                     }}
                     redirectTo="http://localhost:3000/auth/callback"
                 />
-            </NoSsr>
         </MiddleDiv>
     );
 };

--- a/src/components/LoginPanel.tsx
+++ b/src/components/LoginPanel.tsx
@@ -6,8 +6,8 @@ import { Auth } from "@supabase/auth-ui-react";
 import { ThemeSupa } from "@supabase/auth-ui-shared";
 import React, { useEffect } from "react";
 import styled, { useTheme } from "styled-components";
-import Title from "@/components/Title/Title";
 import NoSsr from "@mui/material/NoSsr";
+import Title from "./Title/Title";
 
 export const LoginMain = styled.main`
     height: 85vh;
@@ -39,7 +39,7 @@ const MiddleDiv = styled.div`
         -webkit-text-fill-color: ${(props) => props.theme.main.foreground[2]} !important;
     }
 
-    @media (min-width: 400px) {
+    @media (min-width: 500px) {
         padding: 30px 80px;
     }
 `;
@@ -56,23 +56,26 @@ const LoginPanel: React.FC<{}> = () => {
 
     return (
         <MiddleDiv data-loaded={loaded} id="login-panel">
-            <Auth
-                supabaseClient={supabase}
-                providers={[]}
-                appearance={{
-                    theme: ThemeSupa,
-                    variables: {
-                        default: {
-                            colors: {
-                                inputText: theme.main.foreground[2],
-                                inputBackground: theme.main.background[2],
-                                inputBorder: theme.main.background[2],
-                                inputLabelText: theme.main.foreground[0],
-                                anchorTextColor: theme.main.lighterForeground[0],
-                                brand: theme.primary.background[2],
-                                brandAccent: theme.primary.background[2],
-                                brandButtonText: theme.primary.foreground[2],
-                                messageTextDanger: theme.error,
+            <Title>Login</Title>
+            <NoSsr>
+                <Auth
+                    supabaseClient={supabase}
+                    providers={[]}
+                    appearance={{
+                        theme: ThemeSupa,
+                        variables: {
+                            default: {
+                                colors: {
+                                    inputText: theme.main.foreground[2],
+                                    inputBackground: theme.main.background[2],
+                                    inputBorder: theme.main.background[2],
+                                    inputLabelText: theme.main.foreground[0],
+                                    anchorTextColor: theme.main.lighterForeground[0],
+                                    brand: theme.primary.background[2],
+                                    brandAccent: theme.primary.background[2],
+                                    brandButtonText: theme.primary.foreground[2],
+                                    messageTextDanger: theme.error,
+                                },
                             },
                         },
                     }}

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -108,11 +108,7 @@ const SignOutButtonContainer = styled(NavElementContainer)`
     justify-content: end;
 `;
 
-interface LoginDependentProps {
-    children: React.ReactElement;
-}
-
-const LoginDependent: React.FC<LoginDependentProps> = (props) => {
+const LoginDependent: React.FC<Props> = (props) => {
     const pathname = usePathname();
 
     if (pathname === "/login") {
@@ -136,7 +132,6 @@ interface Props {
 
 const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
     const [drawer, setDrawer] = React.useState(false);
-    const pathname = usePathname();
 
     const openDrawer = (): void => {
         setDrawer(true);
@@ -155,7 +150,7 @@ const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
     return (
         <>
             <LoginDependent>
-                <SwipeableDrawer open={drawer} onClose={closeDrawer} onOpen={openDrawer}>
+                <StyledSwipeableDrawer open={drawer} onClose={closeDrawer} onOpen={openDrawer}>
                     <DrawerInner>
                         {pages.map(([page, link]) => (
                             <DrawerButtonWrapper key={page}>
@@ -165,22 +160,19 @@ const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
                             </DrawerButtonWrapper>
                         ))}
                     </DrawerInner>
-                </SwipeableDrawer>
+                </StyledSwipeableDrawer>
             </LoginDependent>
             <AppBar>
                 <AppBarInner>
                     <MobileNavMenuContainer>
-                        <Button
-                            color="secondary"
-                            aria-label="Mobile Menu Button"
-                            onClick={openDrawer}
-                        >
-                            <MenuIcon />
-                        </Button>
                         <LoginDependent>
-                            <IconButton aria-label="Mobile Menu Button" onClick={openDrawer}>
+                            <Button
+                                color="secondary"
+                                aria-label="Mobile Menu Button"
+                                onClick={openDrawer}
+                            >
                                 <MenuIcon />
-                            </IconButton>
+                            </Button>
                         </LoginDependent>
                     </MobileNavMenuContainer>
 

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -12,7 +12,7 @@ import SignOutButton from "@/components/NavBar/SignOutButton";
 import LinkButton from "@/components/Buttons/LinkButton";
 import { usePathname } from "next/navigation";
 
-const NavBarHeight = "4rem";
+export const NavBarHeight = "4rem";
 
 export const PageButton = styled(Button)`
     color: white;

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -10,6 +10,7 @@ import Button from "@mui/material/Button";
 import LightDarkSlider from "@/components/NavBar/LightDarkSlider";
 import SignOutButton from "@/components/NavBar/SignOutButton";
 import LinkButton from "@/components/Buttons/LinkButton";
+import { usePathname } from "next/navigation";
 
 const NavBarHeight = "4rem";
 
@@ -107,12 +108,35 @@ const SignOutButtonContainer = styled(NavElementContainer)`
     justify-content: end;
 `;
 
+interface LoginDependentProps {
+    children: React.ReactElement;
+}
+
+const LoginDependent: React.FC<LoginDependentProps> = (props) => {
+    const pathname = usePathname();
+
+    if (pathname === "/login") {
+        return <></>;
+    }
+
+    return <>{props.children}</>;
+};
+
+const ContentDiv = styled.div`
+    height: calc(100% - ${NavBarHeight});
+    width: 100%;
+    position: absolute;
+    top: ${NavBarHeight};
+    overflow: auto;
+`;
+
 interface Props {
     children?: React.ReactNode;
 }
 
 const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
     const [drawer, setDrawer] = React.useState(false);
+    const pathname = usePathname();
 
     const openDrawer = (): void => {
         setDrawer(true);
@@ -130,19 +154,19 @@ const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
 
     return (
         <>
-            <StyledSwipeableDrawer open={drawer} onClose={closeDrawer} onOpen={openDrawer}>
-                <DrawerInner>
-                    {pages.map(([page, link]) => (
-                        <DrawerButtonWrapper key={page}>
-                            <UnstyledLink href={link} onClick={closeDrawer} prefetch={false}>
-                                <DrawerButton color="secondary" variant="text">
-                                    {page}
-                                </DrawerButton>
-                            </UnstyledLink>
-                        </DrawerButtonWrapper>
-                    ))}
-                </DrawerInner>
-            </StyledSwipeableDrawer>
+            <LoginDependent>
+                <SwipeableDrawer open={drawer} onClose={closeDrawer} onOpen={openDrawer}>
+                    <DrawerInner>
+                        {pages.map(([page, link]) => (
+                            <DrawerButtonWrapper key={page}>
+                                <UnstyledLink href={link} onClick={closeDrawer} prefetch={false}>
+                                    <DrawerButton variant="text">{page}</DrawerButton>
+                                </UnstyledLink>
+                            </DrawerButtonWrapper>
+                        ))}
+                    </DrawerInner>
+                </SwipeableDrawer>
+            </LoginDependent>
             <AppBar>
                 <AppBarInner>
                     <MobileNavMenuContainer>
@@ -153,24 +177,34 @@ const ResponsiveAppBar: React.FC<Props> = ({ children }) => {
                         >
                             <MenuIcon />
                         </Button>
+                        <LoginDependent>
+                            <IconButton aria-label="Mobile Menu Button" onClick={openDrawer}>
+                                <MenuIcon />
+                            </IconButton>
+                        </LoginDependent>
                     </MobileNavMenuContainer>
+
                     <LogoElementContainer>
                         <UnstyledLink href="/" prefetch={false}>
                             <Logo alt="Vauxhall Foodbank Logo" src="/logo.webp" />
                         </UnstyledLink>
                     </LogoElementContainer>
-                    <DesktopButtonContainer>
-                        {pages.map(([page, link]) => (
-                            <React.Fragment key={page}>
-                                <LinkButton link={link} page={page} />
-                                <Gap />
-                            </React.Fragment>
-                        ))}
-                    </DesktopButtonContainer>
+                    <LoginDependent>
+                        <DesktopButtonContainer>
+                            {pages.map(([page, link]) => (
+                                <>
+                                    <LinkButton key={page} link={link} page={page} />
+                                    <Gap />
+                                </>
+                            ))}
+                        </DesktopButtonContainer>
+                    </LoginDependent>
                     <SignOutButtonContainer>
                         <LightDarkSlider />
                         <Gap />
-                        <SignOutButton />
+                        <LoginDependent>
+                            <SignOutButton />
+                        </LoginDependent>
                     </SignOutButtonContainer>
                 </AppBarInner>
             </AppBar>

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -118,14 +118,6 @@ const LoginDependent: React.FC<Props> = (props) => {
     return <>{props.children}</>;
 };
 
-const ContentDiv = styled.div`
-    height: calc(100% - ${NavBarHeight});
-    width: 100%;
-    position: absolute;
-    top: ${NavBarHeight};
-    overflow: auto;
-`;
-
 interface Props {
     children?: React.ReactNode;
 }


### PR DESCRIPTION
1. Centered the login component
2. Put title inside the login panel
3. Wrap a NoSsr to suppress hydration error
4. Made a LoginDependent component which will only show the children when not in the login page. Used to hide the navbar elements when we are in the login page.

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
