### PR TITLE
VFB-266 Add wiki update button view conditional on user role

### DIFF
--- a/src/app/info/ClientSideHelpers.tsx
+++ b/src/app/info/ClientSideHelpers.tsx
@@ -1,32 +1,12 @@
 "use client";
 
 import { RoleUpdateContext } from "@/app/roles";
-import { Props } from "@/components/Tables/TableSurface";
-import { Paper } from "@mui/material";
 import { useContext } from "react";
-import styled from "styled-components";
+import { StyledPaper } from "@/app/info/StyleComponents";
 
-export const AccordionWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-    min-width: 100%;
-`;
-
-export const WikiUpdateButton = styled.button`
-    border: none;
-    background-color: rgba(0, 0, 0, 0);
-    &:hover {
-        color: lightgray;
-        cursor: pointer;
-    }
-`;
-
-const StyledPaper = styled(Paper)`
-    margin: 1rem;
-    padding: 1rem;
-    border-radius: 1rem;
-    width: 90vw;
-`;
+export interface Props {
+    children: React.ReactNode;
+}
 
 export const AccordionSurface: React.FC<Props> = ({ children }) => {
     return <StyledPaper elevation={3}>{children}</StyledPaper>;

--- a/src/app/info/ClientSideHelpers.tsx
+++ b/src/app/info/ClientSideHelpers.tsx
@@ -2,15 +2,6 @@
 
 import { RoleUpdateContext } from "@/app/roles";
 import { useContext } from "react";
-import { StyledPaper } from "@/app/info/StyleComponents";
-
-export interface Props {
-    children: React.ReactNode;
-}
-
-export const AccordionSurface: React.FC<Props> = ({ children }) => {
-    return <StyledPaper elevation={3}>{children}</StyledPaper>;
-};
 
 export const buttonAlert = (): void => {
     alert("Wiki item has been updated!");

--- a/src/app/info/StyleComponents.tsx
+++ b/src/app/info/StyleComponents.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Paper } from "@mui/material";
+import styled from "styled-components";
+
+export const AccordionWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    min-width: 100%;
+`;
+
+export const WikiUpdateButton = styled.button`
+    border: none;
+    background-color: rgba(0, 0, 0, 0);
+    &:hover {
+        color: lightgray;
+        cursor: pointer;
+    }
+`;
+
+export const StyledPaper = styled(Paper)`
+    margin: 1rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    width: 90vw;
+`;

--- a/src/app/info/StyleComponents.tsx
+++ b/src/app/info/StyleComponents.tsx
@@ -3,13 +3,13 @@
 import { Paper } from "@mui/material";
 import styled from "styled-components";
 
-export const AccordionWrapper = styled.div`
+export const WikiItemPositioner = styled.div`
     display: flex;
     justify-content: center;
     min-width: 100%;
 `;
 
-export const WikiUpdateButton = styled.button`
+export const WikiUpdateDataButton = styled.button`
     border: none;
     background-color: rgba(0, 0, 0, 0);
     &:hover {
@@ -24,3 +24,11 @@ export const StyledPaper = styled(Paper)`
     border-radius: 1rem;
     width: 90vw;
 `;
+
+export interface Props {
+    children: React.ReactNode;
+}
+
+export const WikiItemAccordionSurface: React.FC<Props> = ({ children }) => {
+    return <StyledPaper elevation={3}>{children}</StyledPaper>;
+};

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -4,16 +4,15 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { DbWikiRow } from "@/databaseUtils";
 import UpdateIcon from "@mui/icons-material/Update";
-import {
-    AccordionWrapper,
-    WikiUpdateButton,
-    buttonAlert,
-    AdminManagerDependent,
-    AccordionSurface,
-} from "@/app/info/lib/ClientSideHelpers";
+import { buttonAlert, AdminManagerDependent, AccordionSurface } from "@/app/info/ClientSideHelpers";
+import { AccordionWrapper, WikiUpdateButton } from "@/app/info/StyleComponents";
 
-interface AccordianProps {
+interface AccordionProps {
     rows: DbWikiRow[];
+}
+
+interface AccordionContentProps {
+    row: DbWikiRow;
 }
 
 interface ContentPart {
@@ -48,7 +47,7 @@ export const convertContentToElements = (rowContent: string): React.JSX.Element[
     });
 };
 
-const WikiItems: React.FC<AccordianProps> = (props) => {
+const WikiItems: React.FC<AccordionProps> = (props) => {
     const sortedRows: DbWikiRow[] = props.rows.slice().sort((r1: DbWikiRow, r2: DbWikiRow) => {
         return r1.order > r2.order ? 1 : -1;
     });
@@ -57,29 +56,38 @@ const WikiItems: React.FC<AccordianProps> = (props) => {
             {sortedRows.map((row: DbWikiRow) => {
                 return (
                     <AccordionWrapper key={row.order}>
-                        <AdminManagerDependent>
-                            <WikiUpdateButton onClick={buttonAlert}>
-                                <UpdateIcon />
-                            </WikiUpdateButton>
-                        </AdminManagerDependent>
-                        <AccordionSurface>
-                            <Accordion elevation={0}>
-                                <AccordionSummary
-                                    expandIcon={<ExpandMoreIcon />}
-                                    aria-controls="panel1-content"
-                                    id="panel1-header"
-                                >
-                                    <h2>{row.title}</h2>
-                                </AccordionSummary>
-                                <AccordionDetails>
-                                    {convertContentToElements(row.content)}
-                                </AccordionDetails>
-                            </Accordion>
-                        </AccordionSurface>
+                        <UpdateComponent />
+                        <AccordionContent row={row} />
                     </AccordionWrapper>
                 );
             })}
         </>
+    );
+};
+
+const UpdateComponent: React.FC = () => {
+    return (
+        <AdminManagerDependent>
+            <WikiUpdateButton onClick={buttonAlert}>
+                <UpdateIcon />
+            </WikiUpdateButton>
+        </AdminManagerDependent>
+    );
+};
+const AccordionContent: React.FC<AccordionContentProps> = ({ row }) => {
+    return (
+        <AccordionSurface>
+            <Accordion elevation={0}>
+                <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    aria-controls="panel1-content"
+                    id="panel1-header"
+                >
+                    <h2>{row.title}</h2>
+                </AccordionSummary>
+                <AccordionDetails>{convertContentToElements(row.content)}</AccordionDetails>
+            </Accordion>
+        </AccordionSurface>
     );
 };
 

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -3,7 +3,14 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { DbWikiRow } from "@/databaseUtils";
-import TableSurface from "@/components/Tables/TableSurface";
+import UpdateIcon from "@mui/icons-material/Update";
+import {
+    AccordionWrapper,
+    WikiUpdateButton,
+    buttonAlert,
+    AdminManagerDependent,
+    AccordionSurface,
+} from "@/app/info/lib/ClientSideHelpers";
 
 interface AccordianProps {
     rows: DbWikiRow[];
@@ -49,20 +56,27 @@ const WikiItems: React.FC<AccordianProps> = (props) => {
         <>
             {sortedRows.map((row: DbWikiRow) => {
                 return (
-                    <TableSurface key={row.order}>
-                        <Accordion elevation={0}>
-                            <AccordionSummary
-                                expandIcon={<ExpandMoreIcon />}
-                                aria-controls="panel1-content"
-                                id="panel1-header"
-                            >
-                                <h2>{row.title}</h2>
-                            </AccordionSummary>
-                            <AccordionDetails>
-                                {convertContentToElements(row.content)}
-                            </AccordionDetails>
-                        </Accordion>
-                    </TableSurface>
+                    <AccordionWrapper key={row.order}>
+                        <AdminManagerDependent>
+                            <WikiUpdateButton onClick={buttonAlert}>
+                                <UpdateIcon />
+                            </WikiUpdateButton>
+                        </AdminManagerDependent>
+                        <AccordionSurface>
+                            <Accordion elevation={0}>
+                                <AccordionSummary
+                                    expandIcon={<ExpandMoreIcon />}
+                                    aria-controls="panel1-content"
+                                    id="panel1-header"
+                                >
+                                    <h2>{row.title}</h2>
+                                </AccordionSummary>
+                                <AccordionDetails>
+                                    {convertContentToElements(row.content)}
+                                </AccordionDetails>
+                            </Accordion>
+                        </AccordionSurface>
+                    </AccordionWrapper>
                 );
             })}
         </>

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -4,14 +4,19 @@ import AccordionDetails from "@mui/material/AccordionDetails";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { DbWikiRow } from "@/databaseUtils";
 import UpdateIcon from "@mui/icons-material/Update";
-import { buttonAlert, AdminManagerDependent, AccordionSurface } from "@/app/info/ClientSideHelpers";
-import { AccordionWrapper, WikiUpdateButton } from "@/app/info/StyleComponents";
+import { buttonAlert, AdminManagerDependent } from "@/app/info/ClientSideHelpers";
+import {
+    WikiItemPositioner,
+    WikiUpdateDataButton,
+    WikiItemAccordionSurface,
+} from "@/app/info/StyleComponents";
+import React from "react";
 
-interface AccordionProps {
+interface WikiItemsProps {
     rows: DbWikiRow[];
 }
 
-interface AccordionContentProps {
+interface WikiItemProps {
     row: DbWikiRow;
 }
 
@@ -47,47 +52,40 @@ export const convertContentToElements = (rowContent: string): React.JSX.Element[
     });
 };
 
-const WikiItems: React.FC<AccordionProps> = (props) => {
+const WikiItems: React.FC<WikiItemsProps> = (props) => {
     const sortedRows: DbWikiRow[] = props.rows.slice().sort((r1: DbWikiRow, r2: DbWikiRow) => {
         return r1.order > r2.order ? 1 : -1;
     });
     return (
         <>
             {sortedRows.map((row: DbWikiRow) => {
-                return (
-                    <AccordionWrapper key={row.order}>
-                        <UpdateComponent />
-                        <AccordionContent row={row} />
-                    </AccordionWrapper>
-                );
+                return <WikiItem key={row.order} row={row} />;
             })}
         </>
     );
 };
 
-const UpdateComponent: React.FC = () => {
+const WikiItem: React.FC<WikiItemProps> = ({ row }) => {
     return (
-        <AdminManagerDependent>
-            <WikiUpdateButton onClick={buttonAlert}>
-                <UpdateIcon />
-            </WikiUpdateButton>
-        </AdminManagerDependent>
-    );
-};
-const AccordionContent: React.FC<AccordionContentProps> = ({ row }) => {
-    return (
-        <AccordionSurface>
-            <Accordion elevation={0}>
-                <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
-                    aria-controls="panel1-content"
-                    id="panel1-header"
-                >
-                    <h2>{row.title}</h2>
-                </AccordionSummary>
-                <AccordionDetails>{convertContentToElements(row.content)}</AccordionDetails>
-            </Accordion>
-        </AccordionSurface>
+        <WikiItemPositioner>
+            <AdminManagerDependent>
+                <WikiUpdateDataButton onClick={buttonAlert}>
+                    <UpdateIcon />
+                </WikiUpdateDataButton>
+            </AdminManagerDependent>
+            <WikiItemAccordionSurface>
+                <Accordion elevation={0}>
+                    <AccordionSummary
+                        expandIcon={<ExpandMoreIcon />}
+                        aria-controls="panel1-content"
+                        id="panel1-header"
+                    >
+                        <h2>{row.title}</h2>
+                    </AccordionSummary>
+                    <AccordionDetails>{convertContentToElements(row.content)}</AccordionDetails>
+                </Accordion>
+            </WikiItemAccordionSurface>
+        </WikiItemPositioner>
     );
 };
 

--- a/src/app/info/lib/ClientSideHelpers.tsx
+++ b/src/app/info/lib/ClientSideHelpers.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { RoleUpdateContext } from "@/app/roles";
+import { Props } from "@/components/Tables/TableSurface";
+import { Paper } from "@mui/material";
+import { useContext } from "react";
+import styled from "styled-components";
+
+export const AccordionWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    min-width: 100%;
+`;
+
+export const WikiUpdateButton = styled.button`
+    border: none;
+    background-color: rgba(0, 0, 0, 0);
+    &:hover {
+        color: lightgray;
+        cursor: pointer;
+    }
+`;
+
+const StyledPaper = styled(Paper)`
+    margin: 1rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    width: 90vw;
+`;
+
+export const AccordionSurface: React.FC<Props> = ({ children }) => {
+    return <StyledPaper elevation={3}>{children}</StyledPaper>;
+};
+
+export const buttonAlert = (): void => {
+    alert("Wiki item has been updated!");
+};
+
+interface RoleProps {
+    children?: React.ReactNode;
+}
+
+export const AdminManagerDependent: React.FC<RoleProps> = (props) => {
+    const { role } = useContext(RoleUpdateContext);
+
+    return <>{(role === "admin" || role === "manager") && props.children}</>;
+};

--- a/src/components/Tables/TableSurface.tsx
+++ b/src/components/Tables/TableSurface.tsx
@@ -10,7 +10,7 @@ const StyledPaper = styled(Paper)`
     border-radius: 1rem;
 `;
 
-interface Props {
+export interface Props {
     children: React.ReactNode;
 }
 


### PR DESCRIPTION
## What's changed
Added update buttons to the wiki page which are conditional on the role of the user (appear only for admins and managers) and give an alert when clicked

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| 
![image](https://github.com/user-attachments/assets/5ddfb40c-857c-47ad-bf4c-6645fd0af8fa)
| 
![Screenshot 2024-07-19 155657](https://github.com/user-attachments/assets/b613af2f-2103-4866-a726-b6facb59071e)
|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
