### PR TITLE
VFB-201: Remove new packing slot from table if error on creation

### DIFF
--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -165,6 +165,7 @@ const PackingSlotsTable: React.FC = () => {
                 setErrorMessage(
                     `Failed to add the packing slot. Log ID: ${insertPackingSlotError.logId}`
                 );
+                setRows((rows) => rows.slice(0, -1));
                 void sendAuditLog({
                     ...baseAuditLog,
                     wasSuccess: false,


### PR DESCRIPTION
## What's changed
If there is an error when creating a new packing slot, the new row now disappears.

## Screenshots / Videos
When adding "test" slot. Now is not shown once the error has occurred.
| Before     | After      |
|------------|------------|
| ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/8f78c7c4-0f31-4e31-92c1-b335c7675c99) | ![image](https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/assets/167985147/30ea4232-c3b9-40ac-adf9-ae971ceecefb) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test:e2e`
