### PR TITLE
VFB-35: FIX - event ordering by date

### DIFF
--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 import DataViewer from "@/components/DataViewer/DataViewer";
 import getExpandedParcelDetails from "@/app/parcels/getExpandedParcelDetails";
-import EventTable from "./EventTable";
+import EventTable, { EventTableRow } from "./EventTable";
 
 interface Props {
     parcelId: string | null;
 }
+
+const sortByTimestampWithMostRecentFirst = (events: EventTableRow[]): EventTableRow[] => {
+    return events.sort((eventA, eventB) => eventB.timestamp.getTime() - eventA.timestamp.getTime());
+};
 
 const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactElement> => {
     if (!parcelId) {
@@ -17,9 +21,7 @@ const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactEl
         <>
             <DataViewer data={expandedParcelDetails.expandedParcelData} />
             <EventTable
-                tableData={expandedParcelDetails.events.sort(
-                    (eventA, eventB) => eventB.timestamp.getTime() - eventA.timestamp.getTime()
-                )}
+                tableData={sortByTimestampWithMostRecentFirst(expandedParcelDetails.events)}
             />
         </>
     );

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -16,7 +16,7 @@ const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactEl
     return (
         <>
             <DataViewer data={expandedParcelDetails.expandedParcelData} />
-            <EventTable tableData={expandedParcelDetails.events} />
+            <EventTable tableData={expandedParcelDetails.events.sort((eventA, eventB) => eventB.timestamp.getTime() - eventA.timestamp.getTime())} />
         </>
     );
 };

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -16,7 +16,11 @@ const ExpandedParcelDetails = async ({ parcelId }: Props): Promise<React.ReactEl
     return (
         <>
             <DataViewer data={expandedParcelDetails.expandedParcelData} />
-            <EventTable tableData={expandedParcelDetails.events.sort((eventA, eventB) => eventB.timestamp.getTime() - eventA.timestamp.getTime())} />
+            <EventTable
+                tableData={expandedParcelDetails.events.sort(
+                    (eventA, eventB) => eventB.timestamp.getTime() - eventA.timestamp.getTime()
+                )}
+            />
         </>
     );
 };

--- a/src/app/parcels/ExpandedParcelDetailsFallback.tsx
+++ b/src/app/parcels/ExpandedParcelDetailsFallback.tsx
@@ -18,7 +18,6 @@ const clientDetailFields = [
 const ExpandedParcelDetailsFallback: React.FC<{}> = () => {
     return (
         <>
-            {" "}
             <DataViewerFallback fieldPlaceholders={clientDetailFields} />;
             <EventTable tableData={[]} />
         </>

--- a/src/app/parcels/ExpandedParcelDetailsFallback.tsx
+++ b/src/app/parcels/ExpandedParcelDetailsFallback.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import DataViewerFallback from "@/components/DataViewer/DataViewerFallback";
+import EventTable from "./EventTable";
 
 const clientDetailFields = [
     "VOUCHER #",
@@ -15,7 +16,13 @@ const clientDetailFields = [
 ];
 
 const ExpandedParcelDetailsFallback: React.FC<{}> = () => {
-    return <DataViewerFallback fieldPlaceholders={clientDetailFields} />;
+    return (
+        <>
+            {" "}
+            <DataViewerFallback fieldPlaceholders={clientDetailFields} />;
+            <EventTable tableData={[]} />
+        </>
+    );
 };
 
 export default ExpandedParcelDetailsFallback;


### PR DESCRIPTION
## What's changed
This PR is a fix to VFB-35-Parcel-modal-statuses. 
Fixed event ordering to be by date/time, with most recent at the top. Also, added an empty event table to the fallback option for the parcel details modal.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/ff02f3d8-d010-48c1-8eaf-64c7e0f38707) | ![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/1da1e7b9-e256-4b30-87e4-d76413aa81ed) |

## Checklist
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
