### PR TITLE
VFB-278 allow selecting list type when creating parcel

### DIFF
--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -16,6 +16,7 @@ import { ErrorSecondaryText } from "../errorStylingandMessages";
 import { CircularProgress } from "@mui/material";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
 import { updateClientNotes } from "./updateClientNotes";
+import { capitaliseWords } from "@/common/format";
 
 interface Props {
     clientId: string;
@@ -89,6 +90,9 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
                 onCancel: onCancelNotes,
                 onSave: onSaveNotes,
             },
+        };
+        clientDetailsForDataViewer["defaultList"] = {
+            value: capitaliseWords(clientDetails["defaultList"]),
         };
         clientDetailsForDataViewer["isActive"] = {
             value: clientDetails["isActive"],

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -97,6 +97,7 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
         address: formatAddressFromClientDetails(client),
         deliveryInstructions: client.delivery_instructions ?? "",
         phoneNumber: client.phone_number ?? "",
+        defaultList: client.default_list,
         household: formatHouseholdFromFamilyDetails(client.family),
         adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
         children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
@@ -108,7 +109,6 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
         extraInformation: client.extra_information ?? "",
         notes: client.notes,
         isActive: client.is_active,
-        defaultList: client.default_list,
     };
 };
 

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -8,7 +8,7 @@ import {
     getChildAgeUsingBirthYearAndMonth,
     isAdultUsingBirthYear,
 } from "@/common/getAgesOfFamily";
-import { ListName } from "@/common/fetch";
+import { ListType } from "@/common/fetch";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);
@@ -88,7 +88,7 @@ export interface ExpandedClientData {
     extraInformation: string;
     notes: string | null;
     isActive: boolean;
-    defaultList: ListName;
+    defaultList: ListType;
 }
 
 export const rawDataToExpandedClientDetails = (client: RawClientDetails): ExpandedClientData => {

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -8,6 +8,7 @@ import {
     getChildAgeUsingBirthYearAndMonth,
     isAdultUsingBirthYear,
 } from "@/common/getAgesOfFamily";
+import { ListName } from "../lists/ListDataview";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);
@@ -45,7 +46,8 @@ const getRawClientDetails = async (clientId: string) => {
             other_items,
             extra_information,
             notes,
-            is_active
+            is_active,
+            default_list
         `
         )
         .eq("primary_key", clientId)
@@ -86,6 +88,7 @@ export interface ExpandedClientData {
     extraInformation: string;
     notes: string | null;
     isActive: boolean;
+    defaultList: ListName;
 }
 
 export const rawDataToExpandedClientDetails = (client: RawClientDetails): ExpandedClientData => {
@@ -105,6 +108,7 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
         extraInformation: client.extra_information ?? "",
         notes: client.notes,
         isActive: client.is_active,
+        defaultList: client.default_list,
     };
 };
 

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -8,7 +8,7 @@ import {
     getChildAgeUsingBirthYearAndMonth,
     isAdultUsingBirthYear,
 } from "@/common/getAgesOfFamily";
-import { ListName } from "../lists/ListDataview";
+import { ListName } from "@/common/fetch";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);

--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -15,11 +15,13 @@ import {
     fetchClient,
     fetchPackingSlotsInfo,
     getActiveCollectionCentres,
+    listTypes,
 } from "@/common/fetch";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import supabase from "@/supabaseClient";
 import Title from "@/components/Title/Title";
 import { insertParcel } from "@/app/parcels/form/submitFormHelpers";
+import { capitaliseWords } from "@/common/format";
 
 interface AddParcelProps {
     clientId: string;
@@ -93,15 +95,11 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
             }
             initialParcelFields.listType = clientData.default_list;
             setListTypeLabelsAndValues(
-                clientData.default_list === "regular"
-                    ? [
-                          ["Regular (default)", "regular"],
-                          ["Hotel", "hotel"],
-                      ]
-                    : [
-                          ["Regular", "regular"],
-                          ["Hotel (default)", "hotel"],
-                      ]
+                listTypes.map((listType) =>
+                    clientData.default_list === listType
+                        ? [capitaliseWords(listType) + " (default)", listType]
+                        : [capitaliseWords(listType), listType]
+                )
             );
 
             setIsLoading(false);

--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -7,9 +7,12 @@ import ParcelForm, {
 } from "@/app/parcels/form/ParcelForm";
 import {
     CollectionCentresLabelsAndValues,
+    FetchClientError,
     FetchCollectionCentresError,
+    ListTypeLabelsAndValues,
     PackingSlotsError,
     PackingSlotsLabelsAndValues,
+    fetchClient,
     fetchPackingSlotsInfo,
     getActiveCollectionCentres,
 } from "@/common/fetch";
@@ -22,7 +25,9 @@ interface AddParcelProps {
     clientId: string;
 }
 
-const getErrorMessage = (error: FetchCollectionCentresError | PackingSlotsError): string => {
+const getErrorMessage = (
+    error: FetchCollectionCentresError | PackingSlotsError | FetchClientError
+): string => {
     let errorMessage: string;
     switch (error.type) {
         case "collectionCentresFetchFailed":
@@ -30,6 +35,12 @@ const getErrorMessage = (error: FetchCollectionCentresError | PackingSlotsError)
             break;
         case "packingSlotsFetchFailed":
             errorMessage = "Failed to fetch packing slots data. Please refresh the page.";
+            break;
+        case "clientFetchFailed":
+            errorMessage = "Unable to fetch client data. Please refresh the page.";
+            break;
+        case "noMatchingClients":
+            errorMessage = "No matching clients with client ID. Please refresh the page.";
             break;
     }
     return `${errorMessage} Log ID: ${error.logId}`;
@@ -41,9 +52,12 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
         useState<CollectionCentresLabelsAndValues | null>(null);
     const [packingSlotsLabelsAndValues, setPackingSlotsLabelsAndValues] =
         useState<PackingSlotsLabelsAndValues | null>(null);
-    const [error, setError] = useState<FetchCollectionCentresError | PackingSlotsError | null>(
-        null
+    const [listTypeLabelsAndValues, setListTypeLabelsAndValues] = useState<ListTypeLabelsAndValues>(
+        []
     );
+    const [error, setError] = useState<
+        FetchCollectionCentresError | PackingSlotsError | FetchClientError | null
+    >(null);
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
@@ -70,9 +84,29 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
                 return;
             }
             setPackingSlotsLabelsAndValues(packingSlotsData);
+
+            const { data: clientData, error: clientError } = await fetchClient(clientId, supabase);
+            if (clientError) {
+                setError(clientError);
+                setIsLoading(false);
+                return;
+            }
+            initialParcelFields.listType = clientData.default_list;
+            setListTypeLabelsAndValues(
+                clientData.default_list === "regular"
+                    ? [
+                          ["Regular (default)", "regular"],
+                          ["Hotel", "hotel"],
+                      ]
+                    : [
+                          ["Regular", "regular"],
+                          ["Hotel (default)", "hotel"],
+                      ]
+            );
+
             setIsLoading(false);
         })();
-    }, []);
+    }, [clientId]);
 
     return (
         <>
@@ -93,6 +127,7 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
                         deliveryPrimaryKey={deliveryPrimaryKey}
                         collectionCentresLabelsAndValues={collectionCentresLabelsAndValues}
                         packingSlotsLabelsAndValues={packingSlotsLabelsAndValues}
+                        listTypeLabelsAndValues={listTypeLabelsAndValues}
                     />
                 )
             )}

--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -15,7 +15,7 @@ import {
     fetchClient,
     fetchPackingSlotsInfo,
     getActiveCollectionCentres,
-    listTypes,
+    LIST_TYPES_ARRAY,
 } from "@/common/fetch";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import supabase from "@/supabaseClient";
@@ -95,7 +95,7 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
             }
             initialParcelFields.listType = clientData.default_list;
             setListTypeLabelsAndValues(
-                listTypes.map((listType) =>
+                LIST_TYPES_ARRAY.map((listType) =>
                     clientData.default_list === listType
                         ? [capitaliseWords(listType) + " (default)", listType]
                         : [capitaliseWords(listType), listType]

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -93,6 +93,38 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
     >(null);
 
     useEffect(() => {
+        async () => {
+            if (!initialFormFields.clientId) {
+                setListTypeLabelsAndValues([
+                    ["Regular", "regular"],
+                    ["Hotel", "hotel"],
+                ]);
+            } else {
+                const { data: clientData, error: clientError } = await fetchClient(
+                    initialFormFields.clientId,
+                    supabase
+                );
+                if (clientError) {
+                    setError(clientError);
+                    setIsLoading(false);
+                    return;
+                }
+                setListTypeLabelsAndValues(
+                    clientData.default_list === "regular"
+                        ? [
+                              ["Regular (default)", "regular"],
+                              ["Hotel", "hotel"],
+                          ]
+                        : [
+                              ["Regular", "regular"],
+                              ["Hotel (default)", "hotel"],
+                          ]
+                );
+            }
+        };
+    }, [initialFormFields.clientId]);
+
+    useEffect(() => {
         (async () => {
             setIsLoading(true);
 
@@ -127,37 +159,8 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
             setPackingSlotsIsShown(parcelData.packing_slot?.is_shown);
             setCollectionCentreIsShown(parcelData.collection_centre?.is_shown === true);
 
-            if (!initialFormFields.clientId) {
-                setListTypeLabelsAndValues([
-                    ["Regular", "regular"],
-                    ["Hotel", "hotel"],
-                ]);
-            } else {
-                const { data: clientData, error: clientError } = await fetchClient(
-                    initialFormFields.clientId,
-                    supabase
-                );
-                if (clientError) {
-                    setError(clientError);
-                    setIsLoading(false);
-                    return;
-                }
-                setListTypeLabelsAndValues(
-                    clientData.default_list === "regular"
-                        ? [
-                              ["Regular (default)", "regular"],
-                              ["Hotel", "hotel"],
-                          ]
-                        : [
-                              ["Regular", "regular"],
-                              ["Hotel (default)", "hotel"],
-                          ]
-                );
-            }
-
             setIsLoading(false);
         })();
-        
     }, [parcelId]);
 
     const initialFormErrors: ParcelErrors = {

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -15,13 +15,14 @@ import {
     PackingSlotsError,
     PackingSlotsLabelsAndValues,
     ParcelWithCollectionCentreAndPackingSlot,
+    listTypes,
 } from "@/common/fetch";
 import supabase from "@/supabaseClient";
 import { Errors } from "@/components/Form/formFunctions";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Title from "@/components/Title/Title";
 import { updateParcel } from "@/app/parcels/form/submitFormHelpers";
-import { formatDatetimeAsTime } from "@/common/format";
+import { formatDatetimeAsTime, capitaliseWords } from "@/common/format";
 
 interface EditParcelFormProps {
     parcelId: string;
@@ -95,10 +96,9 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
     useEffect(() => {
         (async () => {
             if (!initialFormFields.clientId) {
-                setListTypeLabelsAndValues([
-                    ["Regular", "regular"],
-                    ["Hotel", "hotel"],
-                ]);
+                setListTypeLabelsAndValues(
+                    listTypes.map((listType) => [capitaliseWords(listType), listType])
+                );
             } else {
                 const { data: clientData, error: clientError } = await fetchClient(
                     initialFormFields.clientId,
@@ -110,15 +110,11 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                     return;
                 }
                 setListTypeLabelsAndValues(
-                    clientData.default_list === "regular"
-                        ? [
-                              ["Regular (default)", "regular"],
-                              ["Hotel", "hotel"],
-                          ]
-                        : [
-                              ["Regular", "regular"],
-                              ["Hotel (default)", "hotel"],
-                          ]
+                    listTypes.map((listType) =>
+                        clientData.default_list === listType
+                            ? [capitaliseWords(listType) + " (default)", listType]
+                            : [capitaliseWords(listType), listType]
+                    )
                 );
             }
         })();

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -15,7 +15,7 @@ import {
     PackingSlotsError,
     PackingSlotsLabelsAndValues,
     ParcelWithCollectionCentreAndPackingSlot,
-    listTypes,
+    LIST_TYPES_ARRAY,
 } from "@/common/fetch";
 import supabase from "@/supabaseClient";
 import { Errors } from "@/components/Form/formFunctions";
@@ -97,7 +97,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
         (async () => {
             if (!initialFormFields.clientId) {
                 setListTypeLabelsAndValues(
-                    listTypes.map((listType) => [capitaliseWords(listType), listType])
+                    LIST_TYPES_ARRAY.map((listType) => [capitaliseWords(listType), listType])
                 );
             } else {
                 const { data: clientData, error: clientError } = await fetchClient(
@@ -110,7 +110,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                     return;
                 }
                 setListTypeLabelsAndValues(
-                    listTypes.map((listType) =>
+                    LIST_TYPES_ARRAY.map((listType) =>
                         clientData.default_list === listType
                             ? [capitaliseWords(listType) + " (default)", listType]
                             : [capitaliseWords(listType), listType]

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -93,7 +93,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
     >(null);
 
     useEffect(() => {
-        async () => {
+        (async () => {
             if (!initialFormFields.clientId) {
                 setListTypeLabelsAndValues([
                     ["Regular", "regular"],
@@ -121,7 +121,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                           ]
                 );
             }
-        };
+        })();
     }, [initialFormFields.clientId]);
 
     useEffect(() => {

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -56,7 +56,7 @@ import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
-    listType: ListType | "";
+    listType: ListType | null;
     voucherNumber: string | null;
     packingDate: string | null;
     packingSlot: string | undefined;
@@ -82,7 +82,7 @@ export type ParcelCardProps = CardProps<ParcelFields, ParcelErrors>;
 
 export const initialParcelFields: ParcelFields = {
     clientId: null,
-    listType: "",
+    listType: null,
     voucherNumber: "",
     packingDate: null,
     packingSlot: "",

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -56,7 +56,7 @@ import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
-    listType: ListType | undefined;
+    listType?: ListType;
     voucherNumber: string | null;
     packingDate: string | null;
     packingSlot: string | undefined;

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -36,6 +36,7 @@ import {
     CollectionCentresLabelsAndValues,
     CollectionTimeSlotsLabelsAndValues,
     getActiveTimeSlotsForCollectionCentre,
+    ListTypeLabelsAndValues,
     PackingSlotsLabelsAndValues,
 } from "@/common/fetch";
 import getExpandedClientDetails, {
@@ -50,9 +51,12 @@ import PackingSlotsCard from "@/app/parcels/form/formSections/PackingSlotsCard";
 import { getDbDate } from "@/common/format";
 import ExpandedClientDetails from "@/app/clients/ExpandedClientDetails";
 import supabase from "@/supabaseClient";
+import { ListName } from "@/app/lists/ListDataview";
+import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
+    listType: ListName | "";
     voucherNumber: string | null;
     packingDate: string | null;
     packingSlot: string | undefined;
@@ -64,6 +68,7 @@ export interface ParcelFields extends Fields {
 }
 
 export interface ParcelErrors extends FormErrors<ParcelFields> {
+    listType: Errors;
     voucherNumber: Errors;
     packingDate: Errors;
     packingSlot: Errors;
@@ -77,6 +82,7 @@ export type ParcelCardProps = CardProps<ParcelFields, ParcelErrors>;
 
 export const initialParcelFields: ParcelFields = {
     clientId: null,
+    listType: "",
     voucherNumber: "",
     packingDate: null,
     packingSlot: "",
@@ -88,6 +94,7 @@ export const initialParcelFields: ParcelFields = {
 };
 
 export const initialParcelFormErrors: ParcelErrors = {
+    listType: Errors.none,
     voucherNumber: Errors.none,
     packingDate: Errors.initial,
     packingSlot: Errors.initial,
@@ -105,9 +112,11 @@ interface ParcelFormProps {
     collectionCentresLabelsAndValues: CollectionCentresLabelsAndValues;
     packingSlotsLabelsAndValues: PackingSlotsLabelsAndValues;
     writeParcelInfoToDatabase: WriteParcelToDatabaseFunction;
+    listTypeLabelsAndValues: ListTypeLabelsAndValues;
 }
 
 const withCollectionFormSections = [
+    ListTypeCard,
     VoucherNumberCard,
     PackingDateCard,
     PackingSlotsCard,
@@ -118,6 +127,7 @@ const withCollectionFormSections = [
 ];
 
 const noCollectionFormSections = [
+    ListTypeCard,
     VoucherNumberCard,
     PackingDateCard,
     PackingSlotsCard,
@@ -158,6 +168,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
     deliveryPrimaryKey,
     collectionCentresLabelsAndValues,
     packingSlotsLabelsAndValues,
+    listTypeLabelsAndValues,
 }) => {
     const router = useRouter();
     const [fields, setFields] = useState(initialFields);
@@ -307,6 +318,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
                             collectionCentresLabelsAndValues={collectionCentresLabelsAndValues}
                             packingSlotsLabelsAndValues={packingSlotsLabelsAndValues}
                             collectionTimeSlotsLabelsAndValues={collectionSlotsLabelsAndValues}
+                            listTypeLabelsAndValues={listTypeLabelsAndValues}
                         />
                     );
                 })}

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -38,6 +38,7 @@ import {
     getActiveTimeSlotsForCollectionCentre,
     ListTypeLabelsAndValues,
     PackingSlotsLabelsAndValues,
+    ListName,
 } from "@/common/fetch";
 import getExpandedClientDetails, {
     ExpandedClientData,
@@ -51,7 +52,6 @@ import PackingSlotsCard from "@/app/parcels/form/formSections/PackingSlotsCard";
 import { getDbDate } from "@/common/format";
 import ExpandedClientDetails from "@/app/clients/ExpandedClientDetails";
 import supabase from "@/supabaseClient";
-import { ListName } from "@/app/lists/ListDataview";
 import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -56,7 +56,7 @@ import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
-    listType: ListType | null;
+    listType: ListType | undefined;
     voucherNumber: string | null;
     packingDate: string | null;
     packingSlot: string | undefined;
@@ -82,7 +82,7 @@ export type ParcelCardProps = CardProps<ParcelFields, ParcelErrors>;
 
 export const initialParcelFields: ParcelFields = {
     clientId: null,
-    listType: null,
+    listType: undefined,
     voucherNumber: "",
     packingDate: null,
     packingSlot: "",
@@ -266,7 +266,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
 
         const parcelRecord = {
             client_id: clientId || fields.clientId || "",
-            list_type: fields.listType as ListType,
+            list_type: fields.listType,
             packing_date: packingDate,
             packing_slot: fields.packingSlot,
             voucher_number: fields.voucherNumber,

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -38,7 +38,7 @@ import {
     getActiveTimeSlotsForCollectionCentre,
     ListTypeLabelsAndValues,
     PackingSlotsLabelsAndValues,
-    ListName,
+    ListType,
 } from "@/common/fetch";
 import getExpandedClientDetails, {
     ExpandedClientData,
@@ -56,7 +56,7 @@ import ListTypeCard from "./formSections/ListTypeCard";
 
 export interface ParcelFields extends Fields {
     clientId: string | null;
-    listType: ListName | "";
+    listType: ListType | "";
     voucherNumber: string | null;
     packingDate: string | null;
     packingSlot: string | undefined;
@@ -266,7 +266,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
 
         const parcelRecord = {
             client_id: clientId || fields.clientId || "",
-            list_type: fields.listType as ListName,
+            list_type: fields.listType as ListType,
             packing_date: packingDate,
             packing_slot: fields.packingSlot,
             voucher_number: fields.voucherNumber,

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -266,6 +266,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
 
         const parcelRecord = {
             client_id: clientId || fields.clientId || "",
+            list_type: fields.listType as ListName,
             packing_date: packingDate,
             packing_slot: fields.packingSlot,
             voucher_number: fields.voucherNumber,

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -4,7 +4,7 @@ import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ErrorText } from "@/components/Form/formStyling";
 import DropdownListInput from "@/components/DataInput/DropdownListInput";
 import { ParcelCardProps } from "../ParcelForm";
-import { ListTypeLabelsAndValues, ListName } from "@/common/fetch";
+import { ListTypeLabelsAndValues, ListType } from "@/common/fetch";
 
 interface ListTypeCardProps extends ParcelCardProps {
     listTypeLabelsAndValues: ListTypeLabelsAndValues;
@@ -17,12 +17,12 @@ const ListTypeCard: React.FC<ListTypeCardProps> = ({
     fields,
     listTypeLabelsAndValues,
 }) => {
-    const [clientDefaultList, setClientDefaultList] = useState<ListName | null>(null);
+    const [clientDefaultList, setClientDefaultList] = useState<ListType | null>(null);
 
     useEffect(() => {
         const defaultArray = listTypeLabelsAndValues.find(([label, _]) => {
             return label.includes("default");
-        }) as [string, ListName];
+        }) as [string, ListType];
         setClientDefaultList(defaultArray ? defaultArray[1] : null);
     }, [listTypeLabelsAndValues]);
 

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -41,7 +41,7 @@ const ListTypeCard: React.FC<ListTypeCardProps> = ({
                 selectLabelId="list-type-select-label"
                 labelsAndValues={listTypeLabelsAndValues}
                 listTitle="List Type"
-                defaultValue={fields.listType}
+                defaultValue={fields.listType ?? undefined}
                 onChange={valueOnChangeDropdownList(fieldSetter, errorSetter, "listType")}
             />
             <ErrorText>{errorText(formErrors.listType)}</ErrorText>

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -41,7 +41,7 @@ const ListTypeCard: React.FC<ListTypeCardProps> = ({
                 selectLabelId="list-type-select-label"
                 labelsAndValues={listTypeLabelsAndValues}
                 listTitle="List Type"
-                defaultValue={fields.listType ?? undefined}
+                defaultValue={fields.listType}
                 onChange={valueOnChangeDropdownList(fieldSetter, errorSetter, "listType")}
             />
             <ErrorText>{errorText(formErrors.listType)}</ErrorText>

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -4,8 +4,7 @@ import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ErrorText } from "@/components/Form/formStyling";
 import DropdownListInput from "@/components/DataInput/DropdownListInput";
 import { ParcelCardProps } from "../ParcelForm";
-import { ListTypeLabelsAndValues } from "@/common/fetch";
-import { ListName } from "@/app/lists/ListDataview";
+import { ListTypeLabelsAndValues, ListName } from "@/common/fetch";
 
 interface ListTypeCardProps extends ParcelCardProps {
     listTypeLabelsAndValues: ListTypeLabelsAndValues;
@@ -33,7 +32,7 @@ const ListTypeCard: React.FC<ListTypeCardProps> = ({
             required={true}
             text={
                 clientDefaultList
-                    ? `Whist list should be used to pack this parcel? The default list type for this client is ${clientDefaultList}.`
+                    ? `Which list should be used to pack this parcel? The default list type for this client is ${clientDefaultList}.`
                     : "Which list should be used to pack this parcel?"
             }
         >

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { errorText, valueOnChangeDropdownList } from "@/components/Form/formFunctions";
+import GenericFormCard from "@/components/Form/GenericFormCard";
+import { ErrorText } from "@/components/Form/formStyling";
+import DropdownListInput from "@/components/DataInput/DropdownListInput";
+import { ParcelCardProps } from "../ParcelForm";
+import { ListTypeLabelsAndValues } from "@/common/fetch";
+
+interface ListTypeCardProps extends ParcelCardProps {
+    listTypeLabelsAndValues: ListTypeLabelsAndValues;
+}
+
+const ListTypeCard: React.FC<ListTypeCardProps> = ({
+    fieldSetter,
+    errorSetter,
+    formErrors,
+    fields,
+    listTypeLabelsAndValues,
+}) => {
+    return (
+        <GenericFormCard
+            title="List Type"
+            required={true}
+            text="Which list should be used to pack this parcel?"
+        >
+            <DropdownListInput
+                key={fields.listType}
+                selectLabelId="list-type-select-label"
+                labelsAndValues={listTypeLabelsAndValues}
+                listTitle="List Type"
+                defaultValue={fields.listType}
+                onChange={valueOnChangeDropdownList(fieldSetter, errorSetter, "listType")}
+            />
+            <ErrorText>{errorText(formErrors.listType)}</ErrorText>
+        </GenericFormCard>
+    );
+};
+
+export default ListTypeCard;

--- a/src/app/parcels/form/formSections/ListTypeCard.tsx
+++ b/src/app/parcels/form/formSections/ListTypeCard.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { errorText, valueOnChangeDropdownList } from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ErrorText } from "@/components/Form/formStyling";
 import DropdownListInput from "@/components/DataInput/DropdownListInput";
 import { ParcelCardProps } from "../ParcelForm";
 import { ListTypeLabelsAndValues } from "@/common/fetch";
+import { ListName } from "@/app/lists/ListDataview";
 
 interface ListTypeCardProps extends ParcelCardProps {
     listTypeLabelsAndValues: ListTypeLabelsAndValues;
@@ -17,11 +18,24 @@ const ListTypeCard: React.FC<ListTypeCardProps> = ({
     fields,
     listTypeLabelsAndValues,
 }) => {
+    const [clientDefaultList, setClientDefaultList] = useState<ListName | null>(null);
+
+    useEffect(() => {
+        const defaultArray = listTypeLabelsAndValues.find(([label, _]) => {
+            return label.includes("default");
+        }) as [string, ListName];
+        setClientDefaultList(defaultArray ? defaultArray[1] : null);
+    }, [listTypeLabelsAndValues]);
+
     return (
         <GenericFormCard
             title="List Type"
             required={true}
-            text="Which list should be used to pack this parcel?"
+            text={
+                clientDefaultList
+                    ? `Whist list should be used to pack this parcel? The default list type for this client is ${clientDefaultList}.`
+                    : "Which list should be used to pack this parcel?"
+            }
         >
             <DropdownListInput
                 key={fields.listType}

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -15,6 +15,7 @@ import {
     convertDataToDataForDataViewer,
 } from "@/components/DataViewer/DataViewer";
 import { formatEventName } from "./format";
+import { ListType } from "@/common/fetch";
 
 type FetchExpandedParcelDetailsResult =
     | {
@@ -46,6 +47,7 @@ const getExpandedParcelDetails = async (
         packing_date,
         created_at,
         collection_datetime,
+        list_type,
         packing_slot: packing_slots (
             name
          ),
@@ -120,6 +122,7 @@ const getExpandedParcelDetails = async (
                     isActive: true,
                     voucherNumber: rawParcelDetails.voucher_number ?? "",
                     fullName: client.full_name ?? "",
+                    listType: rawParcelDetails.list_type,
                     address: formatAddressFromClientDetails(client),
                     deliveryInstructions: client.delivery_instructions ?? "",
                     phoneNumber: client.phone_number ?? "",
@@ -148,6 +151,7 @@ const getExpandedParcelDetails = async (
                 address: formatAddressFromClientDetails(client),
                 deliveryInstructions: client.delivery_instructions,
                 phoneNumber: client.phone_number,
+                listType: rawParcelDetails.list_type,
                 household: formatHouseholdFromFamilyDetails(client.family),
                 adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
                 children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
@@ -186,6 +190,7 @@ interface ParcelDataForActiveClient extends ParcelDataIndependentOfClient {
     household: string;
     adults: string;
     children: string;
+    listType: ListType;
 }
 
 type ExpandedParcelData = ParcelDataForActiveClient | ParcelDataForInactiveClient;

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -15,7 +15,6 @@ import {
     convertDataToDataForDataViewer,
 } from "@/components/DataViewer/DataViewer";
 import { formatEventName } from "./format";
-import { ListType } from "@/common/fetch";
 
 type FetchExpandedParcelDetailsResult =
     | {
@@ -47,7 +46,6 @@ const getExpandedParcelDetails = async (
         packing_date,
         created_at,
         collection_datetime,
-        list_type,
         packing_slot: packing_slots (
             name
          ),
@@ -122,7 +120,6 @@ const getExpandedParcelDetails = async (
                     isActive: true,
                     voucherNumber: rawParcelDetails.voucher_number ?? "",
                     fullName: client.full_name ?? "",
-                    listType: rawParcelDetails.list_type,
                     address: formatAddressFromClientDetails(client),
                     deliveryInstructions: client.delivery_instructions ?? "",
                     phoneNumber: client.phone_number ?? "",
@@ -151,7 +148,6 @@ const getExpandedParcelDetails = async (
                 address: formatAddressFromClientDetails(client),
                 deliveryInstructions: client.delivery_instructions,
                 phoneNumber: client.phone_number,
-                listType: rawParcelDetails.list_type,
                 household: formatHouseholdFromFamilyDetails(client.family),
                 adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
                 children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
@@ -190,7 +186,6 @@ interface ParcelDataForActiveClient extends ParcelDataIndependentOfClient {
     household: string;
     adults: string;
     children: string;
-    listType: ListType;
 }
 
 type ExpandedParcelData = ParcelDataForActiveClient | ParcelDataForInactiveClient;

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -29,7 +29,7 @@ type UserProfileDataAndError =
 
 export interface ParcelWithCollectionCentreAndPackingSlot {
     client_id: string;
-    list_type: ListType | null;
+    list_type: ListType | undefined;
     collection_centre: CollectionCentre | null;
     collection_datetime: string | null;
     packing_date: string | null;

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -29,7 +29,7 @@ type UserProfileDataAndError =
 
 export interface ParcelWithCollectionCentreAndPackingSlot {
     client_id: string;
-    list_type: ListType | "";
+    list_type: ListType | null;
     collection_centre: CollectionCentre | null;
     collection_datetime: string | null;
     packing_date: string | null;

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -202,7 +202,12 @@ export type ListType = Database["public"]["Enums"]["list_type"];
 export const LIST_TYPES_ARRAY: ListType[] = ["regular", "hotel"] as const;
 
 export type FetchClientError = { type: FetchClientErrorType; logId: string };
+
 export type ListTypeLabelsAndValues = [string, string][];
+
+export type ListName = Database["public"]["Enums"]["list_type"];
+
+export const listTypes = ["regular", "hotel"] as ListName[];
 
 type FetchClientResponse =
     | {

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -29,7 +29,7 @@ type UserProfileDataAndError =
 
 export interface ParcelWithCollectionCentreAndPackingSlot {
     client_id: string;
-    list_type: ListType | undefined;
+    list_type?: ListType;
     collection_centre: CollectionCentre | null;
     collection_datetime: string | null;
     packing_date: string | null;

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -29,7 +29,7 @@ type UserProfileDataAndError =
 
 export interface ParcelWithCollectionCentreAndPackingSlot {
     client_id: string;
-    list_type: ListName | "";
+    list_type: ListType | "";
     collection_centre: CollectionCentre | null;
     collection_datetime: string | null;
     packing_date: string | null;
@@ -204,10 +204,6 @@ export const LIST_TYPES_ARRAY: ListType[] = ["regular", "hotel"] as const;
 export type FetchClientError = { type: FetchClientErrorType; logId: string };
 
 export type ListTypeLabelsAndValues = [string, string][];
-
-export type ListName = Database["public"]["Enums"]["list_type"];
-
-export const listTypes = ["regular", "hotel"] as ListName[];
 
 type FetchClientResponse =
     | {

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -29,6 +29,7 @@ type UserProfileDataAndError =
 
 export interface ParcelWithCollectionCentreAndPackingSlot {
     client_id: string;
+    list_type: ListName | "";
     collection_centre: CollectionCentre | null;
     collection_datetime: string | null;
     packing_date: string | null;
@@ -200,6 +201,9 @@ export type ListType = Database["public"]["Enums"]["list_type"];
 
 export const LIST_TYPES_ARRAY: ListType[] = ["regular", "hotel"] as const;
 
+export type FetchClientError = { type: FetchClientErrorType; logId: string };
+export type ListTypeLabelsAndValues = [string, string][];
+
 type FetchClientResponse =
     | {
           data: Schema["clients"];
@@ -207,7 +211,7 @@ type FetchClientResponse =
       }
     | {
           data: null;
-          error: { type: FetchClientErrorType; logId: string };
+          error: FetchClientError;
       };
 
 export type FetchClientErrorType = "clientFetchFailed" | "noMatchingClients";


### PR DESCRIPTION
## What's changed
Add a dropdown section in the parcel add / edit forms to set the list type of the parcel. One of the dropdown elements shows which of the options is the default list type of the recipient of the parcel. There is also some descriptive text which states this in the form.

When adding the parcel, the dropdown defaults to the parcel's client's default list type.

When editing the parcel, the dropdown defaults to the parcel's current list type.

Changed client details modal to include their default list type,

## Screenshots / Videos
Before 
![image](https://github.com/user-attachments/assets/ba602bd9-230e-4e16-a424-5684919d0ea5)
![image](https://github.com/user-attachments/assets/79286bae-74af-4311-ae8c-3ebc8d30a2a8)

After
![image](https://github.com/user-attachments/assets/e4a901e8-5340-4783-9ea7-302da8a73161)
![image](https://github.com/user-attachments/assets/422681a9-e97b-473a-9b6c-cae514014687)


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Introduction of Enum and Type for Better List Handling**
Added a new enumeration (`ListName`) and a type (`ListTypeLabelsAndValues`) in `fetch.ts` to better handle different types of lists, making it easier for the system to manage them.

* **Enhanced Client Data with Default List**
Upgraded the `ExpandedClientData` interface to include a `defaultList` property. This change, which was made in `getExpandedClientDetails.ts`, allows us to associate a default list with our client data, potentially making list-access more efficient.

* **Adopted `ListName` in Various Components**
The `ListName` enumeration has been imported and utilized in various form-related components for parcels such as `AddParcelForm.tsx`, `EditParcelForm.tsx`, `ParcelForm.tsx`, `EditModal.tsx`, and `ListDataview.tsx`, facilitating greater code uniformity and list handling consistency across these components.

* **Modified Functions for Improved Parcel Form Handling**
In the code for the parcel forms (`AddParcelForm`, `EditParcelForm` and `ParcelForm`), the `ListName` and `listTypeLabelsAndValues` properties have been included. Additionally, the `initialParcelFields` and `initialParcelFormErrors` constants were adjusted, which should improve the way we deal with forms related to parcel data.

* **Addition of New File for List Type Handling in Forms**
Introduced a new file, `ListTypeCard`, in the `formSections` directory, indicating a step towards enhanced form management where listing of types is involved.

