### PR TITLE
VFB-99: Add eslint rules to disallow array index as key

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,7 +37,9 @@
     "@typescript-eslint/no-unused-vars": ["error", {
       "varsIgnorePattern": "^_",
       "argsIgnorePattern": "^_"
-    }]
+    }],
+    "react/jsx-key": "error",
+    "react/no-array-index-key": "error"
   },
   "ignorePatterns": ["databaseTypesFile.ts"]
 }

--- a/src/app/admin/AdminPage.tsx
+++ b/src/app/admin/AdminPage.tsx
@@ -64,9 +64,9 @@ const AdminPage: React.FC<Props> = (props) => {
 
     return (
         <>
-            {adminPanels.map(({ panelTitle, panelIcon, panelContent }, index) => {
+            {adminPanels.map(({ panelTitle, panelIcon, panelContent }) => {
                 return (
-                    <TableSurface key={index}>
+                    <TableSurface key={panelTitle}>
                         <Accordion elevation={0}>
                             <AccordionSummary expandIcon={<ExpandMore />}>
                                 <NoSSR>

--- a/src/app/admin/common/passwordConfig.tsx
+++ b/src/app/admin/common/passwordConfig.tsx
@@ -27,8 +27,8 @@ export const getPasswordRuleList = (passwordRules: PasswordRule[]): ReactElement
         <>
             Password must meet the following criteria:
             <ul>
-                {passwordRules.map(({ message }, index) => (
-                    <li key={index}>{message}</li>
+                {passwordRules.map(({ message }) => (
+                    <li key={message}>{message}</li>
                 ))}
             </ul>
         </>

--- a/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
+++ b/src/app/admin/createCollectionCentre/CreateCollectionCentreForm.tsx
@@ -72,7 +72,7 @@ const CreateCollectionCentreForm: React.FC<{}> = () => {
             <StyledForm>
                 {formSections.map((Card, index) => (
                     <Card
-                        key={index}
+                        key={index} // eslint-disable-line react/no-array-index-key
                         fields={fields}
                         fieldSetter={fieldSetter}
                         formErrors={formErrors}

--- a/src/app/admin/createUser/CreateUserForm.tsx
+++ b/src/app/admin/createUser/CreateUserForm.tsx
@@ -81,7 +81,7 @@ const CreateUserForm: React.FC<{}> = () => {
                 {formSections.map((Card, index) => {
                     return (
                         <Card
-                            key={index}
+                            key={index} // eslint-disable-line react/no-array-index-key
                             fields={fields}
                             fieldSetter={fieldSetter}
                             formErrors={formErrors}

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -147,7 +147,7 @@ const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editMod
                 {formSections.map((Card, index) => {
                     return (
                         <Card
-                            key={index}
+                            key={index} // eslint-disable-line react/no-array-index-key
                             formErrors={formErrors}
                             errorSetter={errorSetter}
                             fieldSetter={fieldSetter}

--- a/src/app/clients/form/formSections/NumberChildrenCard.tsx
+++ b/src/app/clients/form/formSections/NumberChildrenCard.tsx
@@ -66,7 +66,7 @@ const NumberChildrenCard: React.FC<CardProps> = ({
                 />
                 {fields.children.map((child: Person, index: number) => {
                     return (
-                        <StyledCard key={index}>
+                        <StyledCard key={child.primaryKey}>
                             <FormText>Child {index + 1}</FormText>
                             <DropdownListInput
                                 labelsAndValues={[

--- a/src/app/parcels/ActionBar/ActionsModal.tsx
+++ b/src/app/parcels/ActionBar/ActionsModal.tsx
@@ -192,9 +192,9 @@ const ActionsModal: React.FC<ActionsModalProps> = (props) => {
                                 <Heading>
                                     {props.data.length === 1 ? "Parcel" : "Parcels"} selected:
                                 </Heading>
-                                {props.data.slice(0, maxParcelsToShow).map((parcel, index) => {
+                                {props.data.slice(0, maxParcelsToShow).map((parcel) => {
                                     return (
-                                        <ListItem key={index}>
+                                        <ListItem key={parcel.primaryKey}>
                                             {parcel.addressPostcode}
                                             {parcel.fullName && ` - ${parcel.fullName}`}
                                             {parcel.collectionDatetime &&

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -141,9 +141,9 @@ const Statuses: React.FC<Props> = ({
                 <MenuList id="status-menu">
                     {statuses
                         .filter((status) => !nonMenuStatuses.includes(status))
-                        .map((status, index) => {
+                        .map((status) => {
                             return (
-                                <MenuItem key={index} onClick={onMenuItemClick(status)}>
+                                <MenuItem key={status} onClick={onMenuItemClick(status)}>
                                     {status}
                                 </MenuItem>
                             );

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -73,9 +73,9 @@ const StatusesBarModal: React.FC<StatusesBarModalProps> = (props) => {
                     <TimePicker value={date} onChange={onTimeChange} disableFuture />
                 </Row>
                 Applying To:
-                {props.data.map((parcel, index) => {
+                {props.data.map((parcel) => {
                     return (
-                        <StatusText key={index}>
+                        <StatusText key={parcel.primaryKey}>
                             {parcel.addressPostcode}
                             {parcel.fullName && ` - ${parcel.fullName}`}
                             {parcel.collectionDatetime &&

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -185,7 +185,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
                 {formSections.map((Card, index) => {
                     return (
                         <Card
-                            key={index}
+                            key={index} // eslint-disable-line react/no-array-index-key
                             formErrors={formErrors}
                             errorSetter={errorSetter}
                             fieldSetter={fieldSetter}

--- a/src/app/themes.cy.tsx
+++ b/src/app/themes.cy.tsx
@@ -50,7 +50,7 @@ const GenerateForegroundWithBackground: React.FC<{ theme: DefaultTheme }> = (pro
         <StyleManager>
             {singleColourThemes.map((theme, index) => (
                 <ForegroundWithBackground
-                    key={index}
+                    key={index} // eslint-disable-line react/no-array-index-key
                     background={theme.background}
                     foreground={theme.foreground}
                     largeForeground={theme.largeForeground}
@@ -59,7 +59,7 @@ const GenerateForegroundWithBackground: React.FC<{ theme: DefaultTheme }> = (pro
             {gradientThemes.map((theme) =>
                 theme.background.map((background, index) => (
                     <ForegroundWithBackground
-                        key={index + singleColourThemes.length}
+                        key={index + singleColourThemes.length} // eslint-disable-line react/no-array-index-key
                         background={background}
                         foreground={theme.foreground[index]}
                         largeForeground={theme.largeForeground[index]}

--- a/src/components/DataInput/DropdownListInput.tsx
+++ b/src/components/DataInput/DropdownListInput.tsx
@@ -19,9 +19,9 @@ const DropdownListInput: React.FC<Props> = (props) => {
                 label={props.listTitle}
                 onChange={props.onChange}
             >
-                {props.labelsAndValues.map(([label, value], index) => {
+                {props.labelsAndValues.map(([label, value]) => {
                     return (
-                        <MenuItem key={index} value={value}>
+                        <MenuItem key={value} value={value}>
                             {label}
                         </MenuItem>
                     );

--- a/src/components/DataInput/RadioGroupInput.tsx
+++ b/src/components/DataInput/RadioGroupInput.tsx
@@ -22,10 +22,10 @@ const RadioGroupInput: React.FC<Props> = (props) => {
                 defaultValue={props.defaultValue}
                 value={props.value}
             >
-                {props.labelsAndValues.map(([label, value], index) => {
+                {props.labelsAndValues.map(([label, value]) => {
                     return (
                         <FormControlLabel
-                            key={index}
+                            key={value}
                             label={label}
                             value={value}
                             control={<Radio />}

--- a/src/components/DataViewer/DataViewerFallback.tsx
+++ b/src/components/DataViewer/DataViewerFallback.tsx
@@ -30,9 +30,9 @@ interface Props {
 const DataViewerFallback: React.FC<Props> = ({ fieldPlaceholders = defaultFieldPlaceholders }) => {
     return (
         <DataViewerContainer>
-            {fieldPlaceholders.map((placeholder, index) => {
+            {fieldPlaceholders.map((placeholder) => {
                 return (
-                    <DataViewerItem key={index}>
+                    <DataViewerItem key={placeholder}>
                         <SkeletonKey variant="text">{placeholder}</SkeletonKey>
                         <SkeletonValue variant="text" width={200} />
                     </DataViewerItem>

--- a/src/pdf/DayOverview/DayOverviewPdf.tsx
+++ b/src/pdf/DayOverview/DayOverviewPdf.tsx
@@ -151,7 +151,7 @@ const DayOverviewContent: React.FC<DayOverviewContentProps> = ({ date, location,
             <View style={{ borderLeft: "1 solid black" }}>
                 <DayOverviewHeader />
                 {data.map((datum, index) => (
-                    <DayOverviewRow key={index} row={datum} />
+                    <DayOverviewRow key={index} row={datum} /> // eslint-disable-line react/no-array-index-key
                 ))}
             </View>
         </>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -138,6 +138,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
 
     const table = data.tableData.map((rowData, index) => {
         return (
+            // eslint-disable-next-line react/no-array-index-key
             <View key={index} style={[styles.tableRow, styles.flexRow]} wrap={false}>
                 <View style={[styles.tableColumn, styles.nameColumnWidth]}>
                     <Text>{rowData.name}</Text>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -148,7 +148,7 @@ const ShippingLabelsPdf: React.FC<ShippingLabelsPdfProps> = ({ data }) => {
                 [...Array(data.label_quantity)].map((value: undefined, index: number) => {
                     return (
                         <LabelCard
-                            key={index}
+                            key={index} // eslint-disable-line react/no-array-index-key
                             data={data}
                             index={index}
                             quantity={data.label_quantity}

--- a/src/pdf/ShoppingList/ShoppingListPdf.tsx
+++ b/src/pdf/ShoppingList/ShoppingListPdf.tsx
@@ -148,7 +148,7 @@ const DisplayItemsList: React.FC<DisplayItemsListProps> = ({ itemsList }) => {
     return (
         <View>
             {itemsList.map((item, index) => (
-                <ItemToRow {...item} key={index} />
+                <ItemToRow {...item} key={index} /> // eslint-disable-line react/no-array-index-key
             ))}
         </View>
     );
@@ -157,8 +157,8 @@ const DisplayItemsList: React.FC<DisplayItemsListProps> = ({ itemsList }) => {
 const DisplayAsBlock: React.FC<BlockProps> = (data: BlockProps) => {
     return (
         <View style={styles.infoCell}>
-            {Object.entries(data).map(([propKey, propValue], index) => (
-                <OneLine key={index} header={formatCamelCaseKey(propKey)} value={propValue} />
+            {Object.entries(data).map(([propKey, propValue]) => (
+                <OneLine key={propKey} header={formatCamelCaseKey(propKey)} value={propValue} />
             ))}
         </View>
     );
@@ -245,7 +245,7 @@ const ShoppingListPdf: React.FC<ShoppingListPDFProps> = ({ data }) => {
     return (
         <Document>
             {data.lists.map((parcelData: ShoppingListPdfData, index: number) => {
-                return <SingleShoppingList key={index} parcelData={parcelData} />;
+                return <SingleShoppingList key={index} parcelData={parcelData} />; // eslint-disable-line react/no-array-index-key
             })}
         </Document>
     );


### PR DESCRIPTION
## What's changed
- Add eslint rules to disallow array index as key
- If using array index is reasonable - each item could potentially contain the same info, and we don't expect the data to change on the page - then add `eslint-ignore`. This was particularly the case for some of hte PDF elements where none of the fields are inherently unique.

## Checklist
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [ ] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
