### PR TITLE
VFB-259 Fix cancel button bug

### DIFF
--- a/src/app/lists/CommentBox.tsx
+++ b/src/app/lists/CommentBox.tsx
@@ -106,14 +106,14 @@ const CommentBox: React.FC<CommentProps> = ({ originalComment }) => {
         <Wrapper>
             <HeaderAndButtonContainer>
                 <h2>Comments</h2>
-                <ButtonContainer>
+                {hasUnsavedChanges && <ButtonContainer>
                     <Button variant="outlined" onClick={() => setValue(originalComment)}>
                         Cancel
                     </Button>
                     <Button variant="contained" onClick={onSubmit}>
                         Save
                     </Button>
-                </ButtonContainer>
+                </ButtonContainer>}
             </HeaderAndButtonContainer>
             <CommentBoxContainer>
                 <FreeFormTextInput

--- a/src/app/lists/CommentBox.tsx
+++ b/src/app/lists/CommentBox.tsx
@@ -106,14 +106,16 @@ const CommentBox: React.FC<CommentProps> = ({ originalComment }) => {
         <Wrapper>
             <HeaderAndButtonContainer>
                 <h2>Comments</h2>
-                {hasUnsavedChanges && <ButtonContainer>
-                    <Button variant="outlined" onClick={() => setValue(originalComment)}>
-                        Cancel
-                    </Button>
-                    <Button variant="contained" onClick={onSubmit}>
-                        Save
-                    </Button>
-                </ButtonContainer>}
+                {hasUnsavedChanges && (
+                    <ButtonContainer>
+                        <Button variant="outlined" onClick={() => setValue(originalComment)}>
+                            Cancel
+                        </Button>
+                        <Button variant="contained" onClick={onSubmit}>
+                            Save
+                        </Button>
+                    </ButtonContainer>
+                )}
             </HeaderAndButtonContainer>
             <CommentBoxContainer>
                 <FreeFormTextInput


### PR DESCRIPTION
## What's changed
Cancel and save buttons now only appear once an edit has been made on the Lists page.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Modification in the comment input area**
The change was made in a file where the functions for our comments section are defined. This file is stored in a folder that contains the other parts of our application.
* **Enhancement to save function**
Added a new feature that will decide whether or not to show the save button. This decision is based on whether there are changes to be saved. As a result, there will be a cleaner user interface, with the button only appearing when it's relevant.
