### PR TITLE
Removed time dependency from pdf test

### DIFF
--- a/src/components/PdfButton/PdfButton.cy.tsx
+++ b/src/components/PdfButton/PdfButton.cy.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import PdfButton, { formatFileName } from "@/components/PdfButton/PdfButton";
+import PdfButton from "@/components/PdfButton/PdfButton";
 import ShippingLabelsPdf, { ParcelClients } from "@/pdf/ShippingLabels/ShippingLabelsPdf";
 
 const downloadsFolder = Cypress.config("downloadsFolder");

--- a/src/components/PdfButton/PdfButton.cy.tsx
+++ b/src/components/PdfButton/PdfButton.cy.tsx
@@ -49,6 +49,7 @@ describe("Export Pdf Button", () => {
                 fileName={fileName}
                 data={parcelClientsData}
                 pdfComponent={ShippingLabelsPdf}
+                formatName={false}
             />
         );
     });
@@ -57,15 +58,13 @@ describe("Export Pdf Button", () => {
 
     it("File is saved", () => {
         cy.get("a").click();
-        const formattedFileName = formatFileName(fileName);
-        cy.readFile(`${downloadsFolder}/${formattedFileName}`);
+        cy.readFile(`${downloadsFolder}/${fileName}`);
     });
 
     it("All data of shipping label is included in the file", () => {
         cy.get("a").click();
-        const formattedFileName = formatFileName(fileName);
         for (const field of allFields) {
-            cy.task("readPdf", `${downloadsFolder}/${formattedFileName}`).should("contain", field);
+            cy.task("readPdf", `${downloadsFolder}/${fileName}`).should("contain", field);
         }
     });
 });

--- a/src/components/PdfButton/PdfButton.tsx
+++ b/src/components/PdfButton/PdfButton.tsx
@@ -29,7 +29,7 @@ const filenameTimestampNow = (): string => {
     return `${year}_${month}_${day}_${hours}_${minutes}_${seconds}`;
 };
 
-export const formatFileName = (fileName: string): string => {
+const formatFileName = (fileName: string): string => {
     const newFileName = fileName.endsWith(".pdf") ? fileName.slice(0, -4) : fileName;
     return `${newFileName}_${filenameTimestampNow()}.pdf`;
 };


### PR DESCRIPTION
Removed the time dependency in the file name of pdf test. This makes the test not flaky when it takes more than a second to run.

- [x] Make sure you've verified it works on dev via `npm run dev`
- [x] Make sure you've verified it works on prod via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request!
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request!
