### PR TITLE
VFB-302 fix top row item name to show when deleting from list

### DIFF
--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -279,7 +279,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
         <>
             <ConfirmDialog
                 message={`Are you sure you want to delete ${
-                    toDelete ? listOfIngredients[toDelete].itemName : ""
+                    toDelete !== null ? listOfIngredients[toDelete].itemName : ""
                 }?`}
                 isOpen={toDeleteModalOpen}
                 onConfirm={onConfirmDeletion}


### PR DESCRIPTION
## What's changed
changed logic so when deleting the top item from the lists table, the message appears correctly.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/user-attachments/assets/28b66d02-be59-4e0f-a180-540bb8b81ada) | ![image](https://github.com/user-attachments/assets/d7bfd492-24d1-424a-8ad4-591008a5c687) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`