### PR TITLE
#373: fix migration that removes 'Map Generated' events from breaking…

### DIFF
--- a/supabase/migrations/20240722221642_set_no_status_to_empty_string_and_remove_map_generated.sql
+++ b/supabase/migrations/20240722221642_set_no_status_to_empty_string_and_remove_map_generated.sql
@@ -1,6 +1,13 @@
+update public.audit_log
+  set event_id = null
+  from public.events
+  where audit_log.event_id = events.primary_key
+    and events.new_parcel_status = 'Map Generated';
+
 delete from public.events where new_parcel_status = 'Map Generated';
 
 delete from public.status_order where event_name = 'Map Generated';
+
 
 update status_order set event_name = '' where event_name = 'No Status';
 


### PR DESCRIPTION
… audit log constraint

## What's changed
Sorry, the migration in PR #436 didn't check for audit log constraint before deleting a defunct status event.
https://github.com/NorwoodAndBrixtonFoodbank/nbf-website/actions/runs/10061976750/job/27813328454
![image](https://github.com/user-attachments/assets/449e4aa5-7256-44dc-baa7-7672f98534cc)

Therefore I'm editing that migration here.

## Testing
I did the following:
* restored my local DB to before the problematic migration
* used the local webapp to ensure that the audit log had a range of events, including "Map Generated"
* checked out this branch
* ran `npx supabase migrations up --include-all --local`
* checked that the DB looked as expected
* tested the local webapp to verify all was as expected, including the audit log

Before deployment, I've also checked that the `dev` DB's Migrations table does not say that this migration has been run yet.

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Event ID Update in Audit Log**
The PR adds an update statement that removes `event_id` from the `audit_log` table for entries where `event_id` is linked with 'Map Generated' status in the `events` table.

* **Removal of 'Map Generated' Events**
Any rows in the `events` table with `new_parcel_status` as 'Map Generated' have been deleted.

* **Removal of 'Map Generated' Status Orders**
Similarly, entries from the `status_order` table are removed where the `event_name` is marked as 'Map Generated'.

* **Status Order event_name Update**
If the `event_name` in the `status_order` table was previously labeled as 'No Status', it has now been updated to an empty string ('') as the new value.

* **Workflow Order Resetting for No Event Status**
The `workflow_order` for rows in the `status_order` table where the `event_name` is an empty string ('') has been reset to have the value 0. This essentially prioritizes these rows at the base level in the workflow order.
