### PR TITLE
VFB-110: Test starting supabase locally

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,10 +1,3 @@
-env:
-  NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
-  NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.SUPABASE_LOCAL_ANON_KEY}}
-  NEXT_PUBLIC_CYPRESS_TEST_USER: admin@example.com
-  NEXT_PUBLIC_CYPRESS_TEST_PASS: admin123
-
 name: Checks
 on:
   pull_request:
@@ -31,6 +24,9 @@ jobs:
   component_tests:
     name: Run component tests
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.SUPABASE_LOCAL_ANON_KEY}}
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
@@ -66,6 +62,12 @@ jobs:
   e2e_tests:
     name: Run end-to-end tests
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+      NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.SUPABASE_LOCAL_ANON_KEY}}
+      NEXT_PUBLIC_CYPRESS_TEST_USER: admin@example.com
+      NEXT_PUBLIC_CYPRESS_TEST_PASS: admin123
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,9 @@
 env:
-  NEXT_PUBLIC_SUPABASE_URL: ${{secrets.NEXT_PUBLIC_SUPABASE_URL}}
-  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY}}
-  NEXT_PUBLIC_CYPRESS_TEST_USER: ${{secrets.NEXT_PUBLIC_CYPRESS_TEST_USER}}
-  NEXT_PUBLIC_CYPRESS_TEST_PASS: ${{secrets.NEXT_PUBLIC_CYPRESS_TEST_PASS}}
+  NEXT_PUBLIC_SUPABASE_URL: http://127.0.0.1:54321
+  NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_LOCAL_SERVICE_ROLE_KEY }}
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.SUPABASE_LOCAL_ANON_KEY}}
+  NEXT_PUBLIC_CYPRESS_TEST_USER: admin@example.com
+  NEXT_PUBLIC_CYPRESS_TEST_PASS: admin123
 
 name: Checks
 on:
@@ -11,21 +12,34 @@ on:
     branches:
       main
 jobs:
-  linting:
-    name: Check linting and run component tests
+  lint:
+    name: Check linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run linting
         run: npm run lint
+
+  component_tests:
+    name: Run component tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Install npm
+        uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Compile
         run: npm run build
@@ -61,6 +75,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Start local Supabase instance
+        run: npx supabase start
+
+      - name: Create users for the local Supabase instance
+        run: npm run dev:create_admin_and_caller_users
+
+      - name: Create bucket for the local Supabase instance
+        run: npm run dev:create_bucket
 
       - name: Compile
         run: npm run build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -70,10 +70,10 @@ jobs:
       NEXT_PUBLIC_CYPRESS_TEST_PASS: admin123
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install npm
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: Install dependencies
         run: npm ci
@@ -113,7 +113,7 @@ jobs:
     name: Verify generated database types
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: supabase/setup-cli@v1
         with:

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "coverage:run_tests": "start-server-and-test coverage:server http://localhost:3200 test:runner",
     "coverage:server": "nyc npm run test:runner_server_dev",
     "coverage:report": "nyc report --reporter html && nyc report --reporter text-summary",
-    "dev:create_admin_user": "tsc supabase/tools/createAdminAndCallerUsers.ts && node supabase/tools/createAdminAndCallerUsers.js",
+    "dev:create_admin_and_caller_users": "tsc supabase/tools/createAdminAndCallerUsers.ts && node supabase/tools/createAdminAndCallerUsers.js",
     "dev:create_bucket": "tsc supabase/tools/createStorage.ts && node supabase/tools/createStorage.js",
-    "dev:reset_supabase": "supabase db reset && npm run dev:create_admin_user && npm run dev:create_bucket",
+    "dev:reset_supabase": "supabase db reset && npm run dev:create_admin_and_caller_users && npm run dev:create_bucket",
     "db:local:generate_types": "supabase gen types typescript --local --schema public > src/databaseTypesFile.ts",
     "db:remote:generate_types": "supabase gen types typescript --schema public > src/databaseTypesFile.ts",
     "db:generate_seed": "npx tsx seed.mts > supabase/seed.sql"


### PR DESCRIPTION
## What's changed
- Add SUPABASE_LOCAL_SERVICE_ROLE_KEY and SUPABASE_LOCAL_ANON_KEY to secrets to be used in the pipeline
- When running the e2e tests in the pipeline, start a local Supabase instance and create necessary users / bucket.
- Modify the e2e tests to target the local Supabase instance
- Split the `Check linting and run component tests` job into `Check linting` and `Run component tests`
