### PR TITLE
WIP VFB-111: Add step to deploy prod website

### DIFF
--- a/.github/workflows/deploy-prod-website.yml
+++ b/.github/workflows/deploy-prod-website.yml
@@ -1,0 +1,18 @@
+name: Set the production branch to current commit to trigger prod website deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  set-prod-branch:
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Set production branch to current commit
+        run: |
+          git checkout production
+          git reset --hard ${{ github.sha }}
+          git push --force origin production

--- a/.github/workflows/deploy-prod-website.yml
+++ b/.github/workflows/deploy-prod-website.yml
@@ -1,7 +1,8 @@
 name: Set the production branch to current commit to trigger prod website deployment
 
 on:
-  workflow_dispatch:
+#  workflow_dispatch:
+  pull_request:
 
 jobs:
   set-prod-branch:

--- a/.github/workflows/deploy-prod-website.yml
+++ b/.github/workflows/deploy-prod-website.yml
@@ -11,9 +11,12 @@ jobs:
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
+#        with:
+#          ref: prod
 
       - name: Set production branch to current commit
         run: |
-          git switch prod
+          git fetch
+          git checkout prod
           git reset --hard ${{ github.sha }}
           git push --force origin prod

--- a/.github/workflows/deploy-prod-website.yml
+++ b/.github/workflows/deploy-prod-website.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   set-prod-branch:
     runs-on: ubuntu-latest
-    environment: prod
+#    environment: prod
     steps:
       - name: Checkout this repo
         uses: actions/checkout@v4
 
       - name: Set production branch to current commit
         run: |
-          git checkout production
+          git switch prod
           git reset --hard ${{ github.sha }}
-          git push --force origin production
+          git push --force origin prod


### PR DESCRIPTION
## What's changed
This manual step should trigger two things:
- the automatic deployment of the website with Amplify (the Amplify settings have been edited so that it watches changes in the `prod` branch)
- the `Deploy prod database` workflow (see #133)