### PR TITLE
VFB-108: Add job to reset dev database data

### DIFF
--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -1,5 +1,7 @@
-name: Deploy backend
+name: Deploy database
 on:
+  pull_request:
+  workflow_dispatch:
   push:
     paths:
       supabase/migrations/**.sql
@@ -24,3 +26,20 @@ jobs:
         run: npx supabase db push --dry-run
       - name: Apply the migration
         run: npx supabase db push
+
+  reset-dev-database-data:
+    name: Reset data in dev database
+#    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DATABASE_PASSWORD }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_DEV_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Link to the project
+        run: npx supabase link --project-ref $SUPABASE_DEV_PROJECT_ID
+      - name: Reset data in database
+        run: npx supabase db reset --linked

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -28,7 +28,6 @@ jobs:
 
   reset-dev-database-data:
     name: Reset data in dev database
-    needs: deploy-dev-database
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -1,6 +1,5 @@
 name: Deploy database
 on:
-  pull_request:
   workflow_dispatch:
   push:
     paths:
@@ -29,7 +28,8 @@ jobs:
 
   reset-dev-database-data:
     name: Reset data in dev database
-#    if: github.event_name == 'workflow_dispatch'
+    needs: deploy-dev-database
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}


### PR DESCRIPTION
## Overview
I've tried using `pg_dump` and `pg_restore` but the tools didn't quite work as expected - the connection was somehow refused even though the credentials were definitely correct. The somewhat easier / safer option (since Supbase db has a bunch of hidden tables for their housekeeping) would be to use Supabase CLI to reset the dev database, including the seed data. This is easily extendable to the prod pipeline. The only difference for prod is that we want both the "deploy" job and the "reset" job to be manual steps.

## What's changed
- Add a job to reset the dev database data

I have checked that:
- [x] the resetting of the data works with the pipeline (by automatically running it on the PR)
- [x] I have changed the config so that it only runs as a manual step on main 

Once this is merged, I still need to check that we can run this individual job manually without triggering the deploy job. If this works as expected, we can create similar jobs to deploy / reset database on prod. I expect the "reset database on prod" to be a one-off, but it would be good to have that up our sleeves.
