### PR TITLE
VFB-88: Upgrade react-data-table-component to v7.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9556,15 +9556,20 @@
       }
     },
     "node_modules/react-data-table-component": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.5.3.tgz",
-      "integrity": "sha512-JhatRTgThAAa1HobPaPmkNPsjLT6+fnMIdtcXRCy+0bSYN7XJnTgob9Qyi4bjHh/8tMPTHtxZCV/TKiPwRvFMA==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.6.2.tgz",
+      "integrity": "sha512-nHe7040fmtrJyQr/ieGrTfV0jBflYGK4sLokC6/AFOv3ThjmA9WzKz8Z8/2wMxzRqLU+Rn0CVFg+8+frKLepWQ==",
       "dependencies": {
-        "deepmerge": "^4.2.2"
+        "deepmerge": "^4.3.1"
       },
       "peerDependencies": {
         "react": ">= 16.8.3",
-        "styled-components": ">= 4"
+        "styled-components": ">= 5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "styled-components": {
+          "optional": false
+        }
       }
     },
     "node_modules/react-dom": {

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -13,9 +13,9 @@ import { NoSsr } from "@mui/material";
 import IconButton from "@mui/material/IconButton/IconButton";
 import React, { useEffect, useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
-import { Primitive } from "react-data-table-component/dist/src/DataTable/types";
 import styled from "styled-components";
 import { textFilter } from "./TextFilter";
+import { Primitive } from "react-data-table-component/dist/DataTable/types";
 
 export type TableHeaders<Data> = readonly (readonly [keyof Data, string])[];
 


### PR DESCRIPTION
Update react-data-table-component 

- [X] Make sure you've verified it works on dev via `npm run dev`
- [X] Make sure you've verified it works on prod via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request!
- [X] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request!
