### PR TITLE
VFB-327 update unique constraint on lists to use list_type

### DIFF
--- a/supabase/migrations/20240812142332_alter_lists_table_unique_constraint.sql
+++ b/supabase/migrations/20240812142332_alter_lists_table_unique_constraint.sql
@@ -1,0 +1,9 @@
+alter table "public"."lists" drop constraint "lists_item_name_key";
+
+drop index if exists "public"."lists_item_name_key";
+
+CREATE UNIQUE INDEX lists_list_type_item_name_key ON public.lists USING btree (list_type, item_name);
+
+alter table "public"."lists" add constraint "lists_list_type_item_name_key" UNIQUE using index "lists_list_type_item_name_key";
+
+


### PR DESCRIPTION
## What's changed

There was a unique constraint on the list type item name, and we need it to be a unique combination of `(list_type, item_name)` instead

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [x] I have modified the seed in `supabase/seed/seed.mts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [x] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [x] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

