### PR TITLE
VFB-35: parcel modal statuses

### DIFF
--- a/src/app/parcels/EventTable.tsx
+++ b/src/app/parcels/EventTable.tsx
@@ -8,21 +8,18 @@ import TableSurface from "@/components/Tables/TableSurface";
 import { Schema } from "@/databaseUtils";
 
 export interface EventTableRow {
-    eventName: string;
+    event: string;
     timestamp: Date;
-    eventData: string | null;
 }
 
 export const eventsTableHeaderKeysAndLabels: TableHeaders<EventTableRow> = [
-    ["eventName", "Name"],
+    ["event", "Event"],
     ["timestamp", "Timestamp"],
-    ["eventData", "Event Data"]
 ];
 
 const defaultShownHeaders: (keyof EventTableRow)[] = [
-    "eventName",
+    "event",
     "timestamp",
-    "eventData"
 ];
 
 export interface EventTableProps {

--- a/src/app/parcels/EventTable.tsx
+++ b/src/app/parcels/EventTable.tsx
@@ -5,16 +5,16 @@ import Table, { TableHeaders } from "@/components/Tables/Table";
 import TableSurface from "@/components/Tables/TableSurface";
 
 export interface EventTableRow {
-    event: string;
+    eventInfo: string;
     timestamp: Date;
 }
 
 export const eventsTableHeaderKeysAndLabels: TableHeaders<EventTableRow> = [
-    ["event", "Event"],
+    ["eventInfo", "Event"],
     ["timestamp", "Timestamp"],
 ];
 
-const defaultShownHeaders: (keyof EventTableRow)[] = ["event", "timestamp"];
+const defaultShownHeaders: (keyof EventTableRow)[] = ["eventInfo", "timestamp"];
 
 export interface EventTableProps {
     tableData: EventTableRow[];

--- a/src/app/parcels/EventTable.tsx
+++ b/src/app/parcels/EventTable.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import React from "react";
-import Table, {TableHeaders } from "@/components/Tables/Table";
-import styled, { useTheme } from "styled-components";
-import { formatDatetimeAsDate, formatDatetimeAsTime } from "@/app/parcels/getExpandedParcelDetails";
+import Table, { TableHeaders } from "@/components/Tables/Table";
 import TableSurface from "@/components/Tables/TableSurface";
-import { Schema } from "@/databaseUtils";
 
 export interface EventTableRow {
     event: string;
@@ -17,13 +14,10 @@ export const eventsTableHeaderKeysAndLabels: TableHeaders<EventTableRow> = [
     ["timestamp", "Timestamp"],
 ];
 
-const defaultShownHeaders: (keyof EventTableRow)[] = [
-    "event",
-    "timestamp",
-];
+const defaultShownHeaders: (keyof EventTableRow)[] = ["event", "timestamp"];
 
 export interface EventTableProps {
-    tableData: EventTableRow[]
+    tableData: EventTableRow[];
 }
 
 const formatDatetimeAsDatetime = (datetime: Date): string => {
@@ -31,8 +25,6 @@ const formatDatetimeAsDatetime = (datetime: Date): string => {
 };
 
 const EventTable: React.FC<EventTableProps> = (props) => {
-    const theme = useTheme();
-
     const eventsTableColumnDisplayFunctions = {
         timestamp: formatDatetimeAsDatetime,
     };

--- a/src/app/parcels/EventTable.tsx
+++ b/src/app/parcels/EventTable.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import React from "react";
+import Table, {TableHeaders } from "@/components/Tables/Table";
+import styled, { useTheme } from "styled-components";
+import { formatDatetimeAsDate, formatDatetimeAsTime } from "@/app/parcels/getExpandedParcelDetails";
+import TableSurface from "@/components/Tables/TableSurface";
+import { Schema } from "@/databaseUtils";
+
+export interface EventTableRow {
+    eventName: string;
+    timestamp: Date;
+    eventData: string | null;
+}
+
+export const eventsTableHeaderKeysAndLabels: TableHeaders<EventTableRow> = [
+    ["eventName", "Name"],
+    ["timestamp", "Timestamp"],
+    ["eventData", "Event Data"]
+];
+
+const defaultShownHeaders: (keyof EventTableRow)[] = [
+    "eventName",
+    "timestamp",
+    "eventData"
+];
+
+export interface EventTableProps {
+    tableData: EventTableRow[]
+}
+
+const formatDatetimeAsDatetime = (datetime: Date): string => {
+    return datetime.toLocaleString("en-GB");
+};
+
+const EventTable: React.FC<EventTableProps> = (props) => {
+    const theme = useTheme();
+
+    const eventsTableColumnDisplayFunctions = {
+        timestamp: formatDatetimeAsDatetime,
+    };
+
+    return (
+        <>
+            <TableSurface>
+                <Table
+                    data={props.tableData}
+                    headerKeysAndLabels={eventsTableHeaderKeysAndLabels}
+                    columnDisplayFunctions={eventsTableColumnDisplayFunctions}
+                    pagination
+                    defaultShownHeaders={defaultShownHeaders}
+                />
+            </TableSurface>
+        </>
+    );
+};
+
+export default EventTable;

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -13,10 +13,12 @@ const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactEl
     }
     const expandedParcelDetails = await getExpandedParcelDetails(parcelId);
 
-    return (<> 
+    return (
+        <>
             <DataViewer data={expandedParcelDetails.expandedParcelData} />
             <EventTable tableData={expandedParcelDetails.events} />
-        </>)
+        </>
+    );
 };
 
 export default ExpandedParcelDetails;

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import DataViewer from "@/components/DataViewer/DataViewer";
 import getExpandedParcelDetails from "@/app/parcels/getExpandedParcelDetails";
+import EventTable from "./EventTable";
 
 interface Props {
     parcelId: string | null;
@@ -12,7 +13,10 @@ const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactEl
     }
     const expandedParcelDetails = await getExpandedParcelDetails(parcelId);
 
-    return <DataViewer data={expandedParcelDetails} />;
+    return (<> 
+            <DataViewer data={expandedParcelDetails.expandedParcelData} />
+            <EventTable tableData={expandedParcelDetails.events} />
+        </>)
 };
 
 export default ExpandedParcelDetails;

--- a/src/app/parcels/ParcelsPage.cy.tsx
+++ b/src/app/parcels/ParcelsPage.cy.tsx
@@ -12,6 +12,7 @@ import {
     formatDatetimeAsDate,
     formatDatetimeAsTime,
     formatHouseholdFromFamilyDetails,
+    processEventsDetails,
     rawDataToExpandedParcelData,
     RawParcelDetails,
 } from "@/app/parcels/getExpandedParcelDetails";
@@ -278,6 +279,29 @@ describe("Parcels Page", () => {
                     { age: 26, gender: "male" },
                 ])
             ).to.eq("No Children");
+        });
+
+        it("processEventsDetails()", () => {
+            expect(
+                processEventsDetails([
+                    {
+                        event_name: "Event 1",
+                        timestamp: "2023-08-04T13:30:00+00:00",
+                        event_data: "",
+                    },
+                    {
+                        event_name: "Event 2",
+                        timestamp: "2023-06-04T15:30:00+00:00",
+                        event_data: "Message",
+                    },
+                ])
+            ).to.deep.eq([
+                { eventInfo: "Event 1", timestamp: new Date("2023-08-04T13:30:00+00:00") },
+                {
+                    eventInfo: "Event 2 (Message)",
+                    timestamp: new Date("2023-06-04T15:30:00+00:00"),
+                },
+            ]);
         });
     });
 });

--- a/src/app/parcels/ParcelsPage.cy.tsx
+++ b/src/app/parcels/ParcelsPage.cy.tsx
@@ -12,7 +12,7 @@ import {
     formatDatetimeAsDate,
     formatDatetimeAsTime,
     formatHouseholdFromFamilyDetails,
-    rawDataToExpandedParcelDetails,
+    rawDataToExpandedParcelData,
     RawParcelDetails,
 } from "@/app/parcels/getExpandedParcelDetails";
 
@@ -84,6 +84,15 @@ const sampleRawExpandedClientDetails: RawParcelDetails = {
             { age: 24, gender: "other" },
         ],
     },
+
+    events: [
+        { event_name: "Event 1", timestamp: "2023-06-04T13:30:00+00:00", event_data: "" },
+        {
+            event_name: "Event 2",
+            timestamp: "2023-06-04T13:30:00+00:00",
+            event_data: "Something happened",
+        },
+    ],
 };
 
 describe("Parcels Page", () => {
@@ -163,7 +172,7 @@ describe("Parcels Page", () => {
 
     describe("Backend Processing for Expanded Parcel Details", () => {
         it("Fields are set correctly", () => {
-            const expandedClientDetails = rawDataToExpandedParcelDetails(
+            const expandedClientDetails = rawDataToExpandedParcelData(
                 sampleRawExpandedClientDetails
             );
 

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -87,8 +87,8 @@ export interface ExpandedParcelData extends Data {
 }
 
 export interface ExpandedParcelDetails {
-    expandedParcelData: ExpandedParcelData,
-    events: EventTableRow[]
+    expandedParcelData: ExpandedParcelData;
+    events: EventTableRow[];
 }
 
 export const rawDataToExpandedParcelData = (
@@ -199,21 +199,27 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
     return childDetails.join(", ");
 };
 
-const processEventsDetails = ( events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[] ): EventTableRow[] => {
+const processEventsDetails = (
+    events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
+): EventTableRow[] => {
     const eventTableRows: EventTableRow[] = [];
 
     for (const event of events) {
-        eventTableRows.push({event: `${event.event_name}` +
-        (event.event_data ? ` (${event.event_data})` : ""), timestamp: new Date(event.timestamp)});
+        eventTableRows.push({
+            event: `${event.event_name}` + (event.event_data ? ` (${event.event_data})` : ""),
+            timestamp: new Date(event.timestamp),
+        });
     }
 
     return eventTableRows;
-}
+};
 
 const getExpandedParcelDetails = async (parcelId: string): Promise<ExpandedParcelDetails> => {
     const rawParcelDetails = await getRawParcelDetails(parcelId);
-    return {expandedParcelData: rawDataToExpandedParcelData(rawParcelDetails), events: processEventsDetails(rawParcelDetails.events)};
+    return {
+        expandedParcelData: rawDataToExpandedParcelData(rawParcelDetails),
+        events: processEventsDetails(rawParcelDetails.events),
+    };
 };
-
 
 export default getExpandedParcelDetails;

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -2,7 +2,7 @@ import { Schema } from "@/databaseUtils";
 import { Data } from "@/components/DataViewer/DataViewer";
 import supabase from "@/supabaseClient";
 import { DatabaseError } from "@/app/errorClasses";
-
+import { EventTableRow } from "./EventTable";
 export type RawParcelDetails = Awaited<ReturnType<typeof getRawParcelDetails>>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -73,7 +73,7 @@ export const formatDatetimeAsDate = (datetime: Date | string | null): string => 
     return new Date(datetime).toLocaleDateString("en-GB");
 };
 
-export interface ExpandedParcelDetails extends Data {
+export interface ExpandedParcelData extends Data {
     voucherNumber: string;
     fullName: string;
     address: string;
@@ -84,12 +84,16 @@ export interface ExpandedParcelDetails extends Data {
     packingDate: string;
     packingTime: string;
     collection: string;
-    history: string;
 }
 
-export const rawDataToExpandedParcelDetails = (
+export interface ExpandedParcelDetails {
+    expandedParcelData: ExpandedParcelData,
+    events: EventTableRow[]
+}
+
+export const rawDataToExpandedParcelData = (
     rawParcelDetails: RawParcelDetails
-): ExpandedParcelDetails => {
+): ExpandedParcelData => {
     if (rawParcelDetails === null) {
         return {
             voucherNumber: "",
@@ -102,7 +106,6 @@ export const rawDataToExpandedParcelDetails = (
             packingDate: "",
             packingTime: "",
             collection: "",
-            history: ""
         };
     }
 
@@ -119,7 +122,6 @@ export const rawDataToExpandedParcelDetails = (
         packingDate: formatDatetimeAsDate(rawParcelDetails.packing_datetime),
         packingTime: formatDatetimeAsTime(rawParcelDetails.packing_datetime),
         collection: rawParcelDetails.collection_centre?.name ?? "",
-        history: formatHistoryFromEvents(rawParcelDetails.events),
     };
 };
 
@@ -197,24 +199,20 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
     return childDetails.join(", ");
 };
 
-export const formatHistoryFromEvents = (
-    events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
-): string => {
-    const history = [];
+const processEventsDetails = ( events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[] ): EventTableRow[] => {
+    const eventTableRows: EventTableRow[] = [];
 
     for (const event of events) {
-        history.push(
-            `${event.event_name}` +
-            (event.event_data ? ` (${event.event_data})` : "") +
-            ` @ ${formatDatetimeAsDate(event.timestamp)}`
-        );
+        eventTableRows.push({eventName: event.event_name, timestamp: new Date(event.timestamp), eventData: event.event_data});
     }
-    return history.join(", ");
+
+    return eventTableRows;
 }
 
 const getExpandedParcelDetails = async (parcelId: string): Promise<ExpandedParcelDetails> => {
     const rawParcelDetails = await getRawParcelDetails(parcelId);
-    return rawDataToExpandedParcelDetails(rawParcelDetails);
+    return {expandedParcelData: rawDataToExpandedParcelData(rawParcelDetails), events: processEventsDetails(rawParcelDetails.events)};
 };
+
 
 export default getExpandedParcelDetails;

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -33,8 +33,12 @@ export const getRawParcelDetails = async (parcelId: string) => {
                 age,
                 gender
             )
+        ),
+        events:events (
+            event_name,
+            timestamp,
+            event_data
         )
-
     `
         )
         .eq("primary_key", parcelId)
@@ -80,6 +84,7 @@ export interface ExpandedParcelDetails extends Data {
     packingDate: string;
     packingTime: string;
     collection: string;
+    history: string;
 }
 
 export const rawDataToExpandedParcelDetails = (
@@ -97,6 +102,7 @@ export const rawDataToExpandedParcelDetails = (
             packingDate: "",
             packingTime: "",
             collection: "",
+            history: ""
         };
     }
 
@@ -113,6 +119,7 @@ export const rawDataToExpandedParcelDetails = (
         packingDate: formatDatetimeAsDate(rawParcelDetails.packing_datetime),
         packingTime: formatDatetimeAsTime(rawParcelDetails.packing_datetime),
         collection: rawParcelDetails.collection_centre?.name ?? "",
+        history: formatHistoryFromEvents(rawParcelDetails.events),
     };
 };
 
@@ -189,6 +196,21 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
 
     return childDetails.join(", ");
 };
+
+export const formatHistoryFromEvents = (
+    events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
+): string => {
+    const history = [];
+
+    for (const event of events) {
+        history.push(
+            `${event.event_name}` +
+            (event.event_data ? ` (${event.event_data})` : "") +
+            ` @ ${formatDatetimeAsDate(event.timestamp)}`
+        );
+    }
+    return history.join(", ");
+}
 
 const getExpandedParcelDetails = async (parcelId: string): Promise<ExpandedParcelDetails> => {
     const rawParcelDetails = await getRawParcelDetails(parcelId);

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -202,16 +202,10 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
 export const processEventsDetails = (
     events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
 ): EventTableRow[] => {
-    const eventTableRows: EventTableRow[] = [];
-
-    for (const event of events) {
-        eventTableRows.push({
-            eventInfo: `${event.event_name}` + (event.event_data ? ` (${event.event_data})` : ""),
-            timestamp: new Date(event.timestamp),
-        });
-    }
-
-    return eventTableRows;
+    return events.map((event) => ({
+        eventInfo: event.event_name + (event.event_data ? ` (${event.event_data})` : ""),
+        timestamp: new Date(event.timestamp),
+    }));
 };
 
 const getExpandedParcelDetails = async (parcelId: string): Promise<ExpandedParcelDetails> => {

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -199,14 +199,14 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
     return childDetails.join(", ");
 };
 
-const processEventsDetails = (
+export const processEventsDetails = (
     events: Pick<Schema["events"], "event_data" | "event_name" | "timestamp">[]
 ): EventTableRow[] => {
     const eventTableRows: EventTableRow[] = [];
 
     for (const event of events) {
         eventTableRows.push({
-            event: `${event.event_name}` + (event.event_data ? ` (${event.event_data})` : ""),
+            eventInfo: `${event.event_name}` + (event.event_data ? ` (${event.event_data})` : ""),
             timestamp: new Date(event.timestamp),
         });
     }

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -203,7 +203,8 @@ const processEventsDetails = ( events: Pick<Schema["events"], "event_data" | "ev
     const eventTableRows: EventTableRow[] = [];
 
     for (const event of events) {
-        eventTableRows.push({eventName: event.event_name, timestamp: new Date(event.timestamp), eventData: event.event_data});
+        eventTableRows.push({event: `${event.event_name}` +
+        (event.event_data ? ` (${event.event_data})` : ""), timestamp: new Date(event.timestamp)});
     }
 
     return eventTableRows;


### PR DESCRIPTION
## What's changed
Added paginated table of events to the bottom of the parcel details modal. Columns are "event", which displays the event name following by paranthesised event data, if any, and "timestamp", which displays the timestamp in DD/MM/YYYY, HH:MM:SS format.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/5eba12b3-a572-4e07-a4e8-50f3108defbc) | ![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/e7f83098-27f8-42ed-8111-3f771cf22cbe) |

## Checklist
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build && npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
