### PR TITLE
VFB-99: Add migration and reset steps for prod

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,7 @@ on:
       - .github/**
   push:
     branches:
+      dev
       main
 jobs:
   lint:

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -1,6 +1,5 @@
 name: Deploy database
 on:
-  workflow_dispatch:
   push:
     paths:
       supabase/migrations/**.sql
@@ -27,25 +26,6 @@ jobs:
       - name: Apply the migration
         run: npx supabase db push
 
-  deploy-prod-database:
-    name: Deploy to prod database
-    environment: prod
-    runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-
-      - name: Link to the project
-        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
-      - name: Dry run the migration
-        run: npx supabase db push --dry-run
-      - name: Apply the migration
-        run: npx supabase db push
-
   reset-dev-database-data:
     name: Reset data in dev database
     if: github.event_name == 'workflow_dispatch'
@@ -61,23 +41,5 @@ jobs:
 
       - name: Link to the project
         run: npx supabase link --project-ref $SUPABASE_DEV_PROJECT_ID
-      - name: Reset data in database
-        run: npx supabase db reset --linked
-
-  reset-prod-database-data:
-    name: Reset data in prod database
-    if: github.event_name == 'workflow_dispatch'
-    environment: prod
-    runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-
-      - name: Link to the project
-        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
       - name: Reset data in database
         run: npx supabase db reset --linked

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   deploy-dev-database:
     name: Deploy to dev database
+    environment: dev
     runs-on: ubuntu-latest
     env:
       SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
@@ -48,6 +49,7 @@ jobs:
   reset-dev-database-data:
     name: Reset data in dev database
     if: github.event_name == 'workflow_dispatch'
+    environment: dev
     runs-on: ubuntu-latest
     env:
       SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}

--- a/.github/workflows/deploy-database.yml
+++ b/.github/workflows/deploy-database.yml
@@ -26,6 +26,25 @@ jobs:
       - name: Apply the migration
         run: npx supabase db push
 
+  deploy-prod-database:
+    name: Deploy to prod database
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Link to the project
+        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
+      - name: Dry run the migration
+        run: npx supabase db push --dry-run
+      - name: Apply the migration
+        run: npx supabase db push
+
   reset-dev-database-data:
     name: Reset data in dev database
     if: github.event_name == 'workflow_dispatch'
@@ -40,5 +59,23 @@ jobs:
 
       - name: Link to the project
         run: npx supabase link --project-ref $SUPABASE_DEV_PROJECT_ID
+      - name: Reset data in database
+        run: npx supabase db reset --linked
+
+  reset-prod-database-data:
+    name: Reset data in prod database
+    if: github.event_name == 'workflow_dispatch'
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Link to the project
+        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
       - name: Reset data in database
         run: npx supabase db reset --linked

--- a/.github/workflows/deploy-dev-database.yml
+++ b/.github/workflows/deploy-dev-database.yml
@@ -5,7 +5,7 @@ on:
     paths:
       supabase/migrations/**.sql
     branches:
-      main
+      dev
 
 env:
   SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}

--- a/.github/workflows/deploy-dev-database.yml
+++ b/.github/workflows/deploy-dev-database.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   deploy-dev-database:
-    name: Deploy to dev database
+    name: Deploy dev database
     environment: dev
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-dev-database.yml
+++ b/.github/workflows/deploy-dev-database.yml
@@ -1,20 +1,22 @@
 name: Deploy database
 on:
+  workflow_dispatch:
   push:
     paths:
       supabase/migrations/**.sql
     branches:
       main
 
+env:
+  SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
+  SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DATABASE_PASSWORD }}
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_DEV_ACCESS_TOKEN }}
+
 jobs:
   deploy-dev-database:
     name: Deploy to dev database
     environment: dev
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_DEV_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -31,10 +33,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     environment: dev
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_DEV_PROJECT_ID: ${{ secrets.SUPABASE_DEV_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DEV_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_DEV_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-dev-database.yml
+++ b/.github/workflows/deploy-dev-database.yml
@@ -1,4 +1,4 @@
-name: Deploy database
+name: Deploy dev database
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   deploy-prod-database:
-    name: Deploy to prod database
+    name: Deploy prod database
     environment: prod
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -2,7 +2,7 @@ name: Deploy prod database
 on:
   push:
     branches:
-      prod
+      main
 
 env:
   SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -1,4 +1,4 @@
-name: Deploy database
+name: Deploy prod database
 on:
   push:
     branches:

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -4,15 +4,16 @@ on:
     branches:
       prod
 
+env:
+  SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
+  SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
+
 jobs:
   deploy-prod-database:
     name: Deploy to prod database
     environment: prod
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -29,10 +30,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     environment: prod
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-prod-database.yml
+++ b/.github/workflows/deploy-prod-database.yml
@@ -1,0 +1,43 @@
+name: Deploy database
+on:
+  push:
+    branches:
+      prod
+
+jobs:
+  deploy-prod-database:
+    name: Deploy to prod database
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Link to the project
+        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
+      - name: Dry run the migration
+        run: npx supabase db push --dry-run
+      - name: Apply the migration
+        run: npx supabase db push
+
+  reset-prod-database-data:
+    name: Reset data in prod database
+    if: github.event_name == 'workflow_dispatch'
+    environment: prod
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_PROD_PROJECT_ID: ${{ secrets.SUPABASE_PROD_PROJECT_ID }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PROD_DATABASE_PASSWORD }}
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_PROD_ACCESS_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
+      - name: Link to the project
+        run: npx supabase link --project-ref $SUPABASE_PROD_PROJECT_ID
+      - name: Reset data in database
+        run: npx supabase db reset --linked

--- a/.github/workflows/verify-generated-database-types.yml
+++ b/.github/workflows/verify-generated-database-types.yml
@@ -9,6 +9,7 @@ on:
       - supabase/migrations/**.sql
       - src/databaseTypesFile.ts
     branches:
+      dev
       main
 
 jobs:


### PR DESCRIPTION
## What's changed
- Add migration and reset steps for prod
  - This is triggered by pushes to the main branch
- We should now target the `dev` branch when creating pull requests. When we're ready to promote the recent changes to prod, we can move the `main` branch up to the desired commit (or the latest `dev` commit), and that deploys the website and triggers the migration step.
- Add `prod` and `dev` GitHub environments. Workflow jobs for `prod` require approval from myself or @stonelink (config is found [here](https://github.com/VauxhallFoodbank/vauxhall-foodbank/settings/environments))
