### PR TITLE
VFB-none fix large word wrappins issue for wiki item details

### DIFF
--- a/src/app/info/StyleComponents.tsx
+++ b/src/app/info/StyleComponents.tsx
@@ -9,6 +9,10 @@ export const WikiItemPositioner = styled.div`
     min-width: 100%;
 `;
 
+export const WikiItemDetailsTextBreaker = styled.div`
+    word-break: break-all;
+`;
+
 export const WikiUpdateDataButton = styled.button`
     border: none;
     background-color: rgba(0, 0, 0, 0);

--- a/src/app/info/WikiItemDisplay.tsx
+++ b/src/app/info/WikiItemDisplay.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { DbWikiRow } from "@/databaseUtils";
-import { WikiItemAccordionSurface, WikiUpdateDataButton } from "@/app/info/StyleComponents";
+import {
+    WikiItemAccordionSurface,
+    WikiItemDetailsTextBreaker,
+    WikiUpdateDataButton,
+} from "@/app/info/StyleComponents";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { convertContentToElements } from "@/app/info/WikiItems";
@@ -34,7 +38,11 @@ const WikiItemDisplay: React.FC<DefaultViewProps> = ({ rowData, openEditMode }) 
                     >
                         <h2>{rowData.title}</h2>
                     </AccordionSummary>
-                    <AccordionDetails>{convertContentToElements(rowData.content)}</AccordionDetails>
+                    <AccordionDetails>
+                        <WikiItemDetailsTextBreaker>
+                            {convertContentToElements(rowData.content)}
+                        </WikiItemDetailsTextBreaker>
+                    </AccordionDetails>
                 </Accordion>
             </WikiItemAccordionSurface>
         </>


### PR DESCRIPTION
## What's changed
large words in the expanded view of wiki items no longer clip off the page and instead are wrapped onto the next line

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![image](https://github.com/user-attachments/assets/213790b2-a1bd-48e9-a3a7-f1c3f3ce54e2)| ![image](https://github.com/user-attachments/assets/a7e1b406-f903-4007-8fb0-4b780eb38562) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Introduced a New Component**
A fresh code component named `WikiItemDetailsTextBreaker` has been added. This serves like a new ingredient in our code recipe.

* **Implementation of the New Component**
This new component `WikiItemDetailsTextBreaker` has been integrated into another component `WikiItemDisplay`. Basically, we've just added this new ingredient into our main dish to improve the quality.

* **Upgradation of the AccordionDetails Component**
To further enhance the user experience, the functionality of the `AccordionDetails` component has been upgraded by incorporating `convertContentToElements`, wrapped inside the new `WikiItemDetailsTextBreaker` component. This is akin to adding an extra feature to the application, designed to make it more user-friendly and interactive.
