### PR TITLE
VFB-305 add list type to expanded parcel details modal

### DIFF
--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -8,13 +8,14 @@ import {
     formatBreakdownOfChildrenFromFamilyDetails,
     formatHouseholdFromFamilyDetails,
 } from "@/app/clients/getExpandedClientDetails";
-import { formatDateTime, formatDatetimeAsDate } from "@/common/format";
+import { capitaliseWords, formatDateTime, formatDatetimeAsDate } from "@/common/format";
 import {
     Data,
     DataForDataViewer,
     convertDataToDataForDataViewer,
 } from "@/components/DataViewer/DataViewer";
 import { formatEventName } from "./format";
+import { ListType } from "@/common/fetch";
 
 type FetchExpandedParcelDetailsResult =
     | {
@@ -46,6 +47,7 @@ const getExpandedParcelDetails = async (
         packing_date,
         created_at,
         collection_datetime,
+        list_type,
         packing_slot: packing_slots (
             name
          ),
@@ -120,6 +122,7 @@ const getExpandedParcelDetails = async (
                     isActive: true,
                     voucherNumber: rawParcelDetails.voucher_number ?? "",
                     fullName: client.full_name ?? "",
+                    listType: rawParcelDetails.list_type,
                     address: formatAddressFromClientDetails(client),
                     deliveryInstructions: client.delivery_instructions ?? "",
                     phoneNumber: client.phone_number ?? "",
@@ -148,6 +151,7 @@ const getExpandedParcelDetails = async (
                 address: formatAddressFromClientDetails(client),
                 deliveryInstructions: client.delivery_instructions,
                 phoneNumber: client.phone_number,
+                listType: rawParcelDetails.list_type,
                 household: formatHouseholdFromFamilyDetails(client.family),
                 adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
                 children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
@@ -171,6 +175,7 @@ interface ParcelDataIndependentOfClient extends Data {
     packingSlot: string;
     method: string;
     createdAt: string;
+    listType: ListType;
 }
 
 interface ParcelDataForInactiveClient extends ParcelDataIndependentOfClient {
@@ -223,6 +228,9 @@ export const getExpandedParcelDataForDataViewer = (
     parcelDetailsForDataViewer["isActive"] = {
         value: parcelDetails["isActive"],
         hide: true,
+    };
+    parcelDetailsForDataViewer["listType"] = {
+        value: capitaliseWords(parcelDetails["listType"]),
     };
     return parcelDetailsForDataViewer;
 };


### PR DESCRIPTION
## What's changed
Parcel details modal includes list type

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/bf267661-59fa-422f-b6c8-b3821259eabf)
After
![image](https://github.com/user-attachments/assets/2a520b0f-1cf1-45a9-8b5d-2936d4fc51d1)

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Implementation of List Type in getExpandedParcelDetails Functions**
The functions for gathering detailed information about parcels, specific `getExpandedParcelDetails` and `getExpandedParcelDataForDataViewer`, are now enhanced with an additional property, `listType`. This property was added to their relevant interfaces (`FetchExpandedParcelDetailsResult` and `ParcelDataForInactiveClient`), providing more comprehensive data about each parcel. Through this update, we've improved the depth of parcel information that can be fetched, thereby enhancing data accuracy and comprehension.

