### PR TITLE
VFB-306: Fix default parcels tables query to include new parcels

### DIFF
--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -119,7 +119,10 @@ const buildLastStatusFilter = async (): Promise<ParcelsFilter<string[]>> => {
     const lastStatusSearch: ParcelsFilterMethod<string[]> = (query, state) => {
         if (state.length === 0) {
             // Default is to show everything that's not deleted
-            return query.neq("last_status_event_name", "Parcel Deleted");
+            return query.or(
+                // eslint-disable-next-line quotes
+                'last_status_event_name.neq."Parcel Deleted",last_status_event_name.is.null'
+            );
         } else if (state.includes(labelForNoStatus)) {
             return query.or(
                 `last_status_event_name.is.null,last_status_event_name.in.("",${state.join(",")})`


### PR DESCRIPTION
## What's changed
The default parcels table filter, added in #340 , wasn't correctly handling parcels with no (null) event status data

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [X] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`


---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Improvement made to checks in parcel search feature**
The criteria for parcel search interaction in our system has been enhanced. Previously, our search function could mistakenly fetch parcels marked as "Deleted". Now, this update ensures exclusion of any deleted parcel from the search results. It gives more accurate and relevant output to the users, enhancing their overall experience.
