### PR TITLE
Fixing tests on Main

### DIFF
--- a/cypress/e2e/themes.cy.ts
+++ b/cypress/e2e/themes.cy.ts
@@ -9,13 +9,12 @@ describe("Light and dark mode switch works", () => {
     });
 
     it("Switching to Dark Mode Works", () => {
-        cy.get("label[aria-label='Theme Switch']").click();
+        cy.get("[type='checkbox']").first().check();
         cy.get("body").should("have.css", "background-color", hexToRgb("#212121"));
     });
 
     it("Switching back to Light Mode Works", () => {
-        cy.get("label[aria-label='Theme Switch']").click();
-        cy.get("label[aria-label='Theme Switch']").click();
+        cy.get("[type='checkbox']").first().uncheck();
         cy.get("body").should("have.css", "background-color", hexToRgb("#eeeeee"));
     });
 });


### PR DESCRIPTION
Theme tests were failing locally due to having dark mode as the system preference, then the system clicking and switching to light mode but testing to dark mode. Have changed this/ will change any other failing tests on main if they exist.

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
