### PR TITLE
#391: Text filter strings can now contain multiple strings separated by commas

### DIFF
--- a/src/app/clients/clientsTable/filters.ts
+++ b/src/app/clients/clientsTable/filters.ts
@@ -1,7 +1,12 @@
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
 import clientsHeaders from "./headers";
 import { ClientsFilter, ClientsFilterMethod } from "./types";
-import { fullNameSearch, phoneSearch, postcodeSearch } from "@/common/databaseFilters";
+import {
+    familySearch,
+    fullNameSearch,
+    phoneSearch,
+    postcodeSearch,
+} from "@/common/databaseFilters";
 import { DbClientRow } from "@/databaseUtils";
 
 const clientsFullNameSearch: ClientsFilterMethod = fullNameSearch<DbClientRow>(
@@ -19,12 +24,20 @@ const clientsPhoneSearch: ClientsFilterMethod = phoneSearch<DbClientRow>(
     "is_active"
 );
 
+const clientsFamilySearch: ClientsFilterMethod = familySearch("family_count", "is_active");
+
 const clientsFilters: ClientsFilter[] = [
     buildServerSideTextFilter({
         key: "fullName",
         label: "Name",
         headers: clientsHeaders,
         method: clientsFullNameSearch,
+    }),
+    buildServerSideTextFilter({
+        key: "familyCategory",
+        label: "Family",
+        headers: clientsHeaders,
+        method: clientsFamilySearch,
     }),
     buildServerSideTextFilter({
         key: "addressPostcode",

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -21,6 +21,7 @@ import { parcelTableHeaderKeysAndLabels } from "./headers";
 import { DbParcelRow } from "@/databaseUtils";
 import {
     dbFilterWithSubstringQueries,
+    familySearch,
     fullNameSearch,
     phoneSearch,
     postcodeSearch,
@@ -36,30 +37,9 @@ const parcelsPostcodeSearch: ParcelsFilterMethod<string> = postcodeSearch<DbParc
     "client_is_active"
 );
 
-const familySearch: ParcelsFilterMethod<string> = dbFilterWithSubstringQueries<DbParcelRow>(
-    (substring) => {
-        const clientIsActiveColumnLabel = "client_is_active";
-        const familyCountColumnLabel = "family_count";
-
-        if (substring === "-") {
-            return `${clientIsActiveColumnLabel}.is.false`;
-        }
-        if ("single".includes(substring.toLowerCase())) {
-            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.lte.1)`;
-        }
-        if ("family of".includes(substring.toLowerCase())) {
-            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.gte.2)`;
-        }
-
-        const substringAsNumber = Number(substring);
-        if (Number.isNaN(substringAsNumber) || substringAsNumber === 0) {
-            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.eq.-1)`;
-        }
-        if (substringAsNumber >= 10) {
-            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.gte.10)`;
-        }
-        return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.eq.${substringAsNumber})`;
-    }
+const parcelsFamilySearch: ParcelsFilterMethod<string> = familySearch(
+    "family_count",
+    "client_is_active"
 );
 
 const parcelsPhoneSearch: ParcelsFilterMethod<string> = phoneSearch<DbParcelRow>(
@@ -246,7 +226,7 @@ const buildFilters = async (): Promise<{
             key: "familyCategory",
             label: "Family",
             headers: parcelTableHeaderKeysAndLabels,
-            method: familySearch,
+            method: parcelsFamilySearch,
         }),
         buildServerSideTextFilter({
             key: "phoneNumber",

--- a/src/common/databaseFilters.test.ts
+++ b/src/common/databaseFilters.test.ts
@@ -1,0 +1,426 @@
+import { beforeEach, expect, it } from "@jest/globals";
+import { familySearch, fullNameSearch, phoneSearch, postcodeSearch } from "./databaseFilters";
+import { DbParcelRow } from "@/databaseUtils";
+import { DbQuery, ServerSideFilterMethod } from "@/components/Tables/Filters";
+
+const logID = "a2adb0ba-873e-506b-abd1-8cd1782923c8";
+
+jest.mock("@/logger/logger", () => ({
+    logErrorReturnLogId: jest.fn(() => Promise.resolve(logID)),
+}));
+
+jest.mock("@/supabaseClient", () => {
+    return { default: jest.fn() };
+});
+
+const mockQueryWithOrAppended = jest.fn();
+const mockOr: jest.Mock = jest.fn(() => mockQueryWithOrAppended);
+
+describe("test for full name filter", () => {
+    let mockDbQuery: DbQuery<DbParcelRow>;
+    let fullNameFilter: ServerSideFilterMethod<DbParcelRow, string>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Arrange
+        mockDbQuery = {} as DbQuery<DbParcelRow>;
+        mockDbQuery.or = mockOr;
+
+        fullNameFilter = fullNameSearch<DbParcelRow>("client_full_name", "client_is_active");
+    });
+
+    it("should leave the query unchanged when name input is empty", () => {
+        // Act
+        const result = fullNameFilter(mockDbQuery, "");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should leave the query unchanged when name input just whitespace substrings", () => {
+        // Act
+        const result = fullNameFilter(mockDbQuery, " , ,,   ,");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should generate expected search clause for input with no commas", () => {
+        // Act
+        const result = fullNameFilter(mockDbQuery, "  input to be trimmed    ");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_full_name.ilike.%input to be trimmed%)"
+        );
+    });
+
+    it("should generate expected search clause for input with commas", () => {
+        // Act
+        const result = fullNameFilter(
+            mockDbQuery,
+            "substring1,sub string2, sub-string3 , substring4"
+        );
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_full_name.ilike.%substring1%)," +
+                "and(client_is_active.is.true, client_full_name.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, client_full_name.ilike.%sub-string3%)," +
+                "and(client_is_active.is.true, client_full_name.ilike.%substring4%)"
+        );
+    });
+
+    it("should interpret '(Deleted Client)' as possibly a deleted client", () => {
+        // Act
+        const result = fullNameFilter(mockDbQuery, "(Deleted Client)");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "or(client_full_name.ilike.%Deleted Client%, client_is_active.is.false)"
+        );
+    });
+
+    it("should case-insensitively interpret part of '(Deleted Client)' as possibly matching a deleted client", () => {
+        // Act
+        const result = fullNameFilter(mockDbQuery, "del");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "or(client_full_name.ilike.%del%, client_is_active.is.false)"
+        );
+    });
+
+    it("should generate expected search clause for input with commas including special substrings", () => {
+        // Act
+        const result = fullNameFilter(
+            mockDbQuery,
+            " substring1  ,LETED, sub string2 , ,sub  string3"
+        );
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_full_name.ilike.%substring1%)," +
+                "or(client_full_name.ilike.%LETED%, client_is_active.is.false)," +
+                "and(client_is_active.is.true, client_full_name.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, client_full_name.ilike.%sub  string3%)"
+        );
+    });
+});
+
+describe("test for postcode filter", () => {
+    let mockDbQuery: DbQuery<DbParcelRow>;
+    let postcodeFilter: ServerSideFilterMethod<DbParcelRow, string>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Arrange
+        mockDbQuery = {} as DbQuery<DbParcelRow>;
+        mockDbQuery.or = mockOr;
+
+        postcodeFilter = postcodeSearch<DbParcelRow>("client_address_postcode", "client_is_active");
+    });
+
+    it("should leave the query unchanged when postcode input is empty", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, "");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should leave the query unchanged when postcode input just whitespace substrings", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, " , ,,   ,");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should generate expected search clause for input with no commas", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, "  input to be trimmed    ");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_address_postcode.ilike.%input to be trimmed%)"
+        );
+    });
+
+    it("should generate expected search clause for input with commas", () => {
+        // Act
+        const result = postcodeFilter(
+            mockDbQuery,
+            "substring1,sub string2, sub-string3 , substring4"
+        );
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_address_postcode.ilike.%substring1%)," +
+                "and(client_is_active.is.true, client_address_postcode.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, client_address_postcode.ilike.%sub-string3%)," +
+                "and(client_is_active.is.true, client_address_postcode.ilike.%substring4%)"
+        );
+    });
+
+    it("should interpret '-' as Deleted Client", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, "-");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("client_is_active.is.false");
+    });
+
+    it("should interpret 'nfa' as possibly not having a postcode", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, "nfa");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, or(client_address_postcode.ilike.%nfa%, client_address_postcode.is.null))"
+        );
+    });
+
+    it("should interpret 'NFA' as possibly not having a postcode", () => {
+        // Act
+        const result = postcodeFilter(mockDbQuery, "NFA");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, or(client_address_postcode.ilike.%NFA%, client_address_postcode.is.null))"
+        );
+    });
+
+    it("should generate expected search clause for input with commas including special substrings", () => {
+        // Act
+        const result = postcodeFilter(
+            mockDbQuery,
+            " substring1  ,-, sub string2 , nfa,sub  string3"
+        );
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_address_postcode.ilike.%substring1%)," +
+                "client_is_active.is.false," +
+                "and(client_is_active.is.true, client_address_postcode.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, or(client_address_postcode.ilike.%nfa%, client_address_postcode.is.null))," +
+                "and(client_is_active.is.true, client_address_postcode.ilike.%sub  string3%)"
+        );
+    });
+});
+
+describe("test for phone number filter", () => {
+    let mockDbQuery: DbQuery<DbParcelRow>;
+    let phoneFilter: ServerSideFilterMethod<DbParcelRow, string>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Arrange
+        mockDbQuery = {} as DbQuery<DbParcelRow>;
+        mockDbQuery.or = mockOr;
+
+        phoneFilter = phoneSearch<DbParcelRow>("client_phone_number", "client_is_active");
+    });
+
+    it("should leave the query unchanged when phone input is empty", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, "");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should leave the query unchanged when phone input just whitespace substrings", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, " , ,,   ,");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should generate expected search clause for input with no commas", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, "  input to be trimmed    ");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_phone_number.ilike.%input to be trimmed%)"
+        );
+    });
+
+    it("should generate expected search clause for input with commas", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, "substring1,sub string2, sub-string3 , substring4");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_phone_number.ilike.%substring1%)," +
+                "and(client_is_active.is.true, client_phone_number.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, client_phone_number.ilike.%sub-string3%)," +
+                "and(client_is_active.is.true, client_phone_number.ilike.%substring4%)"
+        );
+    });
+
+    it("should interpret '-' as potentially a deleted client, but also hyphen in the number", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, "-");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "or(client_is_active.is.false, client_phone_number.ilike.%-%)"
+        );
+    });
+
+    it("should generate expected search clause for input with commas including special substrings", () => {
+        // Act
+        const result = phoneFilter(mockDbQuery, " substring1  ,-, sub string2 , ,sub  string3");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, client_phone_number.ilike.%substring1%)," +
+                "or(client_is_active.is.false, client_phone_number.ilike.%-%)," +
+                "and(client_is_active.is.true, client_phone_number.ilike.%sub string2%)," +
+                "and(client_is_active.is.true, client_phone_number.ilike.%sub  string3%)"
+        );
+    });
+});
+
+describe("test for family filter", () => {
+    let mockDbQuery: DbQuery<DbParcelRow>;
+    let familyFilter: ServerSideFilterMethod<DbParcelRow, string>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Arrange
+        mockDbQuery = {} as DbQuery<DbParcelRow>;
+        mockDbQuery.or = mockOr;
+
+        familyFilter = familySearch<DbParcelRow>("family_count", "client_is_active");
+    });
+
+    it("should leave the query unchanged when phone input is empty", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should leave the query unchanged when phone input just whitespace substrings", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, " , ,,   ,");
+
+        // Assert
+        expect(result).toBe(mockDbQuery);
+        expect(mockOr).toHaveBeenCalledTimes(0);
+    });
+
+    it("should generate expected search clause for numerical input with no commas", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "  6    ");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("and(client_is_active.is.true, family_count.eq.6)");
+    });
+
+    it("should generate expected search clause for input with commas", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "1,3 , 5");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, family_count.eq.1)," +
+                "and(client_is_active.is.true, family_count.eq.3)," +
+                "and(client_is_active.is.true, family_count.eq.5)"
+        );
+    });
+
+    it("should interpret '-' as a deleted client", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "-");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("client_is_active.is.false");
+    });
+
+    it("should match part of the string 'single' with a family size of 1 or less", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "singl");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("and(client_is_active.is.true, family_count.lte.1)");
+    });
+
+    it("should match part of the string 'family of' with a family size of 2 or more", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "fam");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("and(client_is_active.is.true, family_count.gte.2)");
+    });
+
+    it("should match numbers greater than 10 with a family size of 10 or more", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "12");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("and(client_is_active.is.true, family_count.gte.10)");
+    });
+
+    it("should interpret a non-numeric string as a query that returns no rows", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, "non-numeric");
+
+        // Assert- family size of -1 should return no rows
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith("and(client_is_active.is.true, family_count.eq.-1)");
+    });
+
+    it("should generate expected search clause for input with commas including special substrings", () => {
+        // Act
+        const result = familyFilter(mockDbQuery, " 2  ,7, - , ,carrot, 11,single");
+
+        // Assert
+        expect(result).toBe(mockQueryWithOrAppended);
+        expect(mockOr).toHaveBeenCalledWith(
+            "and(client_is_active.is.true, family_count.eq.2)," +
+                "and(client_is_active.is.true, family_count.eq.7)," +
+                "client_is_active.is.false," +
+                "and(client_is_active.is.true, family_count.eq.-1)," +
+                "and(client_is_active.is.true, family_count.gte.10)," +
+                "and(client_is_active.is.true, family_count.lte.1)"
+        );
+    });
+});

--- a/src/common/databaseFilters.ts
+++ b/src/common/databaseFilters.ts
@@ -60,3 +60,29 @@ export const phoneSearch = <DbData extends DbClientRow | DbParcelRow>(
         return `and(${clientIsActiveColumnLabel}.is.true, ${phoneColumnLabel}.ilike.%${substring}%)`;
     });
 };
+
+export const familySearch = <DbData extends DbClientRow | DbParcelRow>(
+    familyCountColumnLabel: Extract<keyof DbData, "family_count">,
+    clientIsActiveColumnLabel: Extract<keyof DbData, "is_active" | "client_is_active">
+): ServerSideFilterMethod<DbData, string> => {
+    return dbFilterWithSubstringQueries((substring) => {
+        if (substring === "-") {
+            return `${clientIsActiveColumnLabel}.is.false`;
+        }
+        if ("single".includes(substring.toLowerCase())) {
+            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.lte.1)`;
+        }
+        if ("family of".includes(substring.toLowerCase())) {
+            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.gte.2)`;
+        }
+
+        const substringAsNumber = Number(substring);
+        if (Number.isNaN(substringAsNumber) || substringAsNumber === 0) {
+            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.eq.-1)`;
+        }
+        if (substringAsNumber >= 10) {
+            return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.gte.10)`;
+        }
+        return `and(${clientIsActiveColumnLabel}.is.true, ${familyCountColumnLabel}.eq.${substringAsNumber})`;
+    });
+};

--- a/src/common/databaseFilters.ts
+++ b/src/common/databaseFilters.ts
@@ -3,57 +3,60 @@ import { displayPostcodeForHomelessClient } from "./format";
 import { DbClientRow, DbParcelRow } from "@/databaseUtils";
 import { parcelsPageDeletedClientDisplayName } from "@/app/parcels/parcelsTable/format";
 
+const textFilterDelimiter = ",";
+
+export const dbFilterWithSubstringQueries = <DbData extends DbClientRow | DbParcelRow>(
+    substringToSubqueryMap: (value: string) => string
+): ServerSideFilterMethod<DbData, string> => {
+    return (query, state) => {
+        const substrings = state
+            .split(textFilterDelimiter)
+            .map((substring) => substring.trim().replace(/[^a-zA-Z0-9 \-+?]/g, ""))
+            .filter((substring) => substring.length > 0);
+
+        if (substrings.length === 0) {
+            return query;
+        }
+
+        return query.or(substrings.map(substringToSubqueryMap).join(","));
+    };
+};
+
 export const fullNameSearch = <DbData extends DbClientRow | DbParcelRow>(
     fullNameColumnLabel: Extract<keyof DbData, "full_name" | "client_full_name">,
     clientIsActiveColumnLabel: Extract<keyof DbData, "is_active" | "client_is_active">
 ): ServerSideFilterMethod<DbData, string> => {
-    return (query, state) => {
-        const cleanState = state.replace(/[^a-zA-Z0-9 ]/g, "");
-        if (cleanState === "") {
-            return query;
+    return dbFilterWithSubstringQueries((substring) => {
+        if (parcelsPageDeletedClientDisplayName.toLowerCase().includes(substring.toLowerCase())) {
+            return `or(${fullNameColumnLabel}.ilike.%${substring}%, ${clientIsActiveColumnLabel}.is.false)`;
         }
-        if (parcelsPageDeletedClientDisplayName.toLowerCase().includes(cleanState.toLowerCase())) {
-            return query.or(
-                `${fullNameColumnLabel}.ilike.%${cleanState}%, ${clientIsActiveColumnLabel}.eq.false`
-            );
-        }
-        return query.ilike(fullNameColumnLabel, `%${cleanState}%`);
-    };
+        return `and(${clientIsActiveColumnLabel}.is.true, ${fullNameColumnLabel}.ilike.%${substring}%)`;
+    });
 };
 
 export const postcodeSearch = <DbData extends DbClientRow | DbParcelRow>(
     postcodeColumnLabel: Extract<keyof DbData, "address_postcode" | "client_address_postcode">,
     clientIsActiveColumnLabel: Extract<keyof DbData, "is_active" | "client_is_active">
 ): ServerSideFilterMethod<DbData, string> => {
-    return (query, state) => {
-        if (state === "") {
-            return query;
+    return dbFilterWithSubstringQueries((substring) => {
+        if (substring === "-") {
+            return `${clientIsActiveColumnLabel}.is.false`;
         }
-        if (state === "-") {
-            return query.is(clientIsActiveColumnLabel, false);
+        if (displayPostcodeForHomelessClient.toLowerCase().includes(substring.toLowerCase())) {
+            return `and(${clientIsActiveColumnLabel}.is.true, or(${postcodeColumnLabel}.ilike.%${substring}%, ${postcodeColumnLabel}.is.null))`;
         }
-        if (displayPostcodeForHomelessClient.toLowerCase().includes(state.toLowerCase())) {
-            return query
-                .or(`${postcodeColumnLabel}.ilike.%${state}%, ${postcodeColumnLabel}.is.null`)
-                .neq(clientIsActiveColumnLabel, false);
-        }
-        return query.ilike(postcodeColumnLabel, `%${state}%`);
-    };
+        return `and(${clientIsActiveColumnLabel}.is.true, ${postcodeColumnLabel}.ilike.%${substring}%)`;
+    });
 };
 
 export const phoneSearch = <DbData extends DbClientRow | DbParcelRow>(
     phoneColumnLabel: Extract<keyof DbData, "phone_number" | "client_phone_number">,
     clientIsActiveColumnLabel: Extract<keyof DbData, "is_active" | "client_is_active">
 ): ServerSideFilterMethod<DbData, string> => {
-    return (query, state) => {
-        if (state === "") {
-            return query;
+    return dbFilterWithSubstringQueries((substring) => {
+        if ("-".includes(substring.toLowerCase())) {
+            return `or(${clientIsActiveColumnLabel}.is.false, ${phoneColumnLabel}.ilike.%${substring}%)`;
         }
-        if ("-".includes(state.toLowerCase())) {
-            return query.or(
-                `${phoneColumnLabel}.ilike.%${state}%, ${clientIsActiveColumnLabel}.eq.false`
-            );
-        }
-        return query.ilike(phoneColumnLabel, `%${state}%`);
-    };
+        return `and(${clientIsActiveColumnLabel}.is.true, ${phoneColumnLabel}.ilike.%${substring}%)`;
+    });
 };


### PR DESCRIPTION
## What's changed
- The text filters on the Parcels and Clients tables now accept multiple strings separated by commas
- The pre-existing special cases (like '-' for deleted client, or 'NFA' for client with no address) still work
- The Family filter now appears on the Clients table, too

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [X] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`

---
## AI generated change summary

The following is a summary of the changes in the PR generated by [What The Diff](https://whatthediff.ai/).
Delete the command below if you don't want this to be generataed.

wtd:summary
