### PR TITLE
VFB-67 phone number validation is too strict

### DIFF
--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -11,7 +11,7 @@ export const displayNameForDeletedClient = "Deleted Client";
 export const displayNameForNullDriverName = "Unknown Driver";
 
 // Following characters excluded from regex as are removed before checking format matches: ( ) - \s
-export const phoneNumberRegex = /^([0][0-9]{9-12}|[+][0-9]{7,15})?$/;
+export const phoneNumberRegex = /^([0][0-9]{9,12}|[+][0-9]{7,15})?$/;
 // Regex source: https://ihateregex.io/expr/phone/
 
 export const formatCamelCaseKey = (objectKey: string): string => {

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -11,7 +11,7 @@ export const displayNameForDeletedClient = "Deleted Client";
 export const displayNameForNullDriverName = "Unknown Driver";
 
 // Following characters excluded from regex as are removed before checking format matches: ( ) - \s
-export const phoneNumberRegex = /^([0][0-9]{9,12}|[+][0-9]{7,15})?$/;
+export const phoneNumberRegex = /^((0|\+44)\d{9,11}|\+(?!44)\d{7,15})?$/;
 // Regex source: https://ihateregex.io/expr/phone/
 
 export const formatCamelCaseKey = (objectKey: string): string => {

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -10,7 +10,8 @@ export const displayNameForDeletedClient = "Deleted Client";
 
 export const displayNameForNullDriverName = "Unknown Driver";
 
-export const phoneNumberRegex = /^([+]?[(]?[0-9]{3}[)]?[-\s.]?[0-9]{3}[-\s.]?[0-9]{4,6})?$/;
+// Following characters excluded from regex as are removed before checking format matches: ( ) - \s
+export const phoneNumberRegex = /^([0][0-9]{9-12}|[+][0-9]{7,15})?$/;
 // Regex source: https://ihateregex.io/expr/phone/
 
 export const formatCamelCaseKey = (objectKey: string): string => {

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -12,7 +12,6 @@ export const displayNameForNullDriverName = "Unknown Driver";
 
 // Following characters excluded from regex as are removed before checking format matches: ( ) - \s
 export const phoneNumberRegex = /^((0|\+44)\d{9,11}|\+(?!44)\d{7,15})?$/;
-// Regex source: https://ihateregex.io/expr/phone/
 
 export const formatCamelCaseKey = (objectKey: string): string => {
     const withSpace = objectKey.replaceAll(/([a-z])([A-Z])/g, "$1 $2");

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -96,7 +96,9 @@ export const onChangeText = <SpecificFields extends Fields>(
     return (event) => {
         const input = event.target.value;
         const errorType = getErrorType(
-            (key === "telephoneNumber") || (key === "phoneNumber") ? input.replaceAll(/[\s-()]/g, "") : input,
+            key === "telephoneNumber" || key === "phoneNumber"
+                ? input.replaceAll(/[\s-()]/g, "")
+                : input,
             required,
             regex,
             additionalCondition

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -95,7 +95,12 @@ export const onChangeText = <SpecificFields extends Fields>(
 ): SelectChangeEventHandler => {
     return (event) => {
         const input = event.target.value;
-        const errorType = getErrorType(input, required, regex, additionalCondition);
+        const errorType = getErrorType(
+            key === ("telephoneNumber" || "phoneNumber") ? input.replaceAll(/[\s-()]/g, "") : input,
+            required,
+            regex,
+            additionalCondition
+        );
         errorSetter({ [key]: errorType } as { [key in keyof FormErrors<SpecificFields>]: Errors });
         if (errorType === Errors.none) {
             const newValue = formattingFunction ? formattingFunction(input) : input;

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -96,7 +96,7 @@ export const onChangeText = <SpecificFields extends Fields>(
     return (event) => {
         const input = event.target.value;
         const errorType = getErrorType(
-            key === ("telephoneNumber" || "phoneNumber") ? input.replaceAll(/[\s-()]/g, "") : input,
+            (key === "telephoneNumber") || (key === "phoneNumber") ? input.replaceAll(/[\s-()]/g, "") : input,
             required,
             regex,
             additionalCondition


### PR DESCRIPTION
## What's changed
Phone number validation changes:
Three options:
starts with 0 and can be 10 to 12 digits (UK mobile/landline)
starts +44 and can be 11 to 13 (UK mobile)
or starts with + and can be 7 to 15 digits (max and min phone number with country code)

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/9d95c4f1-2af6-41ed-b4f8-154ea51f99dd)

After
![image](https://github.com/user-attachments/assets/9999dda6-2a4c-4959-9e29-9c9863101ee1)

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

* **Enhancement of Phone Number Input**
We have improved the way that phone numbers are validated in our system. A new pattern has been implemented to check the format of the phone numbers, ensuring only valid numbers are accepted.
* **Improved Data Handling in Text Change Function**
In the process of data entry, we have changed the function that processes your text input when entering phone numbers. It will now remove any spaces, dashes, and parentheses automatically. This way, we eliminate potential input errors before the system checks for any further issues.
