### PR TITLE
NONE: Verify generated database types in the pipeline only when necessary

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -108,25 +108,3 @@ jobs:
           name: videos
           path: cypress/videos
           retention-days: 1
-
-  verify-database-types:
-    name: Verify generated database types
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: supabase/setup-cli@v1
-        with:
-          version: 1.145.4
-
-      - name: Start Supabase local development setup
-        run: supabase start
-
-      - name: Verify generated types are checked in
-        run: |
-          supabase gen types typescript --local --schema public > src/databaseTypesFile.ts
-          if ! git diff --ignore-space-at-eol --exit-code --quiet src/databaseTypesFile.ts; then
-            echo "Detected uncommitted changes after build. See status below:"
-            git diff
-            exit 1
-          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,8 @@
 name: Checks
 on:
   pull_request:
+    paths-ignore:
+      - .github/**
   push:
     branches:
       main

--- a/.github/workflows/verify-generated-database-types.yml
+++ b/.github/workflows/verify-generated-database-types.yml
@@ -1,0 +1,35 @@
+name: Verify generated database types
+on:
+  pull_request:
+    paths:
+      - supabase/migrations/**.sql
+      - src/databaseTypesFile.ts
+  push:
+    paths:
+      - supabase/migrations/**.sql
+      - src/databaseTypesFile.ts
+    branches:
+      main
+
+jobs:
+  verify-database-types:
+    name: Verify generated database types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: 1.145.4
+
+      - name: Start Supabase local development setup
+        run: supabase start
+
+      - name: Verify generated types are checked in
+        run: |
+          supabase gen types typescript --local --schema public > src/databaseTypesFile.ts
+          if ! git diff --ignore-space-at-eol --exit-code --quiet src/databaseTypesFile.ts; then
+            echo "Detected uncommitted changes after build. See status below:"
+            git diff
+            exit 1
+          fi


### PR DESCRIPTION
## What's changed
- Verify generated database types in the pipeline only when necessary
- Ignore changes in .github folder for `checks` workflow