### PR TITLE
Vfb 40 sort by status

### DIFF
--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -11,7 +11,6 @@ import StatusesBarModal from "@/app/parcels/ActionBar/StatusesModal";
 import { DatabaseError } from "@/app/errorClasses";
 
 export const statusNamesInWorkflowOrder = [
-    "-",
     "No Status",
     "Request Denied",
     "Pending More Info",

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -10,27 +10,29 @@ import { ParcelsTableRow } from "@/app/parcels/getParcelsTableData";
 import StatusesBarModal from "@/app/parcels/ActionBar/StatusesModal";
 import { DatabaseError } from "@/app/errorClasses";
 
-const statuses = [
+export const statusNamesInWorkflowOrder = [
+    "-",
     "No Status",
     "Request Denied",
     "Pending More Info",
     "Called and Confirmed",
     "Called and No Response",
+    "Shopping List Downloaded",
     "Ready to Dispatch",
     "Received by Centre",
     "Collection Failed",
     "Parcel Collected",
+    "Shipping Labels Downloaded",
+    "Out for Delivery",
     "Delivered",
     "Delivery Failed",
     "Delivery Cancelled",
     "Fulfilled with Trussell Trust",
-    "Shipping Labels Downloaded",
-    "Shopping List Downloaded",
-    "Out for Delivery",
     "Request Deleted",
-] as const;
+];
 
-export type statusType = (typeof statuses)[number];
+
+export type statusType = (typeof statusNamesInWorkflowOrder)[number];
 
 const nonMenuStatuses: statusType[] = [
     "Shipping Labels Downloaded",
@@ -139,7 +141,7 @@ const Statuses: React.FC<Props> = ({
                 anchorEl={statusAnchorElement}
             >
                 <MenuList id="status-menu">
-                    {statuses
+                    {statusNamesInWorkflowOrder
                         .filter((status) => !nonMenuStatuses.includes(status))
                         .map((status, index) => {
                             return (

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -31,7 +31,6 @@ export const statusNamesInWorkflowOrder = [
     "Request Deleted",
 ];
 
-
 export type statusType = (typeof statusNamesInWorkflowOrder)[number];
 
 const nonMenuStatuses: statusType[] = [

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { Suspense, useEffect, useState } from "react";
-import Table, { Row, TableHeaders } from "@/components/Tables/Table";
+import Table, { Row, SortOptions, TableHeaders } from "@/components/Tables/Table";
 import styled, { useTheme } from "styled-components";
 import {
     ParcelsTableRow,
@@ -54,6 +54,47 @@ const defaultShownHeaders: (keyof ParcelsTableRow)[] = [
     "packingDatetime",
     "packingTimeLabel",
     "lastStatus",
+];
+
+const statusNamesInWorkflowOrder = [  "-", "No Status",
+"Request Denied",
+"Pending More Info",
+"Called and Confirmed",
+"Called and No Response",
+"Shopping List Downloaded",
+"Ready to Dispatch",
+"Received by Centre",
+"Collection Failed",
+"Parcel Collected",
+"Shipping Labels Downloaded",
+"Out for Delivery",
+"Delivered",
+"Delivery Failed",
+"Delivery Cancelled",
+"Fulfilled with Trussell Trust",
+"Request Deleted"]
+
+const sortStatusByWorkflowOrder = (statusA: ParcelsTableRow["lastStatus"], statusB: ParcelsTableRow["lastStatus"]) => {
+    const indexA = statusNamesInWorkflowOrder.indexOf(statusA?.name ?? "-");
+    const indexB = statusNamesInWorkflowOrder.indexOf(statusB?.name ?? "-");
+    if (indexA > indexB) {
+        return 1;
+    } else if (indexB > indexA) {
+        return -1;
+    } return 0;
+
+}
+
+const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, any>)[] = [
+    "fullName",
+    "familyCategory",
+    "addressPostcode",
+    "phoneNumber",
+    "voucherNumber",
+    "deliveryCollection",
+    "packingDatetime",
+    "packingTimeLabel",
+    {key: "lastStatus", sortFunction: sortStatusByWorkflowOrder}
 ];
 
 const toggleableHeaders: (keyof ParcelsTableRow)[] = [
@@ -316,7 +357,7 @@ const ParcelsPage: React.FC<{}> = () => {
                             checkboxes
                             onRowSelection={setSelected}
                             pagination
-                            sortable={toggleableHeaders}
+                            sortable={sortable}
                             defaultShownHeaders={defaultShownHeaders}
                             toggleableHeaders={toggleableHeaders}
                             filters={[

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -61,17 +61,15 @@ const sortStatusByWorkflowOrder = (
     statusA: ParcelsTableRow["lastStatus"],
     statusB: ParcelsTableRow["lastStatus"]
 ): number => {
-    const indexA = statusNamesInWorkflowOrder.indexOf(statusA?.name ?? "-");
-    const indexB = statusNamesInWorkflowOrder.indexOf(statusB?.name ?? "-");
-    if (indexA > indexB) {
-        return -1;
-    } else if (indexB > indexA) {
-        return 1;
+    const indexA = statusNamesInWorkflowOrder.indexOf(statusA?.name ?? "");
+    const indexB = statusNamesInWorkflowOrder.indexOf(statusB?.name ?? "");
+    if (indexA === indexB) {
+        return 0;
     }
-    return 0;
+    return indexA < indexB ? 1 : -1;
 };
 
-const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, "lastStatus">)[] = [
+const sortableColumns: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, "lastStatus">)[] = [
     "fullName",
     "familyCategory",
     "addressPostcode",
@@ -343,7 +341,7 @@ const ParcelsPage: React.FC<{}> = () => {
                             checkboxes
                             onRowSelection={setSelected}
                             pagination
-                            sortable={sortable}
+                            sortable={sortableColumns}
                             defaultShownHeaders={defaultShownHeaders}
                             toggleableHeaders={toggleableHeaders}
                             filters={[

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -56,34 +56,40 @@ const defaultShownHeaders: (keyof ParcelsTableRow)[] = [
     "lastStatus",
 ];
 
-const statusNamesInWorkflowOrder = [  "-", "No Status",
-"Request Denied",
-"Pending More Info",
-"Called and Confirmed",
-"Called and No Response",
-"Shopping List Downloaded",
-"Ready to Dispatch",
-"Received by Centre",
-"Collection Failed",
-"Parcel Collected",
-"Shipping Labels Downloaded",
-"Out for Delivery",
-"Delivered",
-"Delivery Failed",
-"Delivery Cancelled",
-"Fulfilled with Trussell Trust",
-"Request Deleted"]
+const statusNamesInWorkflowOrder = [
+    "-",
+    "No Status",
+    "Request Denied",
+    "Pending More Info",
+    "Called and Confirmed",
+    "Called and No Response",
+    "Shopping List Downloaded",
+    "Ready to Dispatch",
+    "Received by Centre",
+    "Collection Failed",
+    "Parcel Collected",
+    "Shipping Labels Downloaded",
+    "Out for Delivery",
+    "Delivered",
+    "Delivery Failed",
+    "Delivery Cancelled",
+    "Fulfilled with Trussell Trust",
+    "Request Deleted",
+];
 
-const sortStatusByWorkflowOrder = (statusA: ParcelsTableRow["lastStatus"], statusB: ParcelsTableRow["lastStatus"]) => {
+const sortStatusByWorkflowOrder = (
+    statusA: ParcelsTableRow["lastStatus"],
+    statusB: ParcelsTableRow["lastStatus"]
+): number => {
     const indexA = statusNamesInWorkflowOrder.indexOf(statusA?.name ?? "-");
     const indexB = statusNamesInWorkflowOrder.indexOf(statusB?.name ?? "-");
     if (indexA > indexB) {
-        return 1;
-    } else if (indexB > indexA) {
         return -1;
-    } return 0;
-
-}
+    } else if (indexB > indexA) {
+        return 1;
+    }
+    return 0;
+};
 
 const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, any>)[] = [
     "fullName",
@@ -94,7 +100,7 @@ const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, any>)[] = 
     "deliveryCollection",
     "packingDatetime",
     "packingTimeLabel",
-    {key: "lastStatus", sortFunction: sortStatusByWorkflowOrder}
+    { key: "lastStatus", sortFunction: sortStatusByWorkflowOrder },
 ];
 
 const toggleableHeaders: (keyof ParcelsTableRow)[] = [

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -91,7 +91,7 @@ const sortStatusByWorkflowOrder = (
     return 0;
 };
 
-const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, any>)[] = [
+const sortable: (keyof ParcelsTableRow | SortOptions<ParcelsTableRow, "lastStatus">)[] = [
     "fullName",
     "familyCategory",
     "addressPostcode",

--- a/src/app/parcels/ParcelsPage.tsx
+++ b/src/app/parcels/ParcelsPage.tsx
@@ -32,6 +32,7 @@ import {
 import dayjs from "dayjs";
 import { checklistFilter } from "@/components/Tables/ChecklistFilter";
 import { Filter } from "@/components/Tables/Filters";
+import { statusNamesInWorkflowOrder } from "./ActionBar/Statuses";
 
 export const parcelTableHeaderKeysAndLabels: TableHeaders<ParcelsTableRow> = [
     ["iconsColumn", "Flags"],
@@ -54,27 +55,6 @@ const defaultShownHeaders: (keyof ParcelsTableRow)[] = [
     "packingDatetime",
     "packingTimeLabel",
     "lastStatus",
-];
-
-const statusNamesInWorkflowOrder = [
-    "-",
-    "No Status",
-    "Request Denied",
-    "Pending More Info",
-    "Called and Confirmed",
-    "Called and No Response",
-    "Shopping List Downloaded",
-    "Ready to Dispatch",
-    "Received by Centre",
-    "Collection Failed",
-    "Parcel Collected",
-    "Shipping Labels Downloaded",
-    "Out for Delivery",
-    "Delivered",
-    "Delivery Failed",
-    "Delivery Cancelled",
-    "Fulfilled with Trussell Trust",
-    "Request Deleted",
 ];
 
 const sortStatusByWorkflowOrder = (


### PR DESCRIPTION
## What's changed
Sorting by last status in the parcel table results in rows ordered to be consistent with workflow - eg packed => ready to dispatch => delivered. Previously, sorting by last status had no effect except to revert any other sorts.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/fd2dbc28-af45-4b3f-b2ad-72feb52b3531)![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/77a80011-656b-4aca-843e-34926fc05ccc)|![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/3b1f6352-947e-40b7-b5e7-7998e737bd21)![image](https://github.com/VauxhallFoodbank/vauxhall-foodbank/assets/138508884/c8727cb8-9d76-41a7-9160-3dbb570848a3)|

## Checklist
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
  - Will also be automatically checked on pull request
- [x] Make sure you've tested via `npm run test`
  - Will also be automatically checked on pull request
