### PR TITLE
VFB-320 date range filter fix

### DIFF
--- a/src/components/DateInputs/DateRangeInputs.tsx
+++ b/src/components/DateInputs/DateRangeInputs.tsx
@@ -38,29 +38,30 @@ const DateRangeInputs: React.FC<Props> = (props) => {
         }
     };
 
+    const shouldSetDatesToBeEqual = (from: Dayjs | null, to: Dayjs | null): boolean => {
+        return from !== null && to !== null && from > to && areDatesAfterMinDate(from, to);
+    };
+
     const setFromValue = (fromValue: Dayjs | null): void => {
         setLocalFromValue(fromValue);
-        if (
-            fromValue &&
-            localToValue &&
-            fromValue > localToValue &&
-            fromValue >= reasonableMinDate
-        ) {
-            setLocalToValue(fromValue);
-            setRangeIfPossible(fromValue, fromValue);
-        } else {
-            setRangeIfPossible(fromValue, localToValue);
+
+        if (!shouldSetDatesToBeEqual(fromValue, localToValue)) {
+            return setRangeIfPossible(fromValue, localToValue);
         }
+
+        setLocalToValue(fromValue);
+        setRangeIfPossible(fromValue, fromValue);
     };
 
     const setToValue = (toValue: Dayjs | null): void => {
         setLocalToValue(toValue);
-        if (toValue && localFromValue && toValue < localFromValue && toValue >= reasonableMinDate) {
-            setLocalFromValue(toValue);
-            setRangeIfPossible(toValue, toValue);
-        } else {
-            setRangeIfPossible(localFromValue, toValue);
+
+        if (!shouldSetDatesToBeEqual(localFromValue, toValue)) {
+            return setRangeIfPossible(localFromValue, toValue);
         }
+
+        setLocalFromValue(toValue);
+        setRangeIfPossible(toValue, toValue);
     };
 
     return (

--- a/src/components/DateInputs/DateRangeInputs.tsx
+++ b/src/components/DateInputs/DateRangeInputs.tsx
@@ -21,12 +21,12 @@ const DateRangeInputs: React.FC<Props> = (props) => {
     const [localToValue, setLocalToValue] = useState<Dayjs | null>(props.range.to);
     const [hasErrorState, setHasErrorState] = useState<boolean>(false);
 
-    const isRangeValid = (from: Dayjs, to: Dayjs): boolean => {
-        return from >= reasonableMinDate && to >= reasonableMinDate && from <= to;
+    const areDatesAfterMinDate = (from: Dayjs, to: Dayjs): boolean => {
+        return from >= reasonableMinDate && to >= reasonableMinDate;
     };
 
     const setRangeIfPossible = (from: Dayjs | null, to: Dayjs | null): void => {
-        if (from && to && isRangeValid(from, to)) {
+        if (from && to && areDatesAfterMinDate(from, to)) {
             setHasErrorState(false);
 
             props.setRange({
@@ -40,12 +40,22 @@ const DateRangeInputs: React.FC<Props> = (props) => {
 
     const setFromValue = (fromValue: Dayjs | null): void => {
         setLocalFromValue(fromValue);
-        setRangeIfPossible(fromValue, localToValue);
+        if (fromValue && localToValue && fromValue > localToValue && fromValue >= reasonableMinDate) {
+            setLocalToValue(fromValue);
+            setRangeIfPossible(fromValue, fromValue);
+        } else {
+            setRangeIfPossible(fromValue, localToValue);
+        }
     };
 
     const setToValue = (toValue: Dayjs | null): void => {
         setLocalToValue(toValue);
-        setRangeIfPossible(localFromValue, toValue);
+        if (toValue && localFromValue && toValue < localFromValue && toValue >= reasonableMinDate) {
+            setLocalFromValue(toValue);
+            setRangeIfPossible(toValue, toValue);
+        } else {
+            setRangeIfPossible(localFromValue, toValue);
+        }
     };
 
     return (

--- a/src/components/DateInputs/DateRangeInputs.tsx
+++ b/src/components/DateInputs/DateRangeInputs.tsx
@@ -40,7 +40,12 @@ const DateRangeInputs: React.FC<Props> = (props) => {
 
     const setFromValue = (fromValue: Dayjs | null): void => {
         setLocalFromValue(fromValue);
-        if (fromValue && localToValue && fromValue > localToValue && fromValue >= reasonableMinDate) {
+        if (
+            fromValue &&
+            localToValue &&
+            fromValue > localToValue &&
+            fromValue >= reasonableMinDate
+        ) {
             setLocalToValue(fromValue);
             setRangeIfPossible(fromValue, fromValue);
         } else {


### PR DESCRIPTION
## What's changed
Changed the date filter so:

When I set the Parcel table FROM date to be later than the currently-shown TO date (either using the datepicker or keyboard input)

Then the TO date should update to match the new FROM date (so the parcels that match that packing date are shown in the table)

The opposite is  true also (that setting the TO date to be earlier than the FROM date causes FROM to update accordingly).

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/f3e1d592-c99a-4365-9689-56fed9f4f424)

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

wtd:summary
