### PR TITLE
VFB-182: Re-navigate to parcel modal on submit and edit of parcel.

### DIFF
--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -16,7 +16,7 @@ import {
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import supabase from "@/supabaseClient";
 import Title from "@/components/Title/Title";
-import { insertParcel } from "@/app/parcels/form/clientDatabaseFunctions";
+import { insertParcel } from "@/app/parcels/form/submitFormHelpers";
 
 interface AddParcelProps {
     clientId: string;

--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -16,6 +16,7 @@ import {
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import supabase from "@/supabaseClient";
 import Title from "@/components/Title/Title";
+import { insertParcel } from "@/app/parcels/form/clientDatabaseFunctions";
 
 interface AddParcelProps {
     clientId: string;
@@ -88,7 +89,7 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
                         initialFields={initialParcelFields}
                         initialFormErrors={initialParcelFormErrors}
                         clientId={clientId}
-                        editMode={false}
+                        writeParcelInfoToDatabase={insertParcel}
                         deliveryPrimaryKey={deliveryPrimaryKey}
                         collectionCentresLabelsAndValues={collectionCentresLabelsAndValues}
                         packingSlotsLabelsAndValues={packingSlotsLabelsAndValues}

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -17,7 +17,7 @@ import supabase from "@/supabaseClient";
 import { Errors } from "@/components/Form/formFunctions";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Title from "@/components/Title/Title";
-import { ParcelDatabaseUpdateRecord, updateParcel } from "@/app/parcels/form/submitFormHelpers";
+import { updateParcel } from "@/app/parcels/form/submitFormHelpers";
 
 interface EditParcelFormProps {
     parcelId: string;
@@ -137,9 +137,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                 <ParcelForm
                     initialFields={initialFormFields}
                     initialFormErrors={initialFormErrors}
-                    writeParcelInfoToDatabase={(parcelDatabaseRecord: ParcelDatabaseUpdateRecord) =>
-                        updateParcel(parcelDatabaseRecord, parcelId)
-                    }
+                    writeParcelInfoToDatabase={updateParcel(parcelId)}
                     deliveryPrimaryKey={deliveryKey}
                     collectionCentresLabelsAndValues={collectionCentres}
                     packingSlotsLabelsAndValues={packingSlots}

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -1,22 +1,26 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import ParcelForm, { ParcelErrors, ParcelFields, initialParcelFields } from "../form/ParcelForm";
+import ParcelForm, { initialParcelFields, ParcelErrors, ParcelFields } from "../form/ParcelForm";
 import {
     CollectionCentresLabelsAndValues,
-    fetchParcel,
-    getActiveCollectionCentres,
-    PackingSlotsLabelsAndValues,
-    fetchPackingSlotsInfo,
-    ParcelWithCollectionCentreAndPackingSlot,
     FetchCollectionCentresError,
-    PackingSlotsError,
+    fetchPackingSlotsInfo,
+    fetchParcel,
     FetchParcelError,
+    getActiveCollectionCentres,
+    PackingSlotsError,
+    PackingSlotsLabelsAndValues,
+    ParcelWithCollectionCentreAndPackingSlot,
 } from "@/common/fetch";
 import supabase from "@/supabaseClient";
 import { Errors } from "@/components/Form/formFunctions";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Title from "@/components/Title/Title";
+import {
+    ParcelDatabaseUpdateRecord,
+    updateParcel,
+} from "@/app/parcels/form/clientDatabaseFunctions";
 
 interface EditParcelFormProps {
     parcelId: string;
@@ -111,7 +115,6 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
             );
             setPackingSlotsIsShown(parcelData.packing_slot?.is_shown);
             setCollectionCentreIsShown(parcelData.collection_centre?.is_shown === true);
-
             setIsLoading(false);
         })();
     }, [parcelId]);
@@ -119,11 +122,11 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
     const initialFormErrors: ParcelErrors = {
         voucherNumber: Errors.none,
         packingDate: Errors.none,
-        packingSlot: Errors.none,
+        packingSlot: packingSlotIsShown ? Errors.none : Errors.invalidPackingSlot,
         shippingMethod: Errors.none,
         collectionDate: Errors.none,
         collectionTime: Errors.none,
-        collectionCentre: Errors.none,
+        collectionCentre: collectionCentreIsShown ? Errors.none : Errors.invalidCollectionCentre,
     };
 
     return (
@@ -137,13 +140,12 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                 <ParcelForm
                     initialFields={initialFormFields}
                     initialFormErrors={initialFormErrors}
-                    editMode={true}
-                    parcelId={parcelId}
+                    writeParcelInfoToDatabase={(parcelDatabaseRecord: ParcelDatabaseUpdateRecord) =>
+                        updateParcel(parcelDatabaseRecord, parcelId)
+                    }
                     deliveryPrimaryKey={deliveryKey}
                     collectionCentresLabelsAndValues={collectionCentres}
                     packingSlotsLabelsAndValues={packingSlots}
-                    packingSlotIsShown={packingSlotIsShown}
-                    collectionCentreIsShown={collectionCentreIsShown}
                 />
             )}
         </>

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -17,10 +17,7 @@ import supabase from "@/supabaseClient";
 import { Errors } from "@/components/Form/formFunctions";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Title from "@/components/Title/Title";
-import {
-    ParcelDatabaseUpdateRecord,
-    updateParcel,
-} from "@/app/parcels/form/clientDatabaseFunctions";
+import { ParcelDatabaseUpdateRecord, updateParcel } from "@/app/parcels/form/submitFormHelpers";
 
 interface EditParcelFormProps {
     parcelId: string;

--- a/src/app/parcels/edit/[id]/page.tsx
+++ b/src/app/parcels/edit/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 
 import React from "react";
-import EditParcelForm from "../editParcelForm";
+import EditParcelForm from "../EditParcelForm";
 
 interface EditParcelsParameters {
     params: { id: string };

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -25,7 +25,7 @@ import CollectionDateCard from "@/app/parcels/form/formSections/CollectionDateCa
 import CollectionTimeCard from "@/app/parcels/form/formSections/CollectionTimeCard";
 import CollectionCentreCard from "@/app/parcels/form/formSections/CollectionCentreCard";
 import {
-    ParcelDatabaseErrors,
+    WriteParcelToDatabaseErrors,
     WriteParcelToDatabaseFunction,
 } from "@/app/parcels/form/submitFormHelpers";
 import { Button, IconButton } from "@mui/material";
@@ -127,7 +127,7 @@ const mergeDateAndTime = (date: string, time: string): Dayjs => {
 const parcelModalRouterPath = (parcelId: string): string => `/parcels?parcelId=${parcelId}`;
 
 const databaseErrorMessageFromErrorType = (
-    errorType: ParcelDatabaseErrors,
+    errorType: WriteParcelToDatabaseErrors,
     logId: string
 ): string => {
     switch (errorType) {
@@ -231,14 +231,10 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
         }
 
         if (error) {
-            /*
-               If the user is trying to edit a parcel that is currently being edited,
-               we want the user to refresh the page to get the current data, so we keep the submit button
-               disabled.
-             */
             if (error.type !== "concurrentUpdateConflict") {
                 setSubmitDisabled(false);
             }
+
             setSubmitErrorMessage(databaseErrorMessageFromErrorType(error.type, error.logId));
         }
     };

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -225,13 +225,20 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
         };
 
         const { parcelId, error } = await writeParcelInfoToDatabase(parcelRecord);
-        setSubmitDisabled(false);
 
         if (parcelId) {
             router.push(parcelModalRouterPath(parcelId));
         }
 
         if (error) {
+            /*
+               If the user is trying to edit a parcel that is currently being edited,
+               we want the user to refresh the page to get the current data, so we keep the submit button
+               disabled.
+             */
+            if (error.type !== "concurrentUpdateConflict") {
+                setSubmitDisabled(false);
+            }
             setSubmitErrorMessage(databaseErrorMessageFromErrorType(error.type, error.logId));
         }
     };

--- a/src/app/parcels/form/submitFormHelpers.ts
+++ b/src/app/parcels/form/submitFormHelpers.ts
@@ -4,7 +4,7 @@ import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
 export type WriteParcelToDatabaseFunction = UpdateParcel | InsertParcel;
-export type ParcelDatabaseErrors = InsertParcelErrors | UpdateParcelErrors;
+export type WriteParcelToDatabaseErrors = InsertParcelErrors | UpdateParcelErrors;
 
 type ParcelDatabaseInsertRecord = InsertSchema["parcels"];
 type ParcelDatabaseUpdateRecord = UpdateSchema["parcels"];


### PR DESCRIPTION
## What's changed
1.  Now navigates to the parcel modal upon parcel form submit
2.  Fixed potential bug when database errors.
3.  Refactored parcel forms code to improve readability. (Have added comments to explain what I've done and why. Please say if I've made a mistake with the refactors / you disagree with any of the changes :) ).

## Screenshots / Videos
Not needed as no ui changes in this pr?

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database... ( I have not :) )

