### PR TITLE
VFB-283 implement full typescript linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "plugin:cypress/recommended",
     "plugin:import/recommended",
     "plugin:import/typescript",
+    "plugin:@typescript-eslint/recommended",
     "prettier"
   ],
   "rules": {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,9 +19,18 @@ export default defineConfig({
                 },
             });
 
+            if (
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_USER === null ||
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS === null
+            ) {
+                throw new Error(
+                    "CYPRESS_TEST_USER and CYPRESS_TEST_PASS must be set in .env.local"
+                );
+            }
+
             config.env = {
-                TEST_USER: process.env.NEXT_PUBLIC_CYPRESS_TEST_USER!,
-                TEST_PASS: process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS!,
+                TEST_USER: process.env.NEXT_PUBLIC_CYPRESS_TEST_USER,
+                TEST_PASS: process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS,
             };
 
             return config;

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -15,6 +15,7 @@ import "@cypress/code-coverage/support";
 import "cypress-axe";
 
 declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
         /* eslint-disable no-unused-vars */
         interface Chainable {
@@ -26,7 +27,7 @@ declare global {
     }
 }
 
-const loginWithRetry = (iteration: number = 0): void => {
+const loginWithRetry = (iteration = 0): void => {
     if (iteration >= 4) {
         // This only ever seems to happen on GH Actions on the first test, so we can just log and move on
         // Redirects are tested by the auth spec

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -23,6 +23,7 @@ import { mount } from "cypress/react18";
 // Alternatively, can be defined in cypress/support/component.d.ts
 // with a <reference path="./component" /> at the top of your spec.
 declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
         /* eslint-disable no-unused-vars */
         interface Chainable {

--- a/src/app/admin/auditLogTable/AuditLogTable.tsx
+++ b/src/app/admin/auditLogTable/AuditLogTable.tsx
@@ -79,7 +79,7 @@ const AuditLogTable: React.FC = () => {
     return (
         <>
             {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
-            <ServerPaginatedTable<AuditLogRow, DbAuditLogRow>
+            <ServerPaginatedTable<AuditLogRow, DbAuditLogRow, never>
                 dataPortion={auditLogDataPortion}
                 headerKeysAndLabels={auditLogTableHeaderKeysAndLabels}
                 defaultShownHeaders={[

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Client.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Client.tsx
@@ -47,7 +47,7 @@ const getClientLinkDetailsOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: ClientLinkDetailsError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedClientFetch":
             errorMessage = "Failed to fetch client's details.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/CollectionCentre.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/CollectionCentre.tsx
@@ -42,7 +42,7 @@ const getCollectionCentreNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: CollectionCentreNameError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedCollectionCentreNameFetch":
             errorMessage = "Failed to fetch collection centre name.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Event.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Event.tsx
@@ -39,7 +39,7 @@ const getEventNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: EventNameError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedEventFetch":
             errorMessage = "Failed to fetch event data.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Lists.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Lists.tsx
@@ -39,7 +39,7 @@ const getListIngredientNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: ListsIngredientError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedListsFetch":
             errorMessage = "Failed to fetch ingredient name.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/ListsHotel.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/ListsHotel.tsx
@@ -39,7 +39,7 @@ const getListsHotelIngredientNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: ListsHotelIngredientError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedListsHotelFetch":
             errorMessage = "Failed to fetch ingredient name.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/PackingSlot.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/PackingSlot.tsx
@@ -39,7 +39,7 @@ const getPackingSlotNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: PackingSlotNameError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedPackingSlotsFetch":
             errorMessage = "Failed to fetch packing slots name.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Parcel.tsx
@@ -64,7 +64,7 @@ const getParcelLinkDetailsOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: ParcelLinkError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedParcelOverviewDetailsFetch":
             errorMessage = "Failed to fetch parcel details.";

--- a/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
+++ b/src/app/admin/auditLogTable/auditLogModal/auditLogModalRows/Profile.tsx
@@ -52,7 +52,7 @@ const getProfileNameOrErrorMessage = async (
 };
 
 const getErrorMessage = (error: ProfileNameError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedProfileFetch":
             errorMessage = "Failed to fetch profile data.";

--- a/src/app/admin/auditLogTable/format.ts
+++ b/src/app/admin/auditLogTable/format.ts
@@ -8,7 +8,7 @@ export const auditLogTableColumnDisplayFunctions = {
 };
 
 export const getAuditLogErrorMessage = (error: AuditLogError | AuditLogCountError): string => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error.type) {
         case "failedAuditLogFetch":
             errorMessage = "Failed to fetch audit log.";

--- a/src/app/admin/auditLogTable/sortFunctions.ts
+++ b/src/app/admin/auditLogTable/sortFunctions.ts
@@ -4,27 +4,27 @@ import { AuditLogRow, AuditLogSortMethod } from "./types";
 export const auditLogTableSortableColumns: SortOptions<AuditLogRow, AuditLogSortMethod>[] = [
     {
         key: "action",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("action", { ascending: sortDirection === "asc" }),
     },
     {
         key: "createdAt",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("created_at", { ascending: sortDirection === "asc" }),
     },
     {
         key: "actorName",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("actor_name", { ascending: sortDirection === "asc" }),
     },
     {
         key: "wasSuccess",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("wasSuccess", { ascending: sortDirection === "asc" }),
     },
     {
         key: "logId",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("log_id", { ascending: sortDirection === "asc" }),
     },
 ];

--- a/src/app/admin/common/RefreshPageButton.tsx
+++ b/src/app/admin/common/RefreshPageButton.tsx
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowsRotate } from "@fortawesome/free-solid-svg-icons/faArrowsRotate";
 import React from "react";
 
-const RefreshPageButton: React.FC<{}> = () => {
+const RefreshPageButton: React.FC = () => {
     const refreshPage = (): void => {
         window.location.reload();
     };

--- a/src/app/admin/createUser/CreateUserForm.tsx
+++ b/src/app/admin/createUser/CreateUserForm.tsx
@@ -22,7 +22,7 @@ import { InviteUserError, adminInviteUser } from "@/server/adminInviteUser";
 import RefreshPageButton from "@/app/admin/common/RefreshPageButton";
 import { UserRole } from "@/databaseUtils";
 
-export interface InviteUserFields {
+export interface InviteUserFields extends Record<string, UserRole | string> {
     email: string;
     role: UserRole;
     firstName: string;
@@ -62,7 +62,7 @@ const getServerErrorMessage = (serverError: InviteUserError): string => {
 
 const formSections = [AccountDetails, UserRoleCard, UserDetailsCard];
 
-const CreateUserForm: React.FC<{}> = () => {
+const CreateUserForm: React.FC = () => {
     const [fields, setFields] = useState(initialFields);
     const [formErrors, setFormErrors] = useState(initialFormErrors);
 

--- a/src/app/admin/deleteUser/DeleteUserDialog.tsx
+++ b/src/app/admin/deleteUser/DeleteUserDialog.tsx
@@ -60,11 +60,11 @@ const DeleteUserDialog: React.FC<Props> = (props) => {
                 success: true,
                 message: (
                     <>
-                        User <b>{props.userToDelete!.email}</b> deleted successfully.
+                        User <b>{props.userToDelete.email}</b> deleted successfully.
                     </>
                 ),
             });
-            void logInfoReturnLogId(`${props.userToDelete?.email} deleted successfully.`);
+            void logInfoReturnLogId(`${props.userToDelete.email} deleted successfully.`);
         }
 
         props.setUserToDelete(null);

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -120,13 +120,14 @@ const PackingSlotsTable: React.FC = () => {
                         const packingSlots = await fetchPackingSlots();
                         setRows(packingSlots);
                     } catch (error) {
-                        if (error) {
-                            setRows([]);
+                        setRows([]);
+                        setErrorMessage("Error fetching data, please reload");
+                        if (error instanceof Error) {
                             void logErrorReturnLogId(
                                 "Error with fetch: Packing slots subscription",
+                                {},
                                 error
                             );
-                            setErrorMessage("Error fetching data, please reload");
                         }
                     }
                 }

--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -126,7 +126,7 @@ const UsersTable: React.FC = () => {
     return (
         <>
             {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
-            <ServerPaginatedTable<UserRow, DbUserRow>
+            <ServerPaginatedTable<UserRow, DbUserRow, string | string[]>
                 dataPortion={users}
                 headerKeysAndLabels={usersTableHeaderKeysAndLabels}
                 columnDisplayFunctions={userTableColumnDisplayFunctions}

--- a/src/app/admin/usersTable/sortableColumns.ts
+++ b/src/app/admin/usersTable/sortableColumns.ts
@@ -4,37 +4,37 @@ import { UserRow, UsersSortMethod } from "./types";
 export const usersSortableColumns: SortOptions<UserRow, UsersSortMethod>[] = [
     {
         key: "firstName",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("first_name", { ascending: sortDirection === "asc" }),
     },
     {
         key: "lastName",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("last_name", { ascending: sortDirection === "asc" }),
     },
     {
         key: "userRole",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("role", { ascending: sortDirection === "asc" }),
     },
     {
         key: "email",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("email", { ascending: sortDirection === "asc" }),
     },
     {
         key: "telephoneNumber",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("telephone_number", { ascending: sortDirection === "asc" }),
     },
     {
         key: "createdAt",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("created_at", { ascending: sortDirection === "asc" }),
     },
     {
         key: "updatedAt",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("updated_at", { ascending: sortDirection === "asc" }),
     },
 ];

--- a/src/app/admin/usersTable/types.ts
+++ b/src/app/admin/usersTable/types.ts
@@ -5,7 +5,8 @@ import { DbUserRow, UserRole } from "@/databaseUtils";
 
 export type UsersFilterMethod<State> = ServerSideFilterMethod<DbUserRow, State>;
 export type UsersFilter<State> = ServerSideFilter<UserRow, State, DbUserRow>;
-export type UsersFilters = (UsersFilter<string> | UsersFilter<string[]>)[];
+export type UsersFilterAllStates = UsersFilter<string> | UsersFilter<string[]>;
+export type UsersFilters = UsersFilterAllStates[];
 export type UsersSortMethod = ServerSideSortMethod<DbUserRow>;
 export type UsersSortState = SortState<UserRow, UsersSortMethod>;
 

--- a/src/app/calendar/parcelCalendarFunctions.ts
+++ b/src/app/calendar/parcelCalendarFunctions.ts
@@ -26,12 +26,15 @@ export const parcelsToCollectionEvents = (
     colorMap: LocationColorMap
 ): CalendarEvent[] => {
     return parcels.map((parcel) => {
-        const fullName = parcel.clients!.full_name ?? "";
+        const fullName = parcel.clients?.full_name ?? "";
 
-        const collectionStart = new Date(parcel.collection_datetime!);
+        if (!parcel.collection_datetime) {
+            throw new Error(`Parcel ${parcel.primary_key} has no collection_datetime`);
+        }
+        const collectionStart = new Date(parcel.collection_datetime);
         const collectionEnd = new Date(collectionStart.getTime() + COLLECTION_DURATION_MS);
 
-        const collectionCentre = parcel.collection_centres!.name ?? "default";
+        const collectionCentre = parcel.collection_centres?.name ?? "default";
         const location = collectionCentre !== "default" ? `[${collectionCentre}]` : "";
 
         const eventColor = colorMap[collectionCentre] ?? colorMap.default;

--- a/src/app/clients/ExpandedClientDetailsFallback.tsx
+++ b/src/app/clients/ExpandedClientDetailsFallback.tsx
@@ -15,7 +15,7 @@ const clientDetailFields = [
     "COLLECTION",
 ];
 
-const ExpandedClientDetailsFallback: React.FC<{}> = () => {
+const ExpandedClientDetailsFallback: React.FC = () => {
     return (
         <>
             <DataViewerFallback fieldPlaceholders={clientDetailFields} />;

--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -32,7 +32,7 @@ import { getIsClientActiveErrorMessage, getDeleteClientErrorMessage } from "./fo
 import { getClientParcelsDetails } from "../getClientParcelsData";
 import { saveParcelStatus } from "@/app/parcels/ActionBar/Statuses";
 
-const ClientsPage: React.FC<{}> = () => {
+const ClientsPage: React.FC = () => {
     const [isLoadingForFirstTime, setIsLoadingForFirstTime] = useState(true);
     const [isLoading, setIsLoading] = useState(true);
     const [clientsDataPortion, setClientsDataPortion] = useState<ClientsTableRow[]>([]);
@@ -178,7 +178,7 @@ const ClientsPage: React.FC<{}> = () => {
                 <>
                     {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
                     <TableSurface>
-                        <ServerPaginatedTable<ClientsTableRow, DbClientRow>
+                        <ServerPaginatedTable<ClientsTableRow, DbClientRow, string>
                             dataPortion={clientsDataPortion}
                             paginationConfig={{
                                 enablePagination: true,

--- a/src/app/clients/clientsTable/sortableColumns.ts
+++ b/src/app/clients/clientsTable/sortableColumns.ts
@@ -3,22 +3,22 @@ import { ClientsSortMethod, ClientsTableRow } from "./types";
 const clientsSortableColumns: SortOptions<ClientsTableRow, ClientsSortMethod>[] = [
     {
         key: "fullName",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("full_name", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familyCategory",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_count", { ascending: sortDirection === "asc" }),
     },
     {
         key: "addressPostcode",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("address_postcode", { ascending: sortDirection === "asc" }),
     },
     {
         key: "phoneNumber",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("phone_number", { ascending: sortDirection === "asc" }),
     },
 ];

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/app/errorStylingandMessages";
 import LinkButton from "@/components/Buttons/LinkButton";
 
-const GlobalError: React.FC<{}> = () => {
+const GlobalError: React.FC = () => {
     return (
         <ErrorCenterer>
             <ErrorPanel elevation={5}>

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -22,7 +22,7 @@ import { buildClientSideTextFilter, filterRowByText } from "@/components/Tables/
 import { ClientSideFilter } from "@/components/Tables/Filters";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
-type ListFilter = ClientSideFilter<ListRow, any>;
+type ListFilter = ClientSideFilter<ListRow, string>;
 
 export interface ListRow {
     primaryKey: string;
@@ -298,7 +298,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
             <EditModal onClose={() => setModal(undefined)} data={modal} key={modal?.primary_key} />
             <TableSurface>
                 <CommentBox originalComment={comment} />
-                <ClientPaginatedTable<ListRow>
+                <ClientPaginatedTable<ListRow, string>
                     headerKeysAndLabels={listsHeaderKeysAndLabels}
                     toggleableHeaders={toggleableHeaders}
                     dataPortion={listData}

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -75,7 +75,7 @@ const formatListData = (listsData: Schema["lists"][]): ListRow[] => {
     );
 };
 
-const ListsPage: React.FC<{}> = () => {
+const ListsPage: React.FC = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [listData, setListData] = useState<ListRow[]>([]);
     const [comment, setComment] = useState("");

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -11,7 +11,7 @@ const Centerer = styled.div`
     height: 80vh;
 `;
 
-const Loading: React.FC<{}> = () => {
+const Loading: React.FC = () => {
     return (
         <main>
             <Centerer>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/app/errorStylingandMessages";
 import LinkButton from "@/components/Buttons/LinkButton";
 
-const NotFoundPage: React.FC<{}> = () => {
+const NotFoundPage: React.FC = () => {
     return (
         <ErrorCenterer>
             <ErrorPanel elevation={5}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from "next/navigation";
 import React from "react";
 
-const Home: React.FC<{}> = () => {
+const Home: React.FC = () => {
     return redirect("/");
 };
 

--- a/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
@@ -13,7 +13,7 @@ export const getUpdateErrorMessage = ({
     parcelId: string | null;
     error: FetchParcelError | UpdateParcelError | null;
 }): string | undefined => {
-    let errorMessage: string = "";
+    let errorMessage = "";
     switch (error?.type) {
         case "noMatchingParcels":
             errorMessage = "No parcel in the database matches the selected parcel.";
@@ -52,7 +52,7 @@ export const packingDateOrSlotUpdate = async (
     const packingDateOrSlotDbUpdate = async (
         fieldToUpdate: FieldToUpdate
     ): Promise<PostgrestSingleResponse<null>> => {
-        return await supabase
+        return supabase
             .from("parcels")
             .update(fieldToUpdate, { count: "exact" })
             .eq("primary_key", parcel.parcelId);

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -86,7 +86,9 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
         setDriverName(trimmedDriverName.length !== 0 ? trimmedDriverName : null);
     };
     const onDateChange = (newDate: Dayjs | null): void => {
-        setDate(newDate!);
+        if (newDate) {
+            setDate(newDate);
+        }
     };
 
     const onClose = (): void => {

--- a/src/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes.ts
+++ b/src/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes.ts
@@ -1,6 +1,6 @@
 import { getParcelPostcodesByEvent } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 
-type DataCallbackType = (postcodes: (string | null)[]) => any;
+type DataCallbackType = (postcodes: (string | null)[]) => void;
 type ErrorCallbackType = (msg: string) => void;
 
 export const getDuplicateDownloadedPostcodes = async (

--- a/src/app/parcels/ExpandedParcelDetailsFallback.tsx
+++ b/src/app/parcels/ExpandedParcelDetailsFallback.tsx
@@ -15,7 +15,7 @@ const clientDetailFields = [
     "COLLECTION",
 ];
 
-const ExpandedParcelDetailsFallback: React.FC<{}> = () => {
+const ExpandedParcelDetailsFallback: React.FC = () => {
     return (
         <>
             <DataViewerFallback fieldPlaceholders={clientDetailFields} />;

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -240,17 +240,21 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
         const packingDate = getDbDate(dayjs(fields.packingDate));
 
         let collectionDateTime = null;
-        if (fields.shippingMethod === "Collection") {
+        if (
+            fields.shippingMethod === "Collection" &&
+            fields.collectionDate &&
+            fields.collectionSlot
+        ) {
             collectionDateTime = mergeDateAndTime(
-                fields.collectionDate!,
-                fields.collectionSlot!
+                fields.collectionDate,
+                fields.collectionSlot
             ).toISOString();
         }
 
         const isDelivery = fields.shippingMethod === "Delivery";
 
         const parcelRecord = {
-            client_id: (clientId || fields.clientId)!,
+            client_id: clientId || fields.clientId || "",
             packing_date: packingDate,
             packing_slot: fields.packingSlot,
             voucher_number: fields.voucherNumber,

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -44,8 +44,9 @@ import { PreTableControls, parcelTableColumnStyleOptions } from "./styles";
 import { DbParcelRow } from "@/databaseUtils";
 import { searchForBreakPoints } from "./conditionalStyling";
 import { Dayjs } from "dayjs";
+import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
 
-const ParcelsPage: React.FC<{}> = () => {
+const ParcelsPage: React.FC = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [parcelsDataPortion, setParcelsDataPortion] = useState<ParcelsTableRow[]>([]);
     const [filteredParcelCount, setFilteredParcelCount] = useState<number>(0);
@@ -74,8 +75,12 @@ const ParcelsPage: React.FC<{}> = () => {
     const startPoint = (currentPage - 1) * parcelCountPerPage;
     const endPoint = currentPage * parcelCountPerPage - 1;
 
-    const [primaryFilters, setPrimaryFilters] = useState<ParcelsFilter<any>[]>([]);
-    const [additionalFilters, setAdditionalFilters] = useState<ParcelsFilter<any>[]>([]);
+    const [primaryFilters, setPrimaryFilters] = useState<
+        (ParcelsFilter<string> | ParcelsFilter<DateRangeState> | ParcelsFilter<string[]>)[]
+    >([]);
+    const [additionalFilters, setAdditionalFilters] = useState<
+        (ParcelsFilter<string> | ParcelsFilter<DateRangeState> | ParcelsFilter<string[]>)[]
+    >([]);
 
     const [areFiltersLoadingForFirstTime, setAreFiltersLoadingForFirstTime] =
         useState<boolean>(true);
@@ -313,7 +318,11 @@ const ParcelsPage: React.FC<{}> = () => {
                 <>
                     {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
                     <TableSurface>
-                        <ServerPaginatedTable<ParcelsTableRow, DbParcelRow>
+                        <ServerPaginatedTable<
+                            ParcelsTableRow,
+                            DbParcelRow,
+                            string | DateRangeState | string[]
+                        >
                             dataPortion={parcelsDataPortion}
                             isLoading={isLoading}
                             paginationConfig={{

--- a/src/app/parcels/parcelsTable/sortableColumns.ts
+++ b/src/app/parcels/parcelsTable/sortableColumns.ts
@@ -5,7 +5,7 @@ import { SortOrder } from "react-data-table-component";
 const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] = [
     {
         key: "fullName",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
                 .order("client_full_name", { ascending: sortDirection === "asc" })
@@ -18,7 +18,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "familyCategory",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
                 .order("family_count", { ascending: sortDirection === "asc" })
@@ -31,7 +31,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "addressPostcode",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
                 .order("client_address_postcode", { ascending: sortDirection === "asc" })
@@ -43,7 +43,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "phoneNumber",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
                 .order("client_phone_number", { ascending: sortDirection === "asc" })
@@ -56,7 +56,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "voucherNumber",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("voucher_number", { ascending: sortDirection === "asc" })
                 .order("packing_date")
@@ -69,7 +69,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "deliveryCollection",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("is_delivery", { ascending: sortDirection === "asc" })
                 .order("collection_centre_name")
@@ -81,7 +81,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "packingDate",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("packing_date", { ascending: sortDirection === "asc" })
                 .order("packing_slot_order")
@@ -93,7 +93,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "packingSlot",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("packing_slot_order", { ascending: sortDirection === "asc" })
                 .order("packing_date")
@@ -105,7 +105,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "lastStatus",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("last_status_workflow_order", { ascending: sortDirection === "asc" })
                 .order("packing_date")
@@ -118,7 +118,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
     },
     {
         key: "createdAt",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query
                 .order("created_at", { ascending: sortDirection === "asc" })
                 .order("packing_date")
@@ -139,6 +139,6 @@ export const defaultParcelsSortConfig: DefaultSortConfig = {
 export const defaultParcelsSort: ParcelsSortMethod =
     parcelsSortableColumns.find(
         (column) => column.key === defaultParcelsSortConfig.defaultColumnHeaderKey
-    )?.sortMethod ?? ((query) => query);
+    )?.sortMethod ?? ((_, query) => query);
 
 export default parcelsSortableColumns;

--- a/src/app/parcels/parcelsTable/types.ts
+++ b/src/app/parcels/parcelsTable/types.ts
@@ -77,11 +77,11 @@ export type ParcelStatusesReturnType =
 
 export type ParcelsFilterMethod<State> = ServerSideFilterMethod<DbParcelRow, State>;
 export type ParcelsFilter<State> = ServerSideFilter<ParcelsTableRow, State, DbParcelRow>;
-export type ParcelsFilters = (
+export type ParcelsFiltersAllStates =
     | ParcelsFilter<string>
     | ParcelsFilter<string[]>
-    | ParcelsFilter<DateRangeState>
-)[];
+    | ParcelsFilter<DateRangeState>;
+export type ParcelsFilters = ParcelsFiltersAllStates[];
 export type ParcelsSortMethod = ServerSideSortMethod<DbParcelRow>;
 export type ParcelsSortState = SortState<ParcelsTableRow, ParcelsSortMethod>;
 

--- a/src/app/reports/reportsTable/ReportsPage.tsx
+++ b/src/app/reports/reportsTable/ReportsPage.tsx
@@ -15,7 +15,7 @@ import reportsSortableColumns from "./sortableColumns";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
 import { reportsTableColumnStyleOptions } from "@/app/reports/reportsTable/styles";
 
-const ReportsPage: React.FC<{}> = () => {
+const ReportsPage: React.FC = () => {
     const [isLoadingForFirstTime, setIsLoadingForFirstTime] = useState(true);
     const [isLoading, setIsLoading] = useState(true);
     const [reportsDataPortion, setReportsDataPortion] = useState<ReportsTableRow[]>([]);
@@ -98,7 +98,7 @@ const ReportsPage: React.FC<{}> = () => {
                 <>
                     {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
                     <TableSurface>
-                        <ServerPaginatedTable<ReportsTableRow, DbReportRow>
+                        <ServerPaginatedTable<ReportsTableRow, DbReportRow, never>
                             dataPortion={reportsDataPortion}
                             paginationConfig={{
                                 enablePagination: true,

--- a/src/app/reports/reportsTable/sortableColumns.ts
+++ b/src/app/reports/reportsTable/sortableColumns.ts
@@ -4,82 +4,82 @@ import { ReportsSortMethod, ReportsTableRow } from "@/app/reports/reportsTable/t
 const reportsSortableColumns: SortOptions<ReportsTableRow, ReportsSortMethod>[] = [
     {
         key: "weekCommencing",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("week_commencing", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize1",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_1", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize2",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_2", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize3",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_3", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize4",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_4", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize5",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_5", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize6",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_6", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize7",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_7", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize8",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_8", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize9",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_9", { ascending: sortDirection === "asc" }),
     },
     {
         key: "familySize10Plus",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("family_size_10_plus", { ascending: sortDirection === "asc" }),
     },
     {
         key: "total",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("total_parcels", { ascending: sortDirection === "asc" }),
     },
     {
         key: "cat",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("cat", { ascending: sortDirection === "asc" }),
     },
     {
         key: "dog",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("dog", { ascending: sortDirection === "asc" }),
     },
     {
         key: "catAndDog",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("cat_and_dog", { ascending: sortDirection === "asc" }),
     },
     {
         key: "totalWithPets",
-        sortMethod: (query, sortDirection) =>
+        sortMethod: (sortDirection, query) =>
             query.order("total_with_pets", { ascending: sortDirection === "asc" }),
     },
 ];

--- a/src/app/roles.tsx
+++ b/src/app/roles.tsx
@@ -55,7 +55,9 @@ interface RoleUpdateContextType {
 
 export const RoleUpdateContext = createContext<RoleUpdateContextType>({
     role: null,
-    setRole: (_role) => {},
+    setRole: (_role) => {
+        throw new Error("Context implementation not provided");
+    },
 });
 
 export const RoleManager: React.FC<Props> = ({ children }) => {

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -42,7 +42,7 @@ export type FetchParcelResponse =
     | { data: null; error: FetchParcelError };
 
 export type FetchParcelErrorType = "failedToFetchParcel" | "noMatchingParcels";
-export interface FetchParcelError {
+export interface FetchParcelError extends Record<string, string> {
     type: FetchParcelErrorType;
     logId: string;
 }
@@ -118,11 +118,11 @@ export const getActiveCollectionCentres = async (
         return { data: null, error: { type: "collectionCentresFetchFailed", logId: logId } };
     }
 
-    const collectionCentresLabelsAndValues: CollectionCentresLabelsAndValues = data!
+    const collectionCentresLabelsAndValues: CollectionCentresLabelsAndValues = data
         .filter((collectionCentre) => collectionCentre.name !== "Delivery")
         .map((collectionCentre) => [collectionCentre.name, collectionCentre.primary_key]);
 
-    const deliveryPrimaryKey = data!.filter(
+    const deliveryPrimaryKey = data.filter(
         (collectionCentre) => collectionCentre.name === "Delivery"
     )[0].primary_key;
 

--- a/src/common/subscriptionStatusRequiresErrorMessage.ts
+++ b/src/common/subscriptionStatusRequiresErrorMessage.ts
@@ -7,10 +7,10 @@ export const subscriptionStatusRequiresErrorMessage = (
 ): boolean => {
     switch (status) {
         case "TIMED_OUT":
-            void logErrorReturnLogId(`Channel Timed Out: Subscribe to ${tableName} table`, err);
+            void logErrorReturnLogId(`Channel Timed Out: Subscribe to ${tableName} table`, {}, err);
             return true;
         case "CHANNEL_ERROR":
-            void logErrorReturnLogId(`Channel Error: Subscribe to ${tableName} table`, err);
+            void logErrorReturnLogId(`Channel Error: Subscribe to ${tableName} table`, {}, err);
             return true;
         case "CLOSED":
             void logInfoReturnLogId(`Subscription to ${tableName} table closed`);

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -221,8 +221,7 @@ const Calendar: React.FC<CalendarProps> = ({
     };
 
     const handleDateClick = (info: DateClickArg): void => {
-        const calendarApi = calendarRef.current!.getApi();
-        calendarApi.changeView("timeGridDay", info.dateStr);
+        calendarRef.current && calendarRef.current.getApi().changeView("timeGridDay", info.dateStr);
     };
 
     return (

--- a/src/components/DataViewer/DataViewer.tsx
+++ b/src/components/DataViewer/DataViewer.tsx
@@ -68,11 +68,11 @@ const ButtonsContainer = styled.div`
 `;
 
 const valueIsEmpty = (value: ValueType): boolean => {
-    return (Array.isArray(value) && value.length === 0) || value === "" || value === null;
+    return (Array.isArray(value) && value.length === 0) || value === "";
 };
 
 const formatDisplayValue = (value: ValueType): string => {
-    if (valueIsEmpty(value)) {
+    if (valueIsEmpty(value) || value === null) {
         return "-";
     }
 
@@ -80,7 +80,7 @@ const formatDisplayValue = (value: ValueType): string => {
         return value ? "Yes" : "No";
     }
 
-    return value!.toString();
+    return value.toString();
 };
 
 export interface DataViewerProps {

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -49,9 +49,7 @@ export interface NumberAdultsByGender {
     numberUnknownGender: number;
 }
 
-export interface Fields {
-    [fieldKey: string]: any;
-}
+export type Fields = Record<string, unknown>;
 
 export type FormErrors<SpecificFields extends Fields> = {
     [errorKey in keyof SpecificFields]?: Errors;
@@ -101,7 +99,9 @@ export const onChangeText = <SpecificFields extends Fields>(
         errorSetter({ [key]: errorType } as { [key in keyof FormErrors<SpecificFields>]: Errors });
         if (errorType === Errors.none) {
             const newValue = formattingFunction ? formattingFunction(input) : input;
-            fieldSetter({ [key]: newValue } as { [key in keyof SpecificFields]: any });
+            fieldSetter({ [key]: newValue } as {
+                [key in keyof SpecificFields]: SpecificFields[key];
+            });
         }
     };
 };
@@ -113,7 +113,7 @@ export const onChangeCheckbox = <SpecificFields extends Fields>(
 ): ChangeEventHandler => {
     return (event) => {
         const newObject = { ...currentObject, [event.target.name]: event.target.checked };
-        fieldSetter({ [key]: newObject } as { [key in keyof SpecificFields]: any });
+        fieldSetter({ [key]: newObject } as { [key in keyof SpecificFields]: SpecificFields[key] });
     };
 };
 
@@ -123,7 +123,9 @@ export const onChangeRadioGroup = <SpecificFields extends Fields>(
 ): SelectChangeEventHandler => {
     return (event) => {
         const input = event.target.value;
-        fieldSetter({ [key]: input === "Yes" } as { [key in keyof SpecificFields]: any });
+        fieldSetter({ [key]: input === "Yes" } as {
+            [key in keyof SpecificFields]: SpecificFields[key];
+        });
     };
 };
 
@@ -134,7 +136,7 @@ export const valueOnChangeRadioGroup = <SpecificFields extends Fields>(
 ): SelectChangeEventHandler => {
     return (event) => {
         const input = event.target.value;
-        fieldSetter({ [key]: input } as { [key in keyof SpecificFields]: any });
+        fieldSetter({ [key]: input } as { [key in keyof SpecificFields]: SpecificFields[key] });
         errorSetter({ [key]: Errors.none } as {
             [key in keyof FormErrors<SpecificFields>]: Errors;
         });
@@ -148,7 +150,7 @@ export const valueOnChangeDropdownList = <SpecificFields extends Fields>(
 ): SelectChangeEventHandler => {
     return (event) => {
         const input = event.target.value;
-        fieldSetter({ [key]: input } as { [key in keyof SpecificFields]: any });
+        fieldSetter({ [key]: input } as { [key in keyof SpecificFields]: SpecificFields[key] });
         errorSetter({ [key]: Errors.none } as {
             [key in keyof FormErrors<SpecificFields>]: Errors;
         });
@@ -162,13 +164,13 @@ export const onChangeDateOrTime = <SpecificFields extends Fields>(
     value: Dayjs | null
 ): void => {
     if (value === null || isNaN(Date.parse(value.toString()))) {
-        fieldSetter({ [key]: null } as { [key in keyof SpecificFields]: any });
+        fieldSetter({ [key]: null } as { [key in keyof SpecificFields]: SpecificFields[key] });
         errorSetter({ [key]: Errors.invalid } as {
             [key in keyof FormErrors<SpecificFields>]: Errors;
         });
         return;
     }
-    fieldSetter({ [key]: value } as { [key in keyof SpecificFields]: any });
+    fieldSetter({ [key]: value } as { [key in keyof SpecificFields]: SpecificFields[key] });
     errorSetter({ [key]: Errors.none } as { [key in keyof FormErrors<SpecificFields>]: Errors });
 };
 
@@ -232,6 +234,7 @@ export const checkErrorOnSubmit = <
     return errorExists;
 };
 
+// This function is not type safe, but I don't have the context to fix it right now
 export const getDefaultTextValue = (fields: Fields, fieldKey: keyof Fields): string | undefined => {
-    return fields[fieldKey] ?? undefined;
+    return (fields[fieldKey] as string) ?? undefined;
 };

--- a/src/components/Icons/CongestionChargeAppliesIcon.tsx
+++ b/src/components/Icons/CongestionChargeAppliesIcon.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faCopyright } from "@fortawesome/free-solid-svg-icons";
 
-const CongestionChargeAppliesIcon: React.FC<{}> = () => {
+const CongestionChargeAppliesIcon: React.FC = () => {
     return <Icon icon={faCopyright} onHoverText="Congestion charge applies" color="red" />;
 };
 

--- a/src/components/Icons/FlaggedForAttentionIcon.tsx
+++ b/src/components/Icons/FlaggedForAttentionIcon.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Icon from "@/components/Icons/Icon";
 import { faFlag } from "@fortawesome/free-solid-svg-icons";
 
-const FlaggedForAttentionIcon: React.FC<{}> = () => {
+const FlaggedForAttentionIcon: React.FC = () => {
     return <Icon icon={faFlag} onHoverText="Flagged for attention" color="orange" />;
 };
 

--- a/src/components/Icons/Icons.cy.tsx
+++ b/src/components/Icons/Icons.cy.tsx
@@ -8,7 +8,7 @@ import SpeechBubbleIcon, { SpeechBubbleProps } from "@/components/Icons/SpeechBu
 import DeliveryIcon from "@/components/Icons/DeliveryIcon";
 import StyleManager from "@/app/themes";
 
-const StyledCongestionChargeAppliesIcon: React.FC<{}> = () => {
+const StyledCongestionChargeAppliesIcon: React.FC = () => {
     return (
         <StyleManager>
             <CongestionChargeAppliesIcon />
@@ -23,14 +23,14 @@ const StyledCollectionIcon: React.FC<CollectionIconProps> = (props) => {
     );
 };
 
-const StyledFlaggedForAttentionIcon: React.FC<{}> = () => {
+const StyledFlaggedForAttentionIcon: React.FC = () => {
     return (
         <StyleManager>
             <FlaggedForAttentionIcon />
         </StyleManager>
     );
 };
-const StyledPhoneIcon: React.FC<{}> = () => {
+const StyledPhoneIcon: React.FC = () => {
     return (
         <StyleManager>
             <PhoneIcon />
@@ -46,7 +46,7 @@ const StyledSpeechBubbleIcon: React.FC<SpeechBubbleProps> = (props) => {
     );
 };
 
-const StyledDeliveryIcon: React.FC<{}> = () => {
+const StyledDeliveryIcon: React.FC = () => {
     return (
         <StyleManager>
             <DeliveryIcon />

--- a/src/components/Modal/Modal.cy.tsx
+++ b/src/components/Modal/Modal.cy.tsx
@@ -17,7 +17,7 @@ describe("General Modal Component", () => {
                 header="Modal Header"
                 headerId="testModal"
                 isOpen={true}
-                onClose={() => {}}
+                onClose={() => undefined}
             >
                 <h1>Modal Content</h1>
             </StyledModal>
@@ -30,7 +30,7 @@ describe("General Modal Component", () => {
                 header="Modal Header"
                 headerId="testModal"
                 isOpen={true}
-                onClose={() => {}}
+                onClose={() => undefined}
             >
                 <h1>Modal Content</h1>
             </StyledModal>
@@ -46,7 +46,7 @@ describe("General Modal Component", () => {
                 header="Modal Header"
                 headerId="testModal"
                 isOpen={false}
-                onClose={() => {}}
+                onClose={() => undefined}
             >
                 <h1>Modal Content</h1>
             </StyledModal>

--- a/src/components/NavigationBar/LightDarkSlider.tsx
+++ b/src/components/NavigationBar/LightDarkSlider.tsx
@@ -51,7 +51,7 @@ const StyledSwitch = styled(Switch)`
     }
 `;
 
-const LightDarkSlider: React.FC<{}> = () => {
+const LightDarkSlider: React.FC = () => {
     const setThemeMode = useContext(ThemeUpdateContext);
     const theme = useTheme();
 

--- a/src/components/NavigationBar/NavigationBar.cy.tsx
+++ b/src/components/NavigationBar/NavigationBar.cy.tsx
@@ -8,7 +8,7 @@ import {
 } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { RoleUpdateContext } from "@/app/roles";
 import StyleManager from "@/app/themes";
-const StyledNavigationBar: React.FC<{}> = () => {
+const StyledNavigationBar: React.FC = () => {
     return (
         <StyleManager>
             <NavigationBar />
@@ -17,16 +17,16 @@ const StyledNavigationBar: React.FC<{}> = () => {
 };
 describe("<NavigationBar />", () => {
     const router: AppRouterInstance = {
-        push: () => {},
-        back: () => {},
-        forward: () => {},
-        replace: () => {},
-        prefetch: () => {},
-        refresh: () => {},
+        push: () => undefined,
+        back: () => undefined,
+        forward: () => undefined,
+        replace: () => undefined,
+        prefetch: () => undefined,
+        refresh: () => undefined,
     };
 
     const role = "admin";
-    const setRole = (): void => {};
+    const setRole = (): void => undefined;
 
     const RouterWrappedNavBar = (
         <RoleUpdateContext.Provider value={{ role, setRole }}>

--- a/src/components/PdfButton/PdfButton.tsx
+++ b/src/components/PdfButton/PdfButton.tsx
@@ -40,7 +40,7 @@ const formatFileName = (fileName: string): string => {
 const PdfButton = <Data, ErrorType extends string>({
     fetchDataAndFileName,
     pdfComponent: PdfComponent,
-    onPdfCreationCompleted = () => {},
+    onPdfCreationCompleted = () => undefined,
     formatName = true,
     disabled = false,
     onPdfCreationFailed,

--- a/src/components/Tables/ChecklistFilter.tsx
+++ b/src/components/Tables/ChecklistFilter.tsx
@@ -4,7 +4,10 @@ import React from "react";
 import CheckboxGroupPopup from "../DataInput/CheckboxGroupPopup";
 import { ServerSideFilter, ServerSideFilterMethod } from "./Filters";
 
-interface ChecklistFilterProps<Data, DbData extends Record<string, any> = {}> {
+interface ChecklistFilterProps<
+    Data,
+    DbData extends Record<string, unknown> = Record<string, never>,
+> {
     key: keyof Data;
     filterLabel: string;
     itemLabelsAndKeys: [string, string][];
@@ -12,7 +15,10 @@ interface ChecklistFilterProps<Data, DbData extends Record<string, any> = {}> {
     method: ServerSideFilterMethod<DbData, string[]>;
 }
 
-export const serverSideChecklistFilter = <Data, DbData extends Record<string, any> = {}>({
+export const serverSideChecklistFilter = <
+    Data,
+    DbData extends Record<string, unknown> = Record<string, never>,
+>({
     key,
     filterLabel,
     itemLabelsAndKeys,
@@ -29,7 +35,7 @@ export const serverSideChecklistFilter = <Data, DbData extends Record<string, an
         filterComponent: function (
             state: string[],
             setState: (state: string[]) => void
-        ): React.ReactElement<any, string | React.JSXElementConstructor<any>> {
+        ): React.ReactNode {
             const onChangeCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
                 const checkboxKey = event.target.name as string;
                 if (event.target.checked) {

--- a/src/components/Tables/DateFilter.tsx
+++ b/src/components/Tables/DateFilter.tsx
@@ -3,7 +3,7 @@ import { ServerSideFilter, ServerSideFilterMethod } from "./Filters";
 import DateRangeInputs, { DateRangeState } from "../DateInputs/DateRangeInputs";
 import dayjs from "dayjs";
 
-interface DateFilterProps<Data, DbData extends Record<string, any>> {
+interface DateFilterProps<Data, DbData extends Record<string, unknown>> {
     key: keyof Data;
     label: string;
     method: ServerSideFilterMethod<DbData, DateRangeState>;
@@ -24,7 +24,7 @@ const areDaysIdentical = (dayA: dayjs.Dayjs | null, dayB: dayjs.Dayjs | null): b
     return dayA && dayB ? dayA.isSame(dayB) : dayA === dayB;
 };
 
-export const serverSideDateFilter = <Data, DbData extends Record<string, any>>({
+export const serverSideDateFilter = <Data, DbData extends Record<string, unknown>>({
     key,
     method,
     initialState,
@@ -38,8 +38,8 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, any>>({
         filterComponent: function (
             state: DateRangeState,
             setState: (state: DateRangeState) => void
-        ): React.ReactElement<any, string | React.JSXElementConstructor<any>> {
-            return <DateRangeInputs range={state} setRange={setState}></DateRangeInputs>;
+        ): React.ReactNode {
+            return <DateRangeInputs range={state} setRange={setState} />;
         },
     };
 };

--- a/src/components/Tables/Table.cy.tsx
+++ b/src/components/Tables/Table.cy.tsx
@@ -221,14 +221,14 @@ const Component: React.FC<TestTableProps> = ({
         enablePagination: false,
     };
 
-    const trueFilterConfig: FilterConfig<ClientSideFilter<TestData, any>> = {
+    const trueFilterConfig: FilterConfig<ClientSideFilter<TestData, string>> = {
         primaryFiltersShown: true,
         primaryFilters: primaryFilters,
         setPrimaryFilters: setPrimaryFilters,
         additionalFiltersShown: false,
     };
 
-    const falseFilterConfig: FilterConfig<ClientSideFilter<TestData, any>> = {
+    const falseFilterConfig: FilterConfig<ClientSideFilter<TestData, never>> = {
         primaryFiltersShown: false,
         additionalFiltersShown: false,
     };
@@ -261,7 +261,7 @@ const Component: React.FC<TestTableProps> = ({
 
     return (
         <StyleManager>
-            <ClientPaginatedTable<TestData>
+            <ClientPaginatedTable<TestData, string>
                 dataPortion={testDataPortion}
                 headerKeysAndLabels={headers}
                 toggleableHeaders={toggleableHeaders}

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -169,8 +169,8 @@ interface Props<Data, DbData extends Record<string, unknown>, PaginationType, Fi
     defaultSortConfig?: DefaultSortConfig;
     filterConfig: FilterConfig<
         PaginationType extends PaginationTypeEnum.Client
-            ? DistributeClientFilter<Data, FilterState> //ClientSideFilter<Data, FilterState>
-            : DistributeServerFilter<Data, FilterState, DbData> //ServerSideFilter<Data, FilterState, DbData>
+            ? DistributeClientFilter<Data, FilterState>
+            : DistributeServerFilter<Data, FilterState, DbData>
     >;
     rowBreakPointConfigs?: BreakPointConfig[];
     defaultShownHeaders?: readonly (keyof Data)[];

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -10,7 +10,7 @@ import {
 } from "./Filters";
 import { TableHeaders } from "./Table";
 
-interface ServerSideTextFilterProps<Data, DbData extends Record<string, any>> {
+interface ServerSideTextFilterProps<Data, DbData extends Record<string, unknown>> {
     key: keyof Data;
     headers: TableHeaders<Data>;
     label: string;
@@ -24,7 +24,7 @@ const TextFilterStyling = styled.div`
     }
 `;
 
-export const buildServerSideTextFilter = <Data, DbData extends Record<string, any>>({
+export const buildServerSideTextFilter = <Data, DbData extends Record<string, unknown>>({
     key,
     label,
     initialValue = "",

--- a/src/components/Tables/sortMethods.ts
+++ b/src/components/Tables/sortMethods.ts
@@ -3,8 +3,8 @@ import { SortOrder } from "react-data-table-component";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 
 export type ServerSideSortMethod<DbData extends Record<string, unknown>> = (
-    query: PostgrestFilterBuilder<Database["public"], DbData, any>,
-    sortDirection: SortOrder
-) => PostgrestFilterBuilder<Database["public"], DbData, any>;
+    sortDirection: SortOrder,
+    query: PostgrestFilterBuilder<Database["public"], DbData, unknown>
+) => PostgrestFilterBuilder<Database["public"], DbData, unknown>;
 
 export type ClientSideSortMethod = (sortDirection: SortOrder) => void;

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -7,11 +7,11 @@ import { v4 as uuid } from "uuid";
 
 const logger = getLogger();
 
-type LogEvent = (message: string, meta?: Record<string, any>) => Promise<string>;
+type LogEvent = (message: string, meta?: Record<string, unknown>, error?: Error) => Promise<string>;
 
-export const logErrorReturnLogId: LogEvent = (message, meta) => {
+export const logErrorReturnLogId: LogEvent = (message, meta, error) => {
     const logId = uuid();
-    logger.error(message, { ...meta, logId });
+    logger.error(message, { ...meta, logId, error });
     return Promise.resolve(logId);
 };
 

--- a/src/pdf/DayOverview/DayOverviewPdf.tsx
+++ b/src/pdf/DayOverview/DayOverviewPdf.tsx
@@ -87,11 +87,11 @@ const CustomSVG: React.FC<CustomSVGProps> = ({ icon, color, fill }) => {
     );
 };
 
-const DayOverviewMargin: React.FC<{}> = () => {
+const DayOverviewMargin: React.FC = () => {
     return <View style={styles.margin} fixed></View>;
 };
 
-const DayOverviewHeader: React.FC<{}> = () => {
+const DayOverviewHeader: React.FC = () => {
     return (
         <View style={[styles.row, styles.bold, { borderTop: "1 solid black" }]} fixed>
             <Text style={[styles.cellLogo, styles.cell]}></Text>
@@ -109,14 +109,16 @@ const DayOverviewRow: React.FC<DayOverviewRowProps> = ({ parcel }) => {
         <View style={styles.row} wrap={false}>
             <View style={[styles.cellLogo, styles.cell, styles.row]}>
                 <CustomSVG icon={faSquare} color="black" fill={false} />
-                {parcel.client!.flagged_for_attention && (
+                {parcel.client?.flagged_for_attention && (
                     <CustomSVG icon={faFlag} color="orange" fill={true} />
                 )}
             </View>
-            <Text style={[styles.cellName, styles.cell]}>{parcel.client!.full_name}</Text>
+            <Text style={[styles.cellName, styles.cell]}>
+                {parcel.client?.full_name ?? "Client Name unknown"}
+            </Text>
             <View style={[styles.cell, styles.cellPostcode, styles.row]}>
-                <Text>{parcel.client!.address_postcode ?? displayPostcodeForHomelessClient} </Text>
-                {parcel.collection_centre!.name === "Delivery" &&
+                <Text>{parcel.client?.address_postcode ?? displayPostcodeForHomelessClient} </Text>
+                {parcel.collection_centre?.name === "Delivery" &&
                     parcel.congestionChargeApplies && (
                         <FontAwesomeIconPdfComponent
                             faIcon={faCopyright}
@@ -127,13 +129,15 @@ const DayOverviewRow: React.FC<DayOverviewRowProps> = ({ parcel }) => {
                     )}
             </View>
             <Text style={[styles.cellTime, styles.cell]}>
-                {dateTimeToAMPM(parcel.collection_datetime!)}
+                {parcel.collection_datetime
+                    ? dateTimeToAMPM(parcel.collection_datetime)
+                    : "collection time not specified"}
             </Text>
             <Text style={[styles.cellCollection, styles.cell]}>
-                {parcel.collection_centre!.name}
+                {parcel.collection_centre?.name ?? "Collection centre not specified"}
             </Text>
             <Text style={[styles.cellInstructions, styles.cell]}>
-                {parcel.client!.delivery_instructions}
+                {parcel.client?.delivery_instructions ?? "No instructions provided"}
             </Text>
         </View>
     );
@@ -143,8 +147,8 @@ const DayOverviewContent: React.FC<DayOverviewContentProps> = ({ parcels }) => {
     return (
         <View style={{ borderLeft: "1 solid black" }}>
             <DayOverviewHeader />
-            {parcels.map((parcel, index) => (
-                <DayOverviewRow key={index} parcel={parcel} /> // eslint-disable-line react/no-array-index-key
+            {parcels.map((parcel) => (
+                <DayOverviewRow key={parcel.primary_key} parcel={parcel} />
             ))}
         </View>
     );

--- a/src/pdf/DayOverview/DayOverviewPdfButton.tsx
+++ b/src/pdf/DayOverview/DayOverviewPdfButton.tsx
@@ -17,7 +17,10 @@ interface Props {
     parcels: ParcelsTableRow[];
 }
 
-export type ParcelForDayOverview = Pick<Schema["parcels"], "collection_datetime"> & {
+export type ParcelForDayOverview = Pick<
+    Schema["parcels"],
+    "collection_datetime" | "primary_key"
+> & {
     client: Pick<
         Schema["clients"],
         "flagged_for_attention" | "full_name" | "address_postcode" | "delivery_instructions"
@@ -44,7 +47,7 @@ const getParcelsForDayOverview = async (
     const { data, error } = await supabase
         .from("parcels")
         .select(
-            `collection_datetime, 
+            `collection_datetime, primary_key,
             collection_centre:collection_centres(name),
             client:clients ( 
                 flagged_for_attention, 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -53,7 +53,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
         .order("clients(address_postcode)");
 
     if (error) {
-        const logId = await logErrorReturnLogId("Error with fetch: Parcels", error);
+        const logId = await logErrorReturnLogId("Error with fetch: Parcels", { error });
         return { data: null, error: { type: "parcelFetchFailed", logId: logId } };
     }
 

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -73,7 +73,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             return { data: null, error: { type: "noCollectionCentre", logId: logId } };
         }
 
-        let labelCount: number = 0;
+        let labelCount = 0;
         if (parcel.events && parcel.events.length > 0 && parcel.events[0].event_data) {
             labelCount = Number.parseInt(parcel.events[0].event_data);
         }

--- a/src/pdf/ShoppingList/ShoppingListPdf.tsx
+++ b/src/pdf/ShoppingList/ShoppingListPdf.tsx
@@ -114,7 +114,7 @@ const OneLine: React.FC<OneLineProps> = ({ header, value }) => {
     );
 };
 
-const TableHeadings: React.FC<{}> = () => {
+const TableHeadings: React.FC = () => {
     return (
         <View style={[styles.flexRow, styles.tableRow]}>
             <View style={styles.tableDone}>

--- a/src/pdf/ShoppingList/getShoppingListData.ts
+++ b/src/pdf/ShoppingList/getShoppingListData.ts
@@ -169,9 +169,19 @@ const getShoppingListData = async (parcelIds: string[]): Promise<ShoppingListPdf
         })
     );
     if (lists.some((list) => list.error)) {
-        return { data: null, error: lists.filter((list) => list.error)[0].error! };
+        return {
+            data: null,
+            error: lists.filter((list) => list.error)[0].error as ShoppingListPdfError,
+        };
     }
-    return { data: lists.map((list) => list.data!), error: null };
+    return {
+        data: lists
+            .filter(
+                (list): list is { data: ShoppingListPdfData; error: null } => list.data !== null
+            )
+            .map((list) => list.data),
+        error: null,
+    };
 };
 
 export default getShoppingListData;

--- a/src/server/getCurrentUser.ts
+++ b/src/server/getCurrentUser.ts
@@ -25,7 +25,7 @@ export async function getCurrentUser(): Promise<CurrentUserResponse> {
     const { data, error } = await supabase.auth.getUser();
 
     if (error) {
-        const logId = await logErrorReturnLogId("error with auth getUser", error);
+        const logId = await logErrorReturnLogId("error with auth getUser", {}, error);
         return { data: null, error: { type: "userFetchFailed", logId: logId } };
     }
 

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -3,7 +3,9 @@ export const corsHeaders = {
     "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
-export const generateCorsOptionsForJsonResponse = (status: number = 200): any => ({
+export const generateCorsOptionsForJsonResponse = (
+    status = 200
+): { headers: Record<string, string>; status: number } => ({
     headers: { ...corsHeaders, "Content-Type": "application/json" },
     status,
 });

--- a/supabase/functions/check-congestion-charge/index.ts
+++ b/supabase/functions/check-congestion-charge/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-unresolved */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck (for Deno references, annoyingly cannot get around for now)
 /* global Deno */
 
@@ -19,7 +20,7 @@ serve(async (req: Handler): Promise<Response> => {
         const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
             global: {
                 headers: {
-                    Authorization: req.headers.get("Authorization")!,
+                    Authorization: req.headers.get("Authorization"),
                 },
             },
         });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": false,
+    "noImplicitAny": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
The `typescript-eslint` recommended rules were never added to eslint config, which lead to some fairly shaky types. This adds that rule and fixes all of the problems that don't require major rewrites.

## Benefits
- Increased type safety in the current code
  - Specifically, there were a lot of complicated nested interfaces that made it look like we had type safety but at their base they were just an any type so nothing was really being checked
- Will maintain higher standards of type safety going forward
- Fewer bugs in the future

## Risks
- Bugs sneaking from many many changes

## Mitigations
- Typechecking and linting pass, and are stricter than before
- I've UAT'd as much as I can, focusing on components such as filters which had the most changes
- Almost all of the changes are purely to types, so should have no runtime impact
- Tests still pass

## Problems I didn't fix
- The implementation of the Filter Types are based around interfaces which led to some type conflicts that were going to be very difficult to resolve, but logically can be ignored. For now, I ignored them with comments. In the long term we should think about rewriting them with classes
- Not all of the problems were solved in the most beautiful way possible. There is a marginal increase in complexity here, however in return we get much stronger type safety.

## Info
The main culprits for bad practice were:
- non-null assertions:
    ```
    const val: client | null
    console.log(client!.name)
    ```
- `any` types
- redundant type definitions, e.g, `const foo: string = "I'm definitely a string"`
- using `{}` in situations you shouldn't

Of those, the first two are the ones that really needed fixing because they could very realistically lead to runtime bugs
