### PR TITLE
VFB-269 add functionality to reorder wiki items

### DIFF
--- a/src/app/info/EditModeDependentItem.tsx
+++ b/src/app/info/EditModeDependentItem.tsx
@@ -5,12 +5,13 @@ import { useState } from "react";
 import WikiItemDisplay from "@/app/info/WikiItemDisplay";
 import WikiItemEdit from "@/app/info/WikiItemEdit";
 import AdminManagerDependentView from "@/app/info/AdminManagerDependentView";
+import { DirectionString } from "@/app/info/WikiItems";
 
 interface EditProps {
     row?: DbWikiRow;
     appendNewRow: (newRow: DbWikiRow, index: number) => void;
     removeRow: (row: DbWikiRow) => number;
-    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
+    swapRows: (row1: DbWikiRow, direction: DirectionString) => void;
     setErrorMessage: (error: string | null) => void;
 }
 

--- a/src/app/info/EditModeDependentItem.tsx
+++ b/src/app/info/EditModeDependentItem.tsx
@@ -10,9 +10,17 @@ interface EditProps {
     row?: DbWikiRow;
     appendNewRow: (newRow: DbWikiRow, index: number) => void;
     removeRow: (row: DbWikiRow) => number;
+    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
+    setErrorMessage: (error: string | null) => void;
 }
 
-const EditModeDependentItem: React.FC<EditProps> = ({ row, appendNewRow, removeRow }) => {
+const EditModeDependentItem: React.FC<EditProps> = ({
+    row,
+    appendNewRow,
+    removeRow,
+    swapRows,
+    setErrorMessage,
+}) => {
     const [rowData, setrowData] = useState<DbWikiRow | undefined>(row);
     const [isInEditMode, setIsInEditMode] = useState<boolean>(false);
     return (
@@ -26,6 +34,8 @@ const EditModeDependentItem: React.FC<EditProps> = ({ row, appendNewRow, removeR
                             setIsInEditMode={setIsInEditMode}
                             appendNewRow={appendNewRow}
                             removeRow={removeRow}
+                            swapRows={swapRows}
+                            setErrorMessage={setErrorMessage}
                         />
                     </AdminManagerDependentView>
                 ) : (
@@ -34,6 +44,7 @@ const EditModeDependentItem: React.FC<EditProps> = ({ row, appendNewRow, removeR
                         openEditMode={() => {
                             setIsInEditMode(true);
                         }}
+                        swapRows={swapRows}
                     />
                 ))}
         </>

--- a/src/app/info/InfoPage.tsx
+++ b/src/app/info/InfoPage.tsx
@@ -1,23 +1,11 @@
 import React from "react";
 import WikiItems from "@/app/info/WikiItems";
-import { DbWikiRow } from "@/databaseUtils";
-import { PostgrestError } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Database } from "@/databaseTypesFile";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
-
-interface WikiRowsQuerySuccessType {
-    data: DbWikiRow[];
-    error: null;
-}
-interface WikiRowsQueryFailureType {
-    data: null;
-    error: PostgrestError;
-}
-
-export type WikiRowsQueryType = WikiRowsQuerySuccessType | WikiRowsQueryFailureType;
+import { WikiRowsQueryType } from "@/common/fetch";
 
 async function getWikiRows(): Promise<WikiRowsQueryType> {
     const cookieStore: ReadonlyRequestCookies = cookies();

--- a/src/app/info/StyleComponents.tsx
+++ b/src/app/info/StyleComponents.tsx
@@ -22,6 +22,14 @@ export const WikiUpdateDataButton = styled.button`
     }
 `;
 
+export const ReorderArrowDiv = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    vertical-align: middle;
+`;
+
 export const StyledPaper = styled(Paper)`
     margin: 1rem;
     padding: 1rem;

--- a/src/app/info/WikiItemDisplay.tsx
+++ b/src/app/info/WikiItemDisplay.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/app/info/StyleComponents";
 import { Accordion, AccordionDetails, AccordionSummary } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { convertContentToElements } from "@/app/info/WikiItems";
+import { convertContentToElements, DirectionString } from "@/app/info/WikiItems";
 import AdminManagerDependentView from "@/app/info/AdminManagerDependentView";
 import EditIcon from "@mui/icons-material/Edit";
 import KeyboardDoubleArrowUpIcon from "@mui/icons-material/KeyboardDoubleArrowUp";
@@ -18,7 +18,7 @@ import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrow
 interface DefaultViewProps {
     rowData: DbWikiRow;
     openEditMode: () => void;
-    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
+    swapRows: (row1: DbWikiRow, direction: DirectionString) => void;
 }
 
 const WikiItemDisplay: React.FC<DefaultViewProps> = ({ rowData, openEditMode, swapRows }) => {
@@ -28,14 +28,14 @@ const WikiItemDisplay: React.FC<DefaultViewProps> = ({ rowData, openEditMode, sw
                 <ReorderArrowDiv>
                     <WikiUpdateDataButton
                         onClick={() => {
-                            swapRows(rowData, true);
+                            swapRows(rowData, "up");
                         }}
                     >
                         <KeyboardDoubleArrowUpIcon />
                     </WikiUpdateDataButton>
                     <WikiUpdateDataButton
                         onClick={() => {
-                            swapRows(rowData, false);
+                            swapRows(rowData, "down");
                         }}
                     >
                         <KeyboardDoubleArrowDownIcon />

--- a/src/app/info/WikiItemDisplay.tsx
+++ b/src/app/info/WikiItemDisplay.tsx
@@ -2,6 +2,7 @@
 
 import { DbWikiRow } from "@/databaseUtils";
 import {
+    ReorderArrowDiv,
     WikiItemAccordionSurface,
     WikiItemDetailsTextBreaker,
     WikiUpdateDataButton,
@@ -11,16 +12,35 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { convertContentToElements } from "@/app/info/WikiItems";
 import AdminManagerDependentView from "@/app/info/AdminManagerDependentView";
 import EditIcon from "@mui/icons-material/Edit";
+import KeyboardDoubleArrowUpIcon from "@mui/icons-material/KeyboardDoubleArrowUp";
+import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
 
 interface DefaultViewProps {
     rowData: DbWikiRow;
     openEditMode: () => void;
+    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
 }
 
-const WikiItemDisplay: React.FC<DefaultViewProps> = ({ rowData, openEditMode }) => {
+const WikiItemDisplay: React.FC<DefaultViewProps> = ({ rowData, openEditMode, swapRows }) => {
     return (
         <>
             <AdminManagerDependentView>
+                <ReorderArrowDiv>
+                    <WikiUpdateDataButton
+                        onClick={() => {
+                            swapRows(rowData, true);
+                        }}
+                    >
+                        <KeyboardDoubleArrowUpIcon />
+                    </WikiUpdateDataButton>
+                    <WikiUpdateDataButton
+                        onClick={() => {
+                            swapRows(rowData, false);
+                        }}
+                    >
+                        <KeyboardDoubleArrowDownIcon />
+                    </WikiUpdateDataButton>
+                </ReorderArrowDiv>
                 <WikiUpdateDataButton
                     onClick={() => {
                         openEditMode();

--- a/src/app/info/WikiItemEdit.tsx
+++ b/src/app/info/WikiItemEdit.tsx
@@ -17,6 +17,7 @@ import { WikiRowQueryType } from "@/app/info/AddWikiItemButton";
 import KeyboardDoubleArrowUpIcon from "@mui/icons-material/KeyboardDoubleArrowUp";
 import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrowDown";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
+import { DirectionString } from "@/app/info/WikiItems";
 
 interface WikiItemEditProps {
     rowData: DbWikiRow;
@@ -24,7 +25,7 @@ interface WikiItemEditProps {
     setIsInEditMode: (isInEditMode: boolean) => void;
     appendNewRow: (newRow: DbWikiRow, index: number) => void;
     removeRow: (row: DbWikiRow) => number;
-    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
+    swapRows: (row1: DbWikiRow, direction: DirectionString) => void;
     setErrorMessage: (error: string | null) => void;
 }
 
@@ -67,9 +68,9 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
                 ...auditLog,
                 wasSuccess: true,
             });
+            removeRow(rowData);
+            setRowData(undefined);
         }
-        removeRow(rowData);
-        setRowData(undefined);
     };
 
     const cancelWikiItemEdit = (): void => {
@@ -149,14 +150,14 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
             <ReorderArrowDiv>
                 <WikiUpdateDataButton
                     onClick={() => {
-                        swapRows(rowData, true);
+                        swapRows(rowData, "up");
                     }}
                 >
                     <KeyboardDoubleArrowUpIcon />
                 </WikiUpdateDataButton>
                 <WikiUpdateDataButton
                     onClick={() => {
-                        swapRows(rowData, false);
+                        swapRows(rowData, "down");
                     }}
                 >
                     <KeyboardDoubleArrowDownIcon />

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -123,13 +123,13 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
         return indexToRemove;
     };
 
-    const [isSwapping, setIsSwapping] = useState(false);
+    const [isSwapMode, setIsSwapMode] = useState(false);
 
     const swapRows = async (row1: DbWikiRow, upwards: boolean): Promise<void> => {
-        if (isSwapping) {
+        if (isSwapMode) {
             return;
         }
-        setIsSwapping(true);
+        setIsSwapMode(true);
 
         const rowIndex1 = displayRows.findIndex((row) => {
             return row.wiki_key == row1.wiki_key;
@@ -137,7 +137,7 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
         const rowIndex2 = rowIndex1 + (upwards ? -1 : 1);
 
         if (rowIndex2 < 0 || rowIndex2 >= displayRows.length) {
-            setIsSwapping(false);
+            setIsSwapMode(false);
             return;
         }
 
@@ -179,7 +179,7 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
                 content: { ...auditLog.content, newRow_order: row2.row_order },
             });
         }
-        setIsSwapping(false);
+        setIsSwapMode(false);
 
         reorderRows(row1, row2);
     };

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -153,7 +153,7 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
             wikiId: row1.wiki_key,
             content: {
                 itemName: row1.title,
-                oldRow_order: row1.row_order,
+                oldRowOrder: row1.row_order,
             },
         } as const satisfies Partial<AuditLog>;
 
@@ -176,7 +176,7 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
             void sendAuditLog({
                 ...auditLog,
                 wasSuccess: true,
-                content: { ...auditLog.content, newRow_order: row2.row_order },
+                content: { ...auditLog.content, newRowOrder: row2.row_order },
             });
         }
         setIsSwapMode(false);

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -9,8 +9,8 @@ import AddWikiItemButton from "@/app/info/AddWikiItemButton";
 import supabase from "@/supabaseClient";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
-import { TextValueContainer } from "../admin/auditLogTable/auditLogModal/AuditLogModalRow";
-import { ErrorSecondaryText } from "../errorStylingandMessages";
+import { TextValueContainer } from "@/app/admin/auditLogTable/auditLogModal/AuditLogModalRow";
+import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 
 interface WikiItemsProps {
     rows: DbWikiRow[];

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -2,10 +2,15 @@
 
 import { DbWikiRow } from "@/databaseUtils";
 import { WikiItemPositioner } from "@/app/info/StyleComponents";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import EditModeDependentItem from "@/app/info/EditModeDependentItem";
 import AdminManagerDependentView from "@/app/info/AdminManagerDependentView";
 import AddWikiItemButton from "@/app/info/AddWikiItemButton";
+import supabase from "@/supabaseClient";
+import { logErrorReturnLogId } from "@/logger/logger";
+import { AuditLog, sendAuditLog } from "@/server/auditLog";
+import { TextValueContainer } from "../admin/auditLogTable/auditLogModal/AuditLogModalRow";
+import { ErrorSecondaryText } from "../errorStylingandMessages";
 
 interface WikiItemsProps {
     rows: DbWikiRow[];
@@ -15,6 +20,8 @@ interface WikiItemProps {
     row: DbWikiRow;
     appendNewRow: (newRow: DbWikiRow, index: number) => void;
     removeRow: (row: DbWikiRow) => number;
+    swapRows: (row1: DbWikiRow, upwards: boolean) => void;
+    setErrorMessage: (errorMessage: string | null) => void;
 }
 
 interface ContentPart {
@@ -49,15 +56,29 @@ export const convertContentToElements = (rowContent: string): React.JSX.Element[
     });
 };
 
-const WikiItem: React.FC<WikiItemProps> = ({ row, appendNewRow, removeRow }) => {
+const WikiItem: React.FC<WikiItemProps> = ({
+    row,
+    appendNewRow,
+    removeRow,
+    swapRows,
+    setErrorMessage,
+}) => {
     return (
         <WikiItemPositioner>
-            <EditModeDependentItem row={row} appendNewRow={appendNewRow} removeRow={removeRow} />
+            <EditModeDependentItem
+                row={row}
+                appendNewRow={appendNewRow}
+                removeRow={removeRow}
+                swapRows={swapRows}
+                setErrorMessage={setErrorMessage}
+            />
         </WikiItemPositioner>
     );
 };
 
 const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
+    const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
     const sortedRows: DbWikiRow[] = rows.slice().sort((r1: DbWikiRow, r2: DbWikiRow) => {
         return r1.row_order > r2.row_order ? 1 : -1;
     });
@@ -83,8 +104,8 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
             index = displayRows.length;
         }
 
-        setDisplayRows((DisplayRows) => {
-            const temp = DisplayRows.slice();
+        setDisplayRows((displayRows) => {
+            const temp = displayRows.slice();
             temp.splice(index, 0, newRow);
             return temp;
         });
@@ -94,13 +115,98 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
         const indexToRemove: number = displayRows.findIndex(
             (sortedRow) => row.wiki_key === sortedRow.wiki_key
         );
-        setDisplayRows((DisplayRows) => {
-            const temp = DisplayRows.slice();
+        setDisplayRows((displayRows) => {
+            const temp = displayRows.slice();
             temp.splice(indexToRemove, 1);
             return temp;
         });
         return indexToRemove;
     };
+
+    const [isSwapping, setIsSwapping] = useState(false);
+
+    const swapRows = async (row1: DbWikiRow, upwards: boolean): Promise<void> => {
+        if (isSwapping) {
+            return;
+        }
+        setIsSwapping(true);
+
+        const rowIndex1 = displayRows.findIndex((row) => {
+            return row.wiki_key == row1.wiki_key;
+        });
+        const rowIndex2 = rowIndex1 + (upwards ? -1 : 1);
+
+        if (rowIndex2 < 0 || rowIndex2 >= displayRows.length) {
+            setIsSwapping(false);
+            return;
+        }
+
+        const row2 = displayRows[rowIndex2];
+
+        const { error } = await supabase.rpc("swap_two_wiki_rows", {
+            key1: row1.wiki_key,
+            key2: row2.wiki_key,
+        });
+
+        const auditLog = {
+            action: `move a wiki item ${row1.row_order <= row2.row_order ? "down" : "up"}`,
+            wikiId: row1.wiki_key,
+            content: {
+                itemName: row1.title,
+                oldRow_order: row1.row_order,
+            },
+        } as const satisfies Partial<AuditLog>;
+
+        if (error) {
+            const logId = await logErrorReturnLogId(
+                "Error with supabase function swap_two_wiki_rows",
+                {
+                    error: error,
+                }
+            );
+            setErrorMessage(`Failed to swap rows. Log ID: ${logId}`);
+
+            void sendAuditLog({
+                ...auditLog,
+                wasSuccess: false,
+                logId: logId,
+            });
+            return;
+        } else {
+            void sendAuditLog({
+                ...auditLog,
+                wasSuccess: true,
+                content: { ...auditLog.content, newRow_order: row2.row_order },
+            });
+        }
+        setIsSwapping(false);
+
+        reorderRows(row1, row2);
+    };
+
+    const reorderRows = (row1: DbWikiRow, row2: DbWikiRow): void => {
+        const wiki_keys = displayRows.map((displayRows) => displayRows.wiki_key);
+
+        const row1Index = wiki_keys.indexOf(row1.wiki_key);
+        const row2Index = wiki_keys.indexOf(row2.wiki_key);
+
+        const row1Item = displayRows[row1Index];
+        const row1Order = row1Item.row_order;
+
+        const row2Item = displayRows[row2Index];
+        const row2Order = row2Item.row_order;
+
+        row1Item.row_order = row2Order;
+        row2Item.row_order = row1Order;
+
+        const newDisplayRows = [...displayRows];
+
+        newDisplayRows[row1Index] = row2Item;
+        newDisplayRows[row2Index] = row1Item;
+
+        setDisplayRows(newDisplayRows);
+    };
+
     return (
         <>
             <AdminManagerDependentView>
@@ -109,13 +215,20 @@ const WikiItems: React.FC<WikiItemsProps> = ({ rows }) => {
                     appendNewRow={appendNewRow}
                 />
             </AdminManagerDependentView>
+            {errorMessage && (
+                <TextValueContainer>
+                    <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>
+                </TextValueContainer>
+            )}
             {displayRows.map((row: DbWikiRow) => {
                 return (
                     <WikiItem
                         row={row}
                         appendNewRow={appendNewRow}
                         removeRow={removeRow}
+                        swapRows={swapRows}
                         key={row.wiki_key}
+                        setErrorMessage={setErrorMessage}
                     />
                 );
             })}

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -1,4 +1,4 @@
-import { Schema } from "@/databaseUtils";
+import { DbWikiRow, Schema } from "@/databaseUtils";
 import { Supabase } from "@/supabaseUtils";
 import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
 import { PostgrestError } from "@supabase/supabase-js";
@@ -375,3 +375,14 @@ export const fetchUserProfile = async (
 
     return { data: data, error: null };
 };
+
+interface WikiRowsQuerySuccessType {
+    data: DbWikiRow[];
+    error: null;
+}
+interface WikiRowsQueryFailureType {
+    data: null;
+    error: PostgrestError;
+}
+
+export type WikiRowsQueryType = WikiRowsQuerySuccessType | WikiRowsQueryFailureType;

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -28,6 +28,7 @@ export type Database = {
           status_order: string | null
           wasSuccess: boolean
           website_data: string | null
+          wiki_id: string | null
         }
         Insert: {
           action: string
@@ -47,6 +48,7 @@ export type Database = {
           status_order?: string | null
           wasSuccess: boolean
           website_data?: string | null
+          wiki_id?: string | null
         }
         Update: {
           action?: string
@@ -66,6 +68,7 @@ export type Database = {
           status_order?: string | null
           wasSuccess?: boolean
           website_data?: string | null
+          wiki_id?: string | null
         }
         Relationships: [
           {
@@ -172,6 +175,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "website_data"
             referencedColumns: ["name"]
+          },
+          {
+            foreignKeyName: "public_audit_log_wiki_id_fkey"
+            columns: ["wiki_id"]
+            isOneToOne: false
+            referencedRelation: "wiki"
+            referencedColumns: ["wiki_key"]
           },
         ]
       }
@@ -1013,6 +1023,13 @@ export type Database = {
         Args: {
           id1: string
           id2: string
+        }
+        Returns: undefined
+      }
+      swap_two_wiki_rows: {
+        Args: {
+          key1: string
+          key2: string
         }
         Returns: undefined
       }

--- a/src/server/auditLog.ts
+++ b/src/server/auditLog.ts
@@ -22,6 +22,7 @@ export interface AuditLog {
     parcelId?: string;
     profileId?: string;
     websiteData?: string;
+    wikiId?: string;
 }
 
 export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
@@ -47,6 +48,7 @@ export async function sendAuditLog(auditLogProps: AuditLog): Promise<void> {
         wasSuccess: auditLogProps.wasSuccess,
         log_id: auditLogProps.logId,
         website_data: auditLogProps.websiteData,
+        wiki_id: auditLogProps.wikiId,
     };
 
     const supabase = getSupabaseServerComponentClient();

--- a/supabase/migrations/20240801110401_make_function_swap_two_wiki_rows_given_wiki_keys.sql
+++ b/supabase/migrations/20240801110401_make_function_swap_two_wiki_rows_given_wiki_keys.sql
@@ -1,0 +1,27 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.swap_two_wiki_rows(key1 uuid, key2 uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$DECLARE
+    row1order INT;
+    row2order INT;
+BEGIN
+    SELECT row_order INTO row1order FROM wiki WHERE wiki_key = key1;
+    SELECT row_order INTO row2order FROM wiki WHERE wiki_key = key2;
+
+    UPDATE wiki
+    SET row_order = -1
+    WHERE wiki_key = key1;
+
+    UPDATE wiki
+    SET row_order = row1order
+    WHERE wiki_key = key2;
+
+    UPDATE wiki
+    SET row_order = row2order
+    WHERE wiki_key = key1;
+END;$function$
+;
+
+

--- a/supabase/migrations/20240801131704_add_wiki_id_column_to_audit_log_table.sql
+++ b/supabase/migrations/20240801131704_add_wiki_id_column_to_audit_log_table.sql
@@ -1,0 +1,7 @@
+alter table "public"."audit_log" add column "wiki_id" uuid;
+
+alter table "public"."audit_log" add constraint "public_audit_log_wiki_id_fkey" FOREIGN KEY (wiki_id) REFERENCES wiki(wiki_key) ON DELETE RESTRICT not valid;
+
+alter table "public"."audit_log" validate constraint "public_audit_log_wiki_id_fkey";
+
+

--- a/supabase/migrations/20240801131704_add_wiki_id_column_to_audit_log_table.sql
+++ b/supabase/migrations/20240801131704_add_wiki_id_column_to_audit_log_table.sql
@@ -1,7 +1,5 @@
 alter table "public"."audit_log" add column "wiki_id" uuid;
 
-alter table "public"."audit_log" add constraint "public_audit_log_wiki_id_fkey" FOREIGN KEY (wiki_id) REFERENCES wiki(wiki_key) ON DELETE RESTRICT not valid;
+alter table "public"."audit_log" add constraint "public_audit_log_wiki_id_fkey" FOREIGN KEY (wiki_id) REFERENCES wiki(wiki_key) ON DELETE SET NULL not valid;
 
 alter table "public"."audit_log" validate constraint "public_audit_log_wiki_id_fkey";
-
-


### PR DESCRIPTION
## What's changed
Add a functionality to reorder wiki items. The wiki items can be reordered when in display or in edit mode.

Error messages added to page when supabase calls return an error. Also added audit logs to all wiki actions: reorder, delete, edit.

Changed save icon to be more obviously a save icon.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| 
![image](https://github.com/user-attachments/assets/fd56bbb1-c733-4d70-9ee4-57dae820386f)
 | ![image](https://github.com/user-attachments/assets/109cbe68-7027-4342-b457-4880d00f2a0a) |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [ ] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [x] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.