### PR TITLE
#185: Add column to driver overview for number of labels per parcel

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -50,7 +50,7 @@ const DriverOverviewInput: React.FC<DriverOverviewInputProps> = ({
 };
 
 const getPdfErrorMessage = (error: DriverOverviewError): string => {
-    let errorMessage: string = "";
+    let errorMessage: string;
     switch (error.type) {
         case "parcelFetchFailed":
             errorMessage = "Failed to fetch parcel data.";

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -50,7 +50,7 @@ const DriverOverviewInput: React.FC<DriverOverviewInputProps> = ({
 };
 
 const getPdfErrorMessage = (error: DriverOverviewError): string => {
-    let errorMessage: string;
+    let errorMessage: string = "";
     switch (error.type) {
         case "parcelFetchFailed":
             errorMessage = "Failed to fetch parcel data.";

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -114,10 +114,10 @@ const styles = StyleSheet.create({
         width: "20%",
     },
     instructionsColumnWidth: {
-        width: "25%",
+        width: "20%",
     },
     numberOfLabelsColumnWidth: {
-        width: "15%",
+        width: "20%",
     },
 });
 

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -16,7 +16,7 @@ export interface DriverOverviewTableData {
     contact?: string;
     packingDate: string | null;
     instructions?: string;
-    numberOfLabels?: number | null;
+    numberOfLabels: number;
 }
 
 export interface DriverOverviewCardDataProps {

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -16,6 +16,7 @@ export interface DriverOverviewTableData {
     contact?: string;
     packingDate: string | null;
     instructions?: string;
+    numberOfLabels?: number | null;
 }
 
 export interface DriverOverviewCardDataProps {
@@ -115,6 +116,9 @@ const styles = StyleSheet.create({
     instructionsColumnWidth: {
         width: "25%",
     },
+    numberOfLabelsColumnWidth: {
+        width: "15%",
+    },
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
@@ -134,6 +138,9 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
             </View>
             <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
                 <Text>Instructions</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
+                <Text>Number of Parcels</Text>
             </View>
         </View>
     );
@@ -162,10 +169,13 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.contact}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.packingDateColumnWidth]}>
-                    <Text>{rowData.packingDate ? rowData.packingDate : "No recorded date"}</Text>
+                    <Text>{rowData.packingDate || "No recorded date"}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
                     <Text>{rowData.instructions}</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
+                    <Text>{rowData.numberOfLabels || "No labels downloaded"}</Text>
                 </View>
             </View>
         );

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -33,7 +33,7 @@ const compareDriverOverviewTableData = (
 
 type ParcelsForDelivery = (Schema["parcels"] & {
     client: Schema["clients"];
-    labelCount?: number;
+    labelCount: number;
 })[];
 
 type ParcelsForDeliveryResponse =
@@ -71,7 +71,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             return { data: null, error: { type: "noMatchingClient", logId: logId } };
         }
 
-        let labelCount: number | undefined;
+        let labelCount: number = 0;
         if (parcel.events && parcel.events.length > 0 && parcel.events[0].event_data) {
             labelCount = Number.parseInt(parcel.events[0].event_data);
         }
@@ -114,7 +114,7 @@ const getDriverPdfData = async (parcelIds: string[]): Promise<DriverPdfResponse>
             contact: client?.phone_number ?? "",
             packingDate: formatDateToDate(parcel.packing_date) ?? null,
             instructions: client?.delivery_instructions ?? "",
-            numberOfLabels: parcel.labelCount ?? null,
+            numberOfLabels: parcel.labelCount,
         });
     }
     clientInformation.sort(compareDriverOverviewTableData);


### PR DESCRIPTION
## What's changed
* Driver overview PDF now has a column showing how many labels have been downloaded for each parcel
  * Column is named "Number of Parcels" as per ticket
* Uses the latest "Shipping Labels Downloaded" event for that parcel and gets the number of labels associated with that event

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/66657691-41f7-48b4-854d-54600644cc4f) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/6e0a24d8-1dc5-49e7-bf2c-4dfab6c1a325) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`
