### PR TITLE
NONE: change seed data date range

### DIFF
--- a/supabase/seed/dateData.mts
+++ b/supabase/seed/dateData.mts
@@ -1,7 +1,8 @@
 import seedrandom from "seedrandom";
 
-export const earliestDate = new Date(2024, 0, 1); // 2024/01/01
-export const latestDate = new Date(2024, 4, 1); // 2024/05/01
+export const earliestParcelEventDate = new Date(2024, 0, 1); // 2024/01/01
+export const latestParcelEventDate = new Date(2024, 4, 1); // 2024/05/01
+export const farFutureDate = new Date(2025, 0, 1); // 2025/01/01
 export const parcelCreationDateTime = new Date("2023-12-31T12:00:00");
 
 export function getPseudoRandomDateBetween(start: Date, end: Date, seed: string): Date {

--- a/supabase/seed/dateData.mts
+++ b/supabase/seed/dateData.mts
@@ -1,7 +1,7 @@
 import seedrandom from "seedrandom";
 
-export const earliestParcelEventDate = new Date(2024, 0, 1); // 2024/01/01
-export const latestParcelEventDate = new Date(2024, 4, 1); // 2024/05/01
+export const earliestParcelOrEventDate = new Date(2024, 0, 1); // 2024/01/01
+export const latestEventDate = new Date(2024, 4, 1); // 2024/05/01
 export const farFutureDate = new Date(2025, 0, 1); // 2025/01/01
 export const parcelCreationDateTime = new Date("2023-12-31T12:00:00");
 

--- a/supabase/seed/dateData.mts
+++ b/supabase/seed/dateData.mts
@@ -1,7 +1,7 @@
 import seedrandom from "seedrandom";
 
 export const earliestDate = new Date(2024, 0, 1); // 2024/01/01
-export const latestDate = new Date(2025, 0, 1); // 2025/01/01
+export const latestDate = new Date(2024, 4, 1); // 2024/05/01
 
 export function getPseudoRandomDateBetween(start: Date, end: Date, seed: string): Date {
     const randomNumberGenerator = seedrandom(seed);

--- a/supabase/seed/dateData.mts
+++ b/supabase/seed/dateData.mts
@@ -2,6 +2,7 @@ import seedrandom from "seedrandom";
 
 export const earliestDate = new Date(2024, 0, 1); // 2024/01/01
 export const latestDate = new Date(2024, 4, 1); // 2024/05/01
+export const parcelCreationDateTime = new Date("2023-12-31T12:00:00");
 
 export function getPseudoRandomDateBetween(start: Date, end: Date, seed: string): Date {
     const randomNumberGenerator = seedrandom(seed);

--- a/supabase/seed/families.mts
+++ b/supabase/seed/families.mts
@@ -1,0 +1,1 @@
+export const genders: ("male" | "female" | "other")[] = ["male", "female", "other"];

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -18,10 +18,10 @@ import { collectionCentres } from "./collectionCentresSeed.mjs";
 import { listsHotels } from "./listsHotelsSeed.mjs";
 import { packingSlots } from "./packingSlotsSeed.mjs";
 import {
-    earliestParcelEventDate,
+    earliestParcelOrEventDate,
     farFutureDate,
     getPseudoRandomDateBetween,
-    latestParcelEventDate,
+    latestEventDate,
     parcelCreationDateTime,
 } from "./dateData.mjs";
 import { genders } from "./families.mjs";
@@ -68,7 +68,7 @@ async function generateSeed(): Promise<void> {
             signpostingCallRequired: (ctx) => copycat.bool(ctx.seed),
             families: (generateFamily) =>
                 generateFamily(
-                    { min: 1, max: 12 },
+                    { min: 1, max: 8 },
                     {
                         age: (ctx) => copycat.int(ctx.seed, { min: 0, max: 100 }),
                         gender: (ctx) => copycat.oneOf(ctx.seed, genders),
@@ -87,9 +87,9 @@ async function generateSeed(): Promise<void> {
         (generate) =>
             generate(5000, {
                 packingDate: (ctx) =>
-                    getPseudoRandomDateBetween(earliestParcelEventDate, farFutureDate, ctx.seed),
+                    getPseudoRandomDateBetween(earliestParcelOrEventDate, farFutureDate, ctx.seed),
                 collectionDatetime: (ctx) =>
-                    getPseudoRandomDateBetween(earliestParcelEventDate, farFutureDate, ctx.seed),
+                    getPseudoRandomDateBetween(earliestParcelOrEventDate, farFutureDate, ctx.seed),
                 createdAt: parcelCreationDateTime,
             }),
         { connect: true }
@@ -103,8 +103,8 @@ async function generateSeed(): Promise<void> {
                     eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
                     timestamp: (ctx) =>
                         getPseudoRandomDateBetween(
-                            earliestParcelEventDate,
-                            latestParcelEventDate,
+                            earliestParcelOrEventDate,
+                            latestEventDate,
                             ctx.seed
                         ),
                 }),
@@ -120,8 +120,8 @@ async function generateSeed(): Promise<void> {
                     eventData: () => "",
                     timestamp: (ctx) =>
                         getPseudoRandomDateBetween(
-                            earliestParcelEventDate,
-                            latestParcelEventDate,
+                            earliestParcelOrEventDate,
+                            latestEventDate,
                             ctx.seed
                         ),
                 }),

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -17,7 +17,12 @@ import { eventNamesWithNoData, eventNamesWithNumberData } from "./eventsSeed.mjs
 import { collectionCentres } from "./collectionCentresSeed.mjs";
 import { listsHotels } from "./listsHotelsSeed.mjs";
 import { packingSlots } from "./packingSlotsSeed.mjs";
-import { earliestDate, getPseudoRandomDateBetween, latestDate } from "./dateData.mjs";
+import {
+    earliestDate,
+    getPseudoRandomDateBetween,
+    latestDate,
+    parcelCreationDateTime,
+} from "./dateData.mjs";
 
 generateSeed();
 
@@ -83,7 +88,7 @@ async function generateSeed(): Promise<void> {
                     getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
                 collectionDatetime: (ctx) =>
                     getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
-                createdAt: new Date("2023-12-31T12:00:00"),
+                createdAt: parcelCreationDateTime,
             }),
         { connect: true }
     );

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -23,6 +23,7 @@ import {
     latestDate,
     parcelCreationDateTime,
 } from "./dateData.mjs";
+import { genders } from "./families.mjs";
 
 generateSeed();
 
@@ -64,18 +65,18 @@ async function generateSeed(): Promise<void> {
             extraInformation: (ctx) => copycat.sentence(ctx.seed, { maxWords: 20 }),
             flaggedForAttention: (ctx) => copycat.bool(ctx.seed),
             signpostingCallRequired: (ctx) => copycat.bool(ctx.seed),
+            families: (generateFamily) =>
+                generateFamily(
+                    { min: 1, max: 12 },
+                    {
+                        age: (ctx) => copycat.int(ctx.seed, { min: 0, max: 100 }),
+                        gender: (ctx) => copycat.oneOf(ctx.seed, genders),
+                    }
+                ),
         })
     );
 
     await seed.collectionCentres(collectionCentres);
-
-    await seed.families(
-        (generate) =>
-            generate(1000, {
-                age: (ctx) => copycat.int(ctx.seed, { min: 0, max: 100 }),
-            }),
-        { connect: true }
-    );
 
     await seed.lists(listsSeedRequired);
 

--- a/supabase/seed/seed.mts
+++ b/supabase/seed/seed.mts
@@ -18,9 +18,10 @@ import { collectionCentres } from "./collectionCentresSeed.mjs";
 import { listsHotels } from "./listsHotelsSeed.mjs";
 import { packingSlots } from "./packingSlotsSeed.mjs";
 import {
-    earliestDate,
+    earliestParcelEventDate,
+    farFutureDate,
     getPseudoRandomDateBetween,
-    latestDate,
+    latestParcelEventDate,
     parcelCreationDateTime,
 } from "./dateData.mjs";
 import { genders } from "./families.mjs";
@@ -86,9 +87,9 @@ async function generateSeed(): Promise<void> {
         (generate) =>
             generate(5000, {
                 packingDate: (ctx) =>
-                    getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                    getPseudoRandomDateBetween(earliestParcelEventDate, farFutureDate, ctx.seed),
                 collectionDatetime: (ctx) =>
-                    getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                    getPseudoRandomDateBetween(earliestParcelEventDate, farFutureDate, ctx.seed),
                 createdAt: parcelCreationDateTime,
             }),
         { connect: true }
@@ -101,7 +102,11 @@ async function generateSeed(): Promise<void> {
                     newParcelStatus: status,
                     eventData: (ctx) => copycat.int(ctx.seed, { min: 1, max: 10 }).toString(),
                     timestamp: (ctx) =>
-                        getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                        getPseudoRandomDateBetween(
+                            earliestParcelEventDate,
+                            latestParcelEventDate,
+                            ctx.seed
+                        ),
                 }),
             { connect: true }
         );
@@ -114,7 +119,11 @@ async function generateSeed(): Promise<void> {
                     newParcelStatus: status,
                     eventData: () => "",
                     timestamp: (ctx) =>
-                        getPseudoRandomDateBetween(earliestDate, latestDate, ctx.seed),
+                        getPseudoRandomDateBetween(
+                            earliestParcelEventDate,
+                            latestParcelEventDate,
+                            ctx.seed
+                        ),
                 }),
             { connect: true }
         );


### PR DESCRIPTION
## What's changed
- change seed data date range
- Add at least one family member for each client
- Assign random gender for each family member

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any. - NA
- [ ] I have documented the testing steps for QA - NA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `db:local:generate_types` - NA
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run dev:reset_supabase` without any errors.
  - Does this require resetting the deployed database? - NO
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following. - NA
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.
