### PR TITLE
Extend auth timeout

### DIFF
--- a/src/app/auth.tsx
+++ b/src/app/auth.tsx
@@ -35,13 +35,12 @@ export const AuthRouting: React.FC<{ children: React.ReactNode }> = ({ children 
             router.push(redirect);
 
             // if Client Side Routing is not working, fallback to changing the window location
-            // This seemingly only happens on GH Actions
             setTimeout(() => {
                 const redirect = toRedirectTo();
                 if (redirect) {
                     window.location.pathname = redirect;
                 }
-            }, 500);
+            }, 2500);
         }
     };
 


### PR DESCRIPTION
Normal login and logout times even locally were exceeding 500ms and causes an unpleasant white flash as themes update when not using client side routing so I've extended the timeout