### PR TITLE
Fix Login Retry in Tests

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -22,8 +22,8 @@ const loginWithRetry = (iteration: number = 0): void => {
         return;
     }
 
-    cy.get("h1").then((heading) => {
-        if (heading.text().includes("Login")) {
+    cy.url().then((url) => {
+        if (url.includes("login")) {
             cy.get("button[type='submit']").then((submitButton) => {
                 if (submitButton.not(":disabled")) {
                     submitButton.trigger("click");


### PR DESCRIPTION
Instead of reading the title of the page to determine what page we're on, read from the url.

- [x] Make sure you've verified it works on dev via `npm run dev`
- [x] Make sure you've verified it works on prod via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request!
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request!
