### PR TITLE
#196: Show collections or deliveries on driver overview

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -61,6 +61,9 @@ const getPdfErrorMessage = (error: DriverOverviewError): string => {
         case "driverMessageFetchFailed":
             errorMessage = "Failed to fetch driver overview message.";
             break;
+        case "noCollectionCentre":
+            errorMessage = "Failed to find a collection centre for one or more of the parcels.";
+            break;
     }
     return `${errorMessage} LogId: ${error.logId}`;
 };

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
         marginRight: "5px",
         marginBottom: "5px",
         alignSelf: "flex-start",
-    }
+    },
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
@@ -179,9 +179,9 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                 <Text>Number of Parcels</Text>
             </View>
         </View>
-    )
+    );
 
-    const createRowData = (rowData: DriverOverviewTableData, index: number) => {
+    const createRowData = (rowData: DriverOverviewTableData, index: number): React.JSX.Element => {
         return (
             // eslint-disable-next-line react/no-array-index-key
             <View key={index} style={[styles.tableRow, styles.flexRow]} wrap={false}>
@@ -189,22 +189,25 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.name}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    { rowData.collection_centre.isDelivery ? rowData.address.postcode || rowData.clientIsActive ? (
-                        <>
-                            <Text>{rowData.address.line1}</Text>
-                            <Text>{rowData.address.line2}</Text>
-                            <Text>{rowData.address.town}</Text>
-                            <Text>{rowData.address.county}</Text>
-                            <Text>{rowData.address.postcode}</Text>
-                        </>
+                    {rowData.collection_centre.isDelivery ? (
+                        rowData.address.postcode || rowData.clientIsActive ? (
+                            <>
+                                <Text>{rowData.address.line1}</Text>
+                                <Text>{rowData.address.line2}</Text>
+                                <Text>{rowData.address.town}</Text>
+                                <Text>{rowData.address.county}</Text>
+                                <Text>{rowData.address.postcode}</Text>
+                            </>
+                        ) : (
+                            <Text>
+                                {rowData.clientIsActive ? displayPostcodeForHomelessClient : "-"}
+                            </Text>
+                        )
                     ) : (
-                        <Text>
-                            {rowData.clientIsActive ? displayPostcodeForHomelessClient : "-"}
-                        </Text>
-                    ):  <>
+                        <>
                             <Text>{rowData.collection_centre.name}</Text>
                         </>
-                    }
+                    )}
                 </View>
                 <View style={[styles.tableColumn, styles.contactColumnWidth]}>
                     <Text>{rowData.contact}</Text>
@@ -220,10 +223,10 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                 </View>
             </View>
         );
-    }
+    };
 
-    const collections = data.tableData[0].map(createRowData)
-    const deliveries = data.tableData[1].map(createRowData)
+    const collections = data.tableData[0].map(createRowData);
+    const deliveries = data.tableData[1].map(createRowData);
 
     return (
         <Document>
@@ -247,12 +250,14 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                 <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
                     <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
                     <FontAwesomeIconPdfComponent faIcon={faTruck}></FontAwesomeIconPdfComponent>
-                    </View>
+                </View>
                 <View style={[styles.flexColumn, { width: "100%" }]}>{deliveryHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
                 <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
                     <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
-                    <FontAwesomeIconPdfComponent faIcon={faShoePrints}></FontAwesomeIconPdfComponent>
+                    <FontAwesomeIconPdfComponent
+                        faIcon={faShoePrints}
+                    ></FontAwesomeIconPdfComponent>
                 </View>
                 <View style={[styles.flexColumn, { width: "100%" }]}>{collectionHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -146,14 +146,14 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const createHeader = (category: string): React.JSX.Element => {
+    const createHeader = (category: Method): React.JSX.Element => {
         return (
             <View style={[styles.tableHeader, styles.flexRow]}>
                 <View style={[styles.tableColumn, styles.nameColumnWidth]}>
                     <Text>Name</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    <Text>{category === "Collection" ? "Collection Centre" : "Address"}</Text>
+                    <Text>{category === Method.Collection ? "Collection Centre" : "Address"}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.contactColumnWidth]}>
                     <Text>Contact</Text>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -40,7 +40,7 @@ type CreateHeaderProps = "Delivery" | "Collection";
 export type DriverOverviewTablesData = {
     collections: DriverOverviewRowData[];
     deliveries: DriverOverviewRowData[];
-}
+};
 
 const styles = StyleSheet.create({
     container: {
@@ -236,7 +236,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
-                {deliveries.length ?
+                {deliveries.length ? (
                     <View style={styles.tableContainer}>
                         <View
                             style={[
@@ -255,10 +255,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         </View>
                         <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
                     </View>
-                    :
-                    null
-                }
-                {collections.length ?
+                ) : null}
+                {collections.length ? (
                     <View style={styles.tableContainer}>
                         <View
                             style={[
@@ -277,9 +275,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         </View>
                         <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
                     </View>
-                    :
-                    null
-                } 
+                ) : null}
             </Page>
         </Document>
     );

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -18,7 +18,10 @@ export interface DriverOverviewTableData {
     instructions?: string;
     clientIsActive: boolean;
     numberOfLabels: number;
-    isDelivery: boolean;
+    collection_centre: {
+        name: string;
+        isDelivery: boolean;
+    };
 }
 
 export interface DriverOverviewCardDataProps {
@@ -125,7 +128,7 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const header = (
+    const deliveryHeader = (
         <View style={[styles.tableHeader, styles.flexRow]}>
             <View style={[styles.tableColumn, styles.nameColumnWidth]}>
                 <Text>Name</Text>
@@ -148,6 +151,29 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         </View>
     );
 
+    const collectionHeader = (
+        <View style={[styles.tableHeader, styles.flexRow]}>
+            <View style={[styles.tableColumn, styles.nameColumnWidth]}>
+                <Text>Name</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.addressColumnWidth]}>
+                <Text>Collection Centre</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.contactColumnWidth]}>
+                <Text>Contact</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.packingDateColumnWidth]}>
+                <Text>Packing Date</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
+                <Text>Instructions</Text>
+            </View>
+            <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
+                <Text>Number of Parcels</Text>
+            </View>
+        </View>
+    )
+
     const createRowData = (rowData: DriverOverviewTableData, index: number) => {
         return (
             // eslint-disable-next-line react/no-array-index-key
@@ -156,20 +182,22 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.name}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    {rowData.address.postcode || rowData.clientIsActive ? (
+                    { rowData.collection_centre.isDelivery ? rowData.address.postcode || rowData.clientIsActive ? (
                         <>
                             <Text>{rowData.address.line1}</Text>
                             <Text>{rowData.address.line2}</Text>
                             <Text>{rowData.address.town}</Text>
                             <Text>{rowData.address.county}</Text>
                             <Text>{rowData.address.postcode}</Text>
-                            <Text>{rowData.isDelivery ? "Delivery" : "Collection"}</Text>
                         </>
                     ) : (
                         <Text>
                             {rowData.clientIsActive ? displayPostcodeForHomelessClient : "-"}
                         </Text>
-                    )}
+                    ):  <>
+                            <Text>{rowData.collection_centre.name}</Text>
+                        </>
+                    }
                 </View>
                 <View style={[styles.tableColumn, styles.contactColumnWidth]}>
                     <Text>{rowData.contact}</Text>
@@ -187,8 +215,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     }
 
-    const deliveries = data.tableData[0].map(createRowData)
-    const collections = data.tableData[1].map(createRowData)
+    const collections = data.tableData[0].map(createRowData)
+    const deliveries = data.tableData[1].map(createRowData)
 
     return (
         <Document>
@@ -209,9 +237,9 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{deliveryHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{collectionHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
             </Page>
         </Document>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -3,6 +3,8 @@
 import React from "react";
 import { Text, Document, Page, View, StyleSheet, Image } from "@react-pdf/renderer";
 import { displayPostcodeForHomelessClient } from "@/common/format";
+import { faTruck, faShoePrints } from "@fortawesome/free-solid-svg-icons";
+import FontAwesomeIconPdfComponent from "../FontAwesomeIconPdfComponent";
 
 export interface DriverOverviewTableData {
     name: string;
@@ -125,6 +127,11 @@ const styles = StyleSheet.create({
     numberOfLabelsColumnWidth: {
         width: "20%",
     },
+    collectionOrDeliveryHeader: {
+        marginRight: "5px",
+        marginBottom: "5px",
+        alignSelf: "flex-start",
+    }
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
@@ -237,8 +244,16 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
+                <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
+                    <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
+                    <FontAwesomeIconPdfComponent faIcon={faTruck}></FontAwesomeIconPdfComponent>
+                    </View>
                 <View style={[styles.flexColumn, { width: "100%" }]}>{deliveryHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
+                <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
+                    <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
+                    <FontAwesomeIconPdfComponent faIcon={faShoePrints}></FontAwesomeIconPdfComponent>
+                </View>
                 <View style={[styles.flexColumn, { width: "100%" }]}>{collectionHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
             </Page>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -37,6 +37,8 @@ interface DriverOverviewCardProps {
     data: DriverOverviewCardDataProps;
 }
 
+type CreateHeaderProps = "Delivery" | "Collection";
+
 const styles = StyleSheet.create({
     container: {
         padding: 25,
@@ -135,7 +137,7 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const createHeader = (category: string): React.JSX.Element => {
+    const createHeader = (category: CreateHeaderProps): React.JSX.Element => {
         return (
             <View style={[styles.tableHeader, styles.flexRow]}>
                 <View style={[styles.tableColumn, styles.nameColumnWidth]}>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -6,7 +6,7 @@ import { displayPostcodeForHomelessClient } from "@/common/format";
 import { faTruck, faShoePrints } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "../FontAwesomeIconPdfComponent";
 
-export interface DriverOverviewTableData {
+export interface DriverOverviewRowData {
     name: string;
     address: {
         line1: string;
@@ -29,7 +29,7 @@ export interface DriverOverviewTableData {
 export interface DriverOverviewCardDataProps {
     driverName: string;
     date: Date;
-    tableData: DriverOverviewTableData[][];
+    tableData: DriverOverviewTablesData;
     message: string;
 }
 
@@ -38,6 +38,11 @@ interface DriverOverviewCardProps {
 }
 
 type CreateHeaderProps = "Delivery" | "Collection";
+
+export type DriverOverviewTablesData = {
+    collections: DriverOverviewRowData[];
+    deliveries: DriverOverviewRowData[];
+}
 
 const styles = StyleSheet.create({
     container: {
@@ -165,7 +170,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     };
 
-    const createRow = (rowData: DriverOverviewTableData, index: number): React.JSX.Element => {
+    const createRow = (rowData: DriverOverviewRowData, index: number): React.JSX.Element => {
         return (
             // eslint-disable-next-line react/no-array-index-key
             <View key={index} style={[styles.tableRow, styles.flexRow]} wrap={false}>
@@ -211,8 +216,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
 
     const deliveriesHeader = createHeader("Delivery");
     const collectionsHeader = createHeader("Collection");
-    const collections = data.tableData[0].map(createRow);
-    const deliveries = data.tableData[1].map(createRow);
+    const collections = data.tableData.collections.map(createRow);
+    const deliveries = data.tableData.deliveries.map(createRow);
 
     return (
         <Document>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -18,12 +18,13 @@ export interface DriverOverviewTableData {
     instructions?: string;
     clientIsActive: boolean;
     numberOfLabels: number;
+    isDelivery: boolean;
 }
 
 export interface DriverOverviewCardDataProps {
     driverName: string;
     date: Date;
-    tableData: DriverOverviewTableData[];
+    tableData: DriverOverviewTableData[][];
     message: string;
 }
 
@@ -76,6 +77,7 @@ const styles = StyleSheet.create({
         width: "100%",
         borderTop: "none",
         borderBottom: "1px solid black",
+        marginBottom: "15px",
     },
     tableRow: {
         width: "100%",
@@ -146,7 +148,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         </View>
     );
 
-    const table = data.tableData.map((rowData, index) => {
+    const createRowData = (rowData: DriverOverviewTableData, index: number) => {
         return (
             // eslint-disable-next-line react/no-array-index-key
             <View key={index} style={[styles.tableRow, styles.flexRow]} wrap={false}>
@@ -161,6 +163,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                             <Text>{rowData.address.town}</Text>
                             <Text>{rowData.address.county}</Text>
                             <Text>{rowData.address.postcode}</Text>
+                            <Text>{rowData.isDelivery ? "Delivery" : "Collection"}</Text>
                         </>
                     ) : (
                         <Text>
@@ -182,7 +185,10 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                 </View>
             </View>
         );
-    });
+    }
+
+    const deliveries = data.tableData[0].map(createRowData)
+    const collections = data.tableData[1].map(createRowData)
 
     return (
         <Document>
@@ -204,7 +210,9 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     </Text>
                 </View>
                 <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
-                <View style={[styles.tableSection, styles.flexColumn]}>{table}</View>
+                <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
+                <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
             </Page>
         </Document>
     );

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -35,7 +35,10 @@ interface DriverOverviewCardProps {
     data: DriverOverviewCardDataProps;
 }
 
-type CreateHeaderProps = "Delivery" | "Collection";
+enum Method {
+    Delivery = "Delivery",
+    Collection = "Collection",
+}
 
 export type DriverOverviewTablesData = {
     collections: DriverOverviewRowData[];
@@ -143,7 +146,7 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const createHeader = (category: CreateHeaderProps): React.JSX.Element => {
+    const createHeader = (category: string): React.JSX.Element => {
         return (
             <View style={[styles.tableHeader, styles.flexRow]}>
                 <View style={[styles.tableColumn, styles.nameColumnWidth]}>
@@ -212,8 +215,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     };
 
-    const deliveriesHeader = createHeader("Delivery");
-    const collectionsHeader = createHeader("Collection");
+    const deliveriesHeader = createHeader(Method.Delivery);
+    const collectionsHeader = createHeader(Method.Collection);
     const collections = data.tableData.collections.map(createRow);
     const deliveries = data.tableData.deliveries.map(createRow);
 

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -162,7 +162,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     };
 
-    const createRowData = (rowData: DriverOverviewTableData, index: number): React.JSX.Element => {
+    const createRow = (rowData: DriverOverviewTableData, index: number): React.JSX.Element => {
         return (
             // eslint-disable-next-line react/no-array-index-key
             <View key={index} style={[styles.tableRow, styles.flexRow]} wrap={false}>
@@ -208,8 +208,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
 
     const deliveriesHeader = createHeader("Delivery");
     const collectionsHeader = createHeader("Collection");
-    const collections = data.tableData[0].map(createRowData);
-    const deliveries = data.tableData[1].map(createRowData);
+    const collections = data.tableData[0].map(createRow);
+    const deliveries = data.tableData[1].map(createRow);
 
     return (
         <Document>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import { Text, Document, Page, View, StyleSheet, Image } from "@react-pdf/renderer";
 import { displayNameForNullDriverName, displayPostcodeForHomelessClient } from "@/common/format";
-import { faTruck, faShoePrints } from "@fortawesome/free-solid-svg-icons";
+import { faTruck, faShoePrints, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "../FontAwesomeIconPdfComponent";
 
 export interface DriverOverviewRowData {
@@ -215,10 +215,36 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     };
 
-    const deliveriesHeader = createHeader(Method.Delivery);
-    const collectionsHeader = createHeader(Method.Collection);
-    const collections = data.tableData.collections.map(createRow);
-    const deliveries = data.tableData.deliveries.map(createRow);
+    const createTable = (
+        name: string,
+        header: React.JSX.Element,
+        tableRows: React.JSX.Element[],
+        icon: IconDefinition
+    ): React.JSX.Element => {
+        return (
+            <View style={styles.tableContainer}>
+                <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
+                    <Text style={[styles.collectionOrDeliveryHeader]}>{name}</Text>
+                    <FontAwesomeIconPdfComponent faIcon={icon}></FontAwesomeIconPdfComponent>
+                </View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
+                <View style={[styles.tableSection, styles.flexColumn]}>{tableRows}</View>
+            </View>
+        );
+    };
+
+    const deliveriesHeader: React.JSX.Element = createHeader(Method.Delivery);
+    const collectionsHeader: React.JSX.Element = createHeader(Method.Collection);
+    const collections: React.JSX.Element[] = data.tableData.collections.map(createRow);
+    const deliveries: React.JSX.Element[] = data.tableData.deliveries.map(createRow);
+
+    const collectionsTable = createTable(
+        "Collections",
+        collectionsHeader,
+        collections,
+        faShoePrints
+    );
+    const deliveriesTable = createTable("Deliveries", deliveriesHeader, deliveries, faTruck);
 
     return (
         <Document>
@@ -241,46 +267,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
-                {deliveries.length ? (
-                    <View style={styles.tableContainer}>
-                        <View
-                            style={[
-                                styles.h2text,
-                                styles.collectionOrDeliveryHeader,
-                                styles.flexRow,
-                            ]}
-                        >
-                            <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
-                            <FontAwesomeIconPdfComponent
-                                faIcon={faTruck}
-                            ></FontAwesomeIconPdfComponent>
-                        </View>
-                        <View style={[styles.flexColumn, { width: "100%" }]}>
-                            {deliveriesHeader}
-                        </View>
-                        <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
-                    </View>
-                ) : null}
-                {collections.length ? (
-                    <View style={styles.tableContainer}>
-                        <View
-                            style={[
-                                styles.h2text,
-                                styles.collectionOrDeliveryHeader,
-                                styles.flexRow,
-                            ]}
-                        >
-                            <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
-                            <FontAwesomeIconPdfComponent
-                                faIcon={faShoePrints}
-                            ></FontAwesomeIconPdfComponent>
-                        </View>
-                        <View style={[styles.flexColumn, { width: "100%" }]}>
-                            {collectionsHeader}
-                        </View>
-                        <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
-                    </View>
-                ) : null}
+                {deliveries.length ? deliveriesTable : null}
+                {collections.length ? collectionsTable : null}
             </Page>
         </Document>
     );

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -20,10 +20,8 @@ export interface DriverOverviewRowData {
     instructions?: string;
     clientIsActive: boolean;
     numberOfLabels: number;
-    collection_centre: {
-        name: string;
-        isDelivery: boolean;
-    };
+    collectionCentre: string;
+    isDelivery: boolean;
 }
 
 export interface DriverOverviewCardDataProps {
@@ -178,7 +176,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.name}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    {rowData.collection_centre.isDelivery ? (
+                    {rowData.isDelivery ? (
                         rowData.address.postcode || rowData.clientIsActive ? (
                             <>
                                 <Text>{rowData.address.line1}</Text>
@@ -194,7 +192,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         )
                     ) : (
                         <>
-                            <Text>{rowData.collection_centre.name}</Text>
+                            <Text>{rowData.collectionCentre}</Text>
                         </>
                     )}
                 </View>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -80,6 +80,9 @@ const styles = StyleSheet.create({
         paddingLeft: 15,
         paddingTop: 5,
     },
+    tableContainer: {
+        width: "100%",
+    },
     tableSection: {
         width: "100%",
         borderTop: "none",
@@ -230,20 +233,50 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
-                <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
-                    <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
-                    <FontAwesomeIconPdfComponent faIcon={faTruck}></FontAwesomeIconPdfComponent>
-                </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{deliveriesHeader}</View>
-                <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
-                <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
-                    <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
-                    <FontAwesomeIconPdfComponent
-                        faIcon={faShoePrints}
-                    ></FontAwesomeIconPdfComponent>
-                </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{collectionsHeader}</View>
-                <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
+                {deliveries.length ?
+                    <View style={styles.tableContainer}>
+                        <View
+                            style={[
+                                styles.h2text,
+                                styles.collectionOrDeliveryHeader,
+                                styles.flexRow,
+                            ]}
+                        >
+                            <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
+                            <FontAwesomeIconPdfComponent
+                                faIcon={faTruck}
+                            ></FontAwesomeIconPdfComponent>
+                        </View>
+                        <View style={[styles.flexColumn, { width: "100%" }]}>
+                            {deliveriesHeader}
+                        </View>
+                        <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
+                    </View>
+                    :
+                    null
+                }
+                {collections.length ?
+                    <View style={styles.tableContainer}>
+                        <View
+                            style={[
+                                styles.h2text,
+                                styles.collectionOrDeliveryHeader,
+                                styles.flexRow,
+                            ]}
+                        >
+                            <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
+                            <FontAwesomeIconPdfComponent
+                                faIcon={faShoePrints}
+                            ></FontAwesomeIconPdfComponent>
+                        </View>
+                        <View style={[styles.flexColumn, { width: "100%" }]}>
+                            {collectionsHeader}
+                        </View>
+                        <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
+                    </View>
+                    :
+                    null
+                } 
             </Page>
         </Document>
     );

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -267,8 +267,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         COMPLETION OF DELIVERIES
                     </Text>
                 </View>
-                {deliveries.length ? deliveriesTable : null}
-                {collections.length ? collectionsTable : null}
+                {deliveries.length && deliveriesTable}
+                {collections.length && collectionsTable}
             </Page>
         </Document>
     );

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -135,51 +135,30 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const deliveryHeader = (
-        <View style={[styles.tableHeader, styles.flexRow]}>
-            <View style={[styles.tableColumn, styles.nameColumnWidth]}>
-                <Text>Name</Text>
+    const createHeader = (category: string): React.JSX.Element => {
+        return (
+            <View style={[styles.tableHeader, styles.flexRow]}>
+                <View style={[styles.tableColumn, styles.nameColumnWidth]}>
+                    <Text>Name</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.addressColumnWidth]}>
+                    <Text>{category === "Collection" ? "Collection Centre" : "Address"}</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.contactColumnWidth]}>
+                    <Text>Contact</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.packingDateColumnWidth]}>
+                    <Text>Packing Date</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
+                    <Text>Instructions</Text>
+                </View>
+                <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
+                    <Text>Number of Parcels</Text>
+                </View>
             </View>
-            <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                <Text>Address</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.contactColumnWidth]}>
-                <Text>Contact</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.packingDateColumnWidth]}>
-                <Text>Packing Date</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
-                <Text>Instructions</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
-                <Text>Number of Parcels</Text>
-            </View>
-        </View>
-    );
-
-    const collectionHeader = (
-        <View style={[styles.tableHeader, styles.flexRow]}>
-            <View style={[styles.tableColumn, styles.nameColumnWidth]}>
-                <Text>Name</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                <Text>Collection Centre</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.contactColumnWidth]}>
-                <Text>Contact</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.packingDateColumnWidth]}>
-                <Text>Packing Date</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
-                <Text>Instructions</Text>
-            </View>
-            <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
-                <Text>Number of Parcels</Text>
-            </View>
-        </View>
-    );
+        );
+    };
 
     const createRowData = (rowData: DriverOverviewTableData, index: number): React.JSX.Element => {
         return (
@@ -225,6 +204,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         );
     };
 
+    const deliveriesHeader = createHeader("Delivery");
+    const collectionsHeader = createHeader("Collection");
     const collections = data.tableData[0].map(createRowData);
     const deliveries = data.tableData[1].map(createRowData);
 
@@ -251,7 +232,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text style={styles.collectionOrDeliveryHeader}>Deliveries</Text>
                     <FontAwesomeIconPdfComponent faIcon={faTruck}></FontAwesomeIconPdfComponent>
                 </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{deliveryHeader}</View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{deliveriesHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{deliveries}</View>
                 <View style={[styles.h2text, styles.collectionOrDeliveryHeader, styles.flexRow]}>
                     <Text style={[styles.collectionOrDeliveryHeader]}>Collections</Text>
@@ -259,7 +240,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                         faIcon={faShoePrints}
                     ></FontAwesomeIconPdfComponent>
                 </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{collectionHeader}</View>
+                <View style={[styles.flexColumn, { width: "100%" }]}>{collectionsHeader}</View>
                 <View style={[styles.tableSection, styles.flexColumn]}>{collections}</View>
             </Page>
         </Document>

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -21,19 +21,6 @@ interface DriverOverviewData {
     message: string;
 }
 
-const compareDriverOverviewTableData = (
-    first: DriverOverviewRowData,
-    second: DriverOverviewRowData
-): number => {
-    if (first.name < second.name) {
-        return -1;
-    }
-    if (first.name > second.name) {
-        return 1;
-    }
-    return 0;
-};
-
 type ParcelForDelivery = Schema["parcels"] & {
     client: Schema["clients"];
     collection_centre: Schema["collection_centres"];
@@ -60,6 +47,8 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
         .limit(1, { foreignTable: "clients" })
         .limit(1, { foreignTable: "collection_centres" })
         .eq("events.new_parcel_status", "Shipping Labels Downloaded")
+        .order("name", { foreignTable: "collection_centres"})
+        .order("address_postcode", { foreignTable: "clients" })
         .order("timestamp", { foreignTable: "events", ascending: false });
 
     if (error) {
@@ -150,8 +139,8 @@ const transformParcelDataToClientInformation = (
     }
 
     return {
-        collections: collections.sort(compareDriverOverviewTableData),
-        deliveries: deliveries.sort(compareDriverOverviewTableData),
+        collections: collections,
+        deliveries: deliveries,
     };
 };
 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -132,7 +132,10 @@ const getDriverPdfData = async (parcelIds: string[]): Promise<DriverPdfResponse>
                 instructions: clientIsActive ? client?.delivery_instructions ?? "" : "-",
                 clientIsActive: clientIsActive,
                 numberOfLabels: parcel.labelCount,
-                isDelivery: parcel.collection_centre?.is_delivery,
+                collection_centre: {
+                    name: parcel.collection_centre?.name,
+                    isDelivery: parcel.collection_centre?.is_delivery,
+                }
             });
         }
 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -47,7 +47,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
         .limit(1, { foreignTable: "clients" })
         .limit(1, { foreignTable: "collection_centres" })
         .eq("events.new_parcel_status", "Shipping Labels Downloaded")
-        .order("name", { foreignTable: "collection_centres"})
+        .order("name", { foreignTable: "collection_centres" })
         .order("address_postcode", { foreignTable: "clients" })
         .order("timestamp", { foreignTable: "events", ascending: false });
 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -108,10 +108,7 @@ type DriverPdfResponse =
 
 type DriverPdfErrorType = ParcelsForDeliveryErrorType;
 
-const pushRowInfo = (
-    array: DriverOverviewTableData[],
-    parcel: ParcelForDelivery
-): undefined => {
+const pushRowInfo = (array: DriverOverviewTableData[], parcel: ParcelForDelivery): undefined => {
     const client = parcel.client;
     const clientIsActive = parcel.client.is_active;
     array.push({

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -72,7 +72,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
         .in("primary_key", parcelIds)
         .limit(1, { foreignTable: "clients" })
         .limit(1, { foreignTable: "collection_centres" })
-        .eq("events.new_parcel_status", "Shipping Labels Downloaded")
+        .eq("events.new_parcel_status", "Shipping Labels Downloaded");
 
     if (error) {
         const logId = await logErrorReturnLogId("Error with fetch: Parcels", error);

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -4,7 +4,10 @@ import React from "react";
 import supabase from "@/supabaseClient";
 import { Schema } from "@/databaseUtils";
 import PdfButton from "@/components/PdfButton/PdfButton";
-import DriverOverviewPdf, { DriverOverviewTablesData, DriverOverviewRowData } from "@/pdf/DriverOverview/DriverOverviewPdf";
+import DriverOverviewPdf, {
+    DriverOverviewTablesData,
+    DriverOverviewRowData,
+} from "@/pdf/DriverOverview/DriverOverviewPdf";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { displayNameForDeletedClient, formatDateToDate } from "@/common/format";
 import { Dayjs } from "dayjs";

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -108,6 +108,33 @@ type DriverPdfResponse =
 
 type DriverPdfErrorType = ParcelsForDeliveryErrorType;
 
+const pushRowInfo = (
+    array: DriverOverviewTableData[],
+    parcel: ParcelForDelivery
+): undefined => {
+    const client = parcel.client;
+    const clientIsActive = parcel.client.is_active;
+    array.push({
+        name: clientIsActive ? client?.full_name ?? "" : displayNameForDeletedClient,
+        address: {
+            line1: client?.address_1 ?? "",
+            line2: client?.address_2 ?? null,
+            town: client?.address_town ?? null,
+            county: client?.address_county ?? null,
+            postcode: client?.address_postcode,
+        },
+        contact: clientIsActive ? client?.phone_number ?? "" : "-",
+        packingDate: formatDateToDate(parcel.packing_date) ?? null,
+        instructions: clientIsActive ? client?.delivery_instructions ?? "" : "-",
+        clientIsActive: clientIsActive,
+        numberOfLabels: parcel.labelCount,
+        collection_centre: {
+            name: parcel.collection_centre?.name,
+            isDelivery: parcel.collection_centre?.is_delivery,
+        },
+    });
+};
+
 const getDriverPdfData = async (parcelIds: string[]): Promise<DriverPdfResponse> => {
     const clientInformation = [];
     const { data: parcels, error: parcelsError } = await getParcelsForDelivery(parcelIds);
@@ -116,32 +143,6 @@ const getDriverPdfData = async (parcelIds: string[]): Promise<DriverPdfResponse>
     }
     const collections: DriverOverviewTableData[] = [];
     const deliveries: DriverOverviewTableData[] = [];
-    const pushRowInfo = (
-        array: DriverOverviewTableData[],
-        parcel: ParcelForDelivery
-    ): undefined => {
-        const client = parcel.client;
-        const clientIsActive = parcel.client.is_active;
-        array.push({
-            name: clientIsActive ? client?.full_name ?? "" : displayNameForDeletedClient,
-            address: {
-                line1: client?.address_1 ?? "",
-                line2: client?.address_2 ?? null,
-                town: client?.address_town ?? null,
-                county: client?.address_county ?? null,
-                postcode: client?.address_postcode,
-            },
-            contact: clientIsActive ? client?.phone_number ?? "" : "-",
-            packingDate: formatDateToDate(parcel.packing_date) ?? null,
-            instructions: clientIsActive ? client?.delivery_instructions ?? "" : "-",
-            clientIsActive: clientIsActive,
-            numberOfLabels: parcel.labelCount,
-            collection_centre: {
-                name: parcel.collection_centre?.name,
-                isDelivery: parcel.collection_centre?.is_delivery,
-            },
-        });
-    };
 
     for (const parcel of parcels) {
         if (parcel.collection_centre?.is_delivery) {

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -42,14 +42,15 @@ type ParcelsForDeliveryErrorType = "parcelFetchFailed" | "noMatchingClient" | "n
 const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDeliveryResponse> => {
     const { data, error } = await supabase
         .from("parcels")
-        .select("*, client:clients(*), events(event_data), collection_centre:collection_centres(*), collection_centres(name), clients(address_postcode)")
+        .select(
+            "*, client:clients(*), events(event_data), collection_centre:collection_centres(*), collection_centres(name), clients(address_postcode)"
+        )
         .in("primary_key", parcelIds)
         .limit(1, { foreignTable: "clients" })
         .limit(1, { foreignTable: "collection_centres" })
         .eq("events.new_parcel_status", "Shipping Labels Downloaded")
         .order("collection_centres(name)")
         .order("clients(address_postcode)");
-
 
     if (error) {
         const logId = await logErrorReturnLogId("Error with fetch: Parcels", error);
@@ -130,9 +131,8 @@ const transformParcelDataToTableData = (parcels: ParcelForDelivery[]): DriverOve
     );
 
     return {
-        collections: transformedParcels
-            .filter((parcel) => !parcel.isDelivery),
-        deliveries: transformedParcels.filter((parcel) => parcel.isDelivery)
+        collections: transformedParcels.filter((parcel) => !parcel.isDelivery),
+        deliveries: transformedParcels.filter((parcel) => parcel.isDelivery),
     };
 };
 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -47,7 +47,7 @@ type ParcelsForDeliveryResponse =
           error: { type: ParcelsForDeliveryErrorType; logId: string };
       };
 
-type ParcelsForDeliveryErrorType = "parcelFetchFailed" | "noMatchingClient";
+type ParcelsForDeliveryErrorType = "parcelFetchFailed" | "noMatchingClient" | "noCollectionCentre";
 
 const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDeliveryResponse> => {
     const { data, error } = await supabase
@@ -77,7 +77,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             const logId = await logErrorReturnLogId(
                 "Error with fetch: Parcels. No collection centre found"
             );
-            return { data: null, error: { type: "noMatchingClient", logId: logId } }; //this needs to be changed
+            return { data: null, error: { type: "noCollectionCentre", logId: logId } };
         }
 
         let labelCount: number = 0;

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -125,10 +125,8 @@ const pushRowInfo = (array: DriverOverviewRowData[], parcel: ParcelForDelivery):
         instructions: clientIsActive ? client?.delivery_instructions ?? "" : "-",
         clientIsActive: clientIsActive,
         numberOfLabels: parcel.labelCount,
-        collection_centre: {
-            name: parcel.collection_centre?.name,
-            isDelivery: parcel.collection_centre?.is_delivery,
-        },
+        collectionCentre: parcel.collection_centre?.name,
+        isDelivery: parcel.collection_centre?.is_delivery,
     });
 };
 


### PR DESCRIPTION
## What's changed
The driver overview PDF groups parcels by collection and delivery
It shows two separate tables with the name 'Collections' or 'Deliveries' with the icon
Collections show the collection centre name and Deliveries show the address
On the PDF, collections are ordered / grouped by collection centre and deliveries are ordered by postcode

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| Collections and deliveries together ordered by name ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/efbb570d-556f-4499-b7fc-988f8c6590fd) | Deliveries ordered by postcode ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/a1e135e9-0b62-4aa1-8ecd-e57aad949e6b) Collections ordered by collection centre ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/b5139bd4-a212-4036-b00b-fe74b7f4facf) When collection or delivery only, the other table is not shown ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167894215/b628fd7c-919a-4729-9cc8-fd10987b7738) |


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`
