### PR TITLE
Add Parcels button on Clients Page

### DIFF
--- a/src/app/clients/ActionBar.cy.tsx
+++ b/src/app/clients/ActionBar.cy.tsx
@@ -7,6 +7,7 @@ import Localization from "../localizationProvider";
 describe("Clients - Action Bar", () => {
     const mockData: ClientsTableRow[] = [
         {
+            primaryKey: "primaryKey1",
             addressPostcode: "AB1 2CD",
             collectionCentre: "Centre 1",
             collectionDatetime: new Date().toISOString(),
@@ -22,6 +23,7 @@ describe("Clients - Action Bar", () => {
             requiresFollowUpPhoneCall: false,
         },
         {
+            primaryKey: "primaryKey2",
             addressPostcode: "AB1 aaaa2CD",
             collectionCentre: "Centraaaae 1",
             collectionDatetime: new Date().toISOString(),

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import { ClientsTableRow } from "@/app/clients/getClientsTableData";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import PopUpButton from "@/components/Buttons/PopUpButton";
+import LinkButton from "@/components/Buttons/LinkButton";
+import Button from "@mui/material/Button";
+import TableSurface from "@/components/Tables/TableSurface";
+import Table, { TableHeaders } from "@/components/Tables/Table";
+import styled from "styled-components";
+
+interface Props {
+    data: ClientsTableRow[];
+}
+
+const PopUp = styled.div`
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    padding: 2rem;
+`;
+
+const headers: TableHeaders = [
+    ["fullName", "Name"],
+    ["familyCategory", "Family"],
+    ["addressPostcode", "Postcode"],
+];
+
+const styleOptions = {
+    fullName: {
+        minWidth: "8rem",
+    },
+    familyCategory: {
+        hide: 550,
+    },
+    addressPostcode: {
+        hide: 800,
+    },
+};
+
+const AddParcelsButton: React.FC<Props> = ({ data }) => {
+    const [existingClientsView, setExistingClientsView] = useState(false);
+    const router = useRouter();
+
+    return (
+        <PopUpButton displayText="Add Parcel">
+            <>
+                {!existingClientsView ? (
+                    <PopUp>
+                        <LinkButton link="/clients/add">New Client</LinkButton>
+                        <Button onClick={() => setExistingClientsView(true)}>
+                            Existing Client
+                        </Button>
+                    </PopUp>
+                ) : (
+                    <>
+                        <TableSurface>
+                            <Table
+                                data={data}
+                                headerKeysAndLabels={headers}
+                                onRowClick={(row) => router.push(`/clients/${row.data.primaryKey}`)}
+                                sortable={true}
+                                pagination={false}
+                                checkboxes={false}
+                                columnStyleOptions={styleOptions}
+                                headerFilters={["fullName"]}
+                            />
+                        </TableSurface>
+                        <Button onClick={() => setExistingClientsView(false)}>Back</Button>
+                    </>
+                )}
+            </>
+        </PopUpButton>
+    );
+};
+
+export default AddParcelsButton;

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -71,32 +71,28 @@ const AddParcelsButton: React.FC<Props> = ({ data }) => {
 
     return (
         <PopUpButton displayText="Add Parcel">
-            <>
-                {!existingClientsView ? (
-                    <PopUp>
-                        <LinkButton link="/clients/add">New Client</LinkButton>
-                        <Button onClick={() => setExistingClientsView(true)}>
-                            Existing Client
-                        </Button>
-                    </PopUp>
-                ) : (
-                    <>
-                        <TableSurface>
-                            <Table
-                                data={clientData}
-                                headerKeysAndLabels={headers}
-                                onRowClick={(row) => router.push(`/clients/${row.data.primaryKey}`)}
-                                sortable={true}
-                                pagination={false}
-                                checkboxes={false}
-                                columnStyleOptions={styleOptions}
-                                headerFilters={["fullName"]}
-                            />
-                        </TableSurface>
-                        <Button onClick={() => setExistingClientsView(false)}>Back</Button>
-                    </>
-                )}
-            </>
+            {!existingClientsView ? (
+                <PopUp>
+                    <LinkButton link="/clients/add">New Client</LinkButton>
+                    <Button onClick={() => setExistingClientsView(true)}>Existing Client</Button>
+                </PopUp>
+            ) : (
+                <>
+                    <TableSurface>
+                        <Table
+                            data={clientData}
+                            headerKeysAndLabels={headers}
+                            onRowClick={(row) => router.push(`/clients/${row.data.primaryKey}`)}
+                            sortable
+                            pagination
+                            checkboxes={false}
+                            columnStyleOptions={styleOptions}
+                            headerFilters={["fullName"]}
+                        />
+                    </TableSurface>
+                    <Button onClick={() => setExistingClientsView(false)}>Back</Button>
+                </>
+            )}
         </PopUpButton>
     );
 };

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import React from "react";
-import { ClientsTableRow } from "@/app/clients/getClientsTableData";
+import styled from "styled-components";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { Schema } from "@/database_utils";
 import PopUpButton from "@/components/Buttons/PopUpButton";
 import LinkButton from "@/components/Buttons/LinkButton";
 import Button from "@mui/material/Button";
 import TableSurface from "@/components/Tables/TableSurface";
 import Table, { Datum, TableHeaders } from "@/components/Tables/Table";
-import styled from "styled-components";
-import { Schema } from "@/database_utils";
+import { ClientsTableRow } from "@/app/clients/getClientsTableData";
 
 interface Props {
     data: ClientsTableRow[];
@@ -22,12 +22,6 @@ interface ClientsListRow extends Datum {
     familyCategory: string;
     addressPostcode: Schema["clients"]["address_postcode"];
 }
-
-const headers: TableHeaders = [
-    ["fullName", "Name"],
-    ["familyCategory", "Family"],
-    ["addressPostcode", "Postcode"],
-];
 
 const PopUp = styled.div`
     display: flex;
@@ -47,6 +41,12 @@ const styleOptions = {
         hide: 800,
     },
 };
+
+const headers: TableHeaders = [
+    ["fullName", "Name"],
+    ["familyCategory", "Family"],
+    ["addressPostcode", "Postcode"],
+];
 
 const showClients = (data: ClientsTableRow[]): ClientsListRow[] => {
     const primaryKeys: string[] = [];

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -71,12 +71,7 @@ const AddParcelsButton: React.FC<Props> = ({ data }) => {
 
     return (
         <PopUpButton displayText="Add Parcel">
-            {!existingClientsView ? (
-                <PopUp>
-                    <LinkButton link="/clients/add">New Client</LinkButton>
-                    <Button onClick={() => setExistingClientsView(true)}>Existing Client</Button>
-                </PopUp>
-            ) : (
+            {existingClientsView ? (
                 <>
                     <TableSurface>
                         <Table
@@ -92,6 +87,11 @@ const AddParcelsButton: React.FC<Props> = ({ data }) => {
                     </TableSurface>
                     <Button onClick={() => setExistingClientsView(false)}>Back</Button>
                 </>
+            ) : (
+                <PopUp>
+                    <LinkButton link="/clients/add">New Client</LinkButton>
+                    <Button onClick={() => setExistingClientsView(true)}>Existing Client</Button>
+                </PopUp>
             )}
         </PopUpButton>
     );

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -10,7 +10,7 @@ import Button from "@mui/material/Button";
 import TableSurface from "@/components/Tables/TableSurface";
 import Table, { Datum, TableHeaders } from "@/components/Tables/Table";
 import styled from "styled-components";
-import { Schema } from "@/supabase";
+import { Schema } from "@/database_utils";
 
 interface Props {
     data: ClientsTableRow[];

--- a/src/app/clients/AddParcelsButton.tsx
+++ b/src/app/clients/AddParcelsButton.tsx
@@ -8,12 +8,26 @@ import PopUpButton from "@/components/Buttons/PopUpButton";
 import LinkButton from "@/components/Buttons/LinkButton";
 import Button from "@mui/material/Button";
 import TableSurface from "@/components/Tables/TableSurface";
-import Table, { TableHeaders } from "@/components/Tables/Table";
+import Table, { Datum, TableHeaders } from "@/components/Tables/Table";
 import styled from "styled-components";
+import { Schema } from "@/supabase";
 
 interface Props {
     data: ClientsTableRow[];
 }
+
+interface ClientsListRow extends Datum {
+    primaryKey: string;
+    fullName: Schema["clients"]["full_name"];
+    familyCategory: string;
+    addressPostcode: Schema["clients"]["address_postcode"];
+}
+
+const headers: TableHeaders = [
+    ["fullName", "Name"],
+    ["familyCategory", "Family"],
+    ["addressPostcode", "Postcode"],
+];
 
 const PopUp = styled.div`
     display: flex;
@@ -21,12 +35,6 @@ const PopUp = styled.div`
     text-align: center;
     padding: 2rem;
 `;
-
-const headers: TableHeaders = [
-    ["fullName", "Name"],
-    ["familyCategory", "Family"],
-    ["addressPostcode", "Postcode"],
-];
 
 const styleOptions = {
     fullName: {
@@ -40,9 +48,26 @@ const styleOptions = {
     },
 };
 
+const showClients = (data: ClientsTableRow[]): ClientsListRow[] => {
+    const primaryKeys: string[] = [];
+    const clientsData: ClientsListRow[] = [];
+
+    for (const datum of data) {
+        if (!primaryKeys.includes(datum.primaryKey)) {
+            const { primaryKey, fullName, familyCategory, addressPostcode } = datum;
+            clientsData.push({ primaryKey, fullName, familyCategory, addressPostcode });
+            primaryKeys.push(datum.primaryKey);
+        }
+    }
+
+    return clientsData;
+};
+
 const AddParcelsButton: React.FC<Props> = ({ data }) => {
     const [existingClientsView, setExistingClientsView] = useState(false);
     const router = useRouter();
+
+    const clientData = showClients(data);
 
     return (
         <PopUpButton displayText="Add Parcel">
@@ -58,7 +83,7 @@ const AddParcelsButton: React.FC<Props> = ({ data }) => {
                     <>
                         <TableSurface>
                             <Table
-                                data={data}
+                                data={clientData}
                                 headerKeysAndLabels={headers}
                                 onRowClick={(row) => router.push(`/clients/${row.data.primaryKey}`)}
                                 sortable={true}

--- a/src/app/clients/ClientsPage.cy.tsx
+++ b/src/app/clients/ClientsPage.cy.tsx
@@ -23,7 +23,7 @@ const sampleProcessingData: ProcessingData = [
         packing_datetime: "2023-08-04T13:30:00+00:00",
 
         client: {
-            primary_key: "primary_key_1",
+            primary_key: "PRIMARY_KEY_1",
             full_name: "CLIENT_NAME",
             address_postcode: "SW1A 2AA",
             flagged_for_attention: false,
@@ -50,6 +50,7 @@ const sampleRawExpandedClientDetails: RawClientDetails = {
     packing_datetime: "2023-08-04T13:30:00+00:00",
 
     client: {
+        primary_key: "PRIMARY_KEY_1",
         full_name: "CLIENT NAME",
         phone_number: "PHONE NUMBER",
         delivery_instructions: "INSTRUCTIONS FOR DELIVERY",
@@ -90,6 +91,7 @@ describe("Clients Page", () => {
                 processingDataToClientsTableData(sampleProcessingData).then((clientTableData) => {
                     expect(clientTableData).to.deep.equal([
                         {
+                            primaryKey: "PRIMARY_KEY_1",
                             parcelId: "PRIMARY_KEY",
                             flaggedForAttention: false,
                             requiresFollowUpPhoneCall: true,

--- a/src/app/clients/ClientsPage.cy.tsx
+++ b/src/app/clients/ClientsPage.cy.tsx
@@ -23,6 +23,7 @@ const sampleProcessingData: ProcessingData = [
         packing_datetime: "2023-08-04T13:30:00+00:00",
 
         client: {
+            primary_key: "primary_key_1",
             full_name: "CLIENT_NAME",
             address_postcode: "SW1A 2AA",
             flagged_for_attention: false,

--- a/src/app/clients/ClientsPage.tsx
+++ b/src/app/clients/ClientsPage.tsx
@@ -18,10 +18,8 @@ import Modal from "@/components/Modal/Modal";
 import { Schema } from "@/database_utils";
 import TableSurface from "@/components/Tables/TableSurface";
 import { CenterComponent } from "@/components/Form/formStyling";
-import Button from "@mui/material/Button";
 import ActionBar from "@/app/clients/ActionBar";
-
-// TODO Change Button to LinkButton
+import AddParcelsButton from "@/app/clients/AddParcelsButton";
 
 const collectionCentreToAbbreviation = (
     collectionCentre: Schema["parcels"]["collection_centre"]
@@ -191,9 +189,7 @@ const ClientsPage: React.FC<Props> = (props) => {
                 </Suspense>
             </Modal>
             <CenterComponent>
-                <Button variant="contained" href="/clients/add">
-                    Add Clients
-                </Button>
+                <AddParcelsButton data={props.clientsTableData} />
             </CenterComponent>
         </>
     );

--- a/src/app/clients/getClientsTableData.ts
+++ b/src/app/clients/getClientsTableData.ts
@@ -13,6 +13,7 @@ export interface ClientsTableRow extends Datum {
     collectionCentre: string;
     congestionChargeApplies: boolean;
     packingTimeLabel: string;
+    collectionDatetime: string;
     lastStatus: string;
 }
 
@@ -77,6 +78,7 @@ export const processingDataToClientsTableData = async (
             congestionChargeApplies: congestionChargeDetails[index].congestionCharge,
             packingDate: formatDatetimeAsDate(parcel.packing_datetime),
             packingTimeLabel: datetimeToPackingTimeLabel(parcel.packing_datetime),
+            collectionDatetime: formatDatetimeAsDate(parcel.collection_datetime),
             lastStatus: eventToStatusMessage(parcel.events[0] ?? null),
         });
     }

--- a/src/app/clients/getClientsTableData.ts
+++ b/src/app/clients/getClientsTableData.ts
@@ -3,6 +3,7 @@ import { Schema } from "@/database_utils";
 import { Datum } from "@/components/Tables/Table";
 
 export interface ClientsTableRow extends Datum {
+    primaryKey: string;
     parcelId: Schema["parcels"]["primary_key"];
     flaggedForAttention: boolean;
     requiresFollowUpPhoneCall: boolean;
@@ -13,7 +14,6 @@ export interface ClientsTableRow extends Datum {
     congestionChargeApplies: boolean;
     packingTimeLabel: string;
     lastStatus: string;
-    collectionDatetime: Schema["parcels"]["collection_datetime"];
 }
 
 export type ProcessingData = Awaited<ReturnType<typeof getProcessingData>>;
@@ -30,6 +30,7 @@ const getProcessingData = async () => {
         packing_datetime,
         
         client:clients (
+            primary_key,
             full_name,
             address_postcode,
             flagged_for_attention,
@@ -57,7 +58,7 @@ const getProcessingData = async () => {
 export const processingDataToClientsTableData = async (
     processingData: ProcessingData
 ): Promise<ClientsTableRow[]> => {
-    const clientTableRows = [];
+    const clientTableRows: ClientsTableRow[] = [];
     const congestionChargeDetails = await getCongestionChargeDetails(processingData);
 
     for (let index = 0; index < processingData.length; index++) {
@@ -65,6 +66,7 @@ export const processingDataToClientsTableData = async (
         const client = parcel.client!;
 
         clientTableRows.push({
+            primaryKey: client.primary_key,
             parcelId: parcel.parcel_id,
             flaggedForAttention: client.flagged_for_attention,
             requiresFollowUpPhoneCall: client.signposting_call_required,
@@ -72,7 +74,6 @@ export const processingDataToClientsTableData = async (
             familyCategory: familyCountToFamilyCategory(client.family.length),
             addressPostcode: client.address_postcode,
             collectionCentre: parcel.collection_centre ?? "-",
-            collectionDatetime: parcel.collection_datetime,
             congestionChargeApplies: congestionChargeDetails[index].congestionCharge,
             packingDate: formatDatetimeAsDate(parcel.packing_datetime),
             packingTimeLabel: datetimeToPackingTimeLabel(parcel.packing_datetime),

--- a/src/app/clients/getClientsTableData.ts
+++ b/src/app/clients/getClientsTableData.ts
@@ -78,7 +78,7 @@ export const processingDataToClientsTableData = async (
             congestionChargeApplies: congestionChargeDetails[index].congestionCharge,
             packingDate: formatDatetimeAsDate(parcel.packing_datetime),
             packingTimeLabel: datetimeToPackingTimeLabel(parcel.packing_datetime),
-            collectionDatetime: formatDatetimeAsDate(parcel.collection_datetime),
+            collectionDatetime: parcel.collection_datetime ?? "-",
             lastStatus: eventToStatusMessage(parcel.events[0] ?? null),
         });
     }

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -18,6 +18,7 @@ export const getRawClientDetails = async (parcelId: string) => {
         packing_datetime,
 
         client:clients(
+            primary_key,
             full_name,
             phone_number,
             delivery_instructions,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,4 +32,6 @@ export const metadata: Metadata = {
     description: "Providing foodbank services to clients in south London.",
 };
 
+export const dynamic = "force-dynamic";
+
 export default App;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,4 @@ export const metadata: Metadata = {
     description: "Providing foodbank services to clients in south London.",
 };
 
-export const dynamic = "force-dynamic";
-
 export default App;


### PR DESCRIPTION
Currently, when the client's row in the popup is clicked, it will redirect to clients/[id] but there is no page for that yet. 

Also had to make some minor changes for the ActionBar which uses parcel.collectionDatetime but that wasn't in ClientsTableRow.

- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've linted via `npm run lint`
    - can run `npm run lint_fix` to try and fix as any mistakes automatically as possible!
- [x] Make sure you've tested via `npm run test`
