### PR TITLE
VFB-237 null collection datetime appears as empty string in parcel ac…

### DIFF
--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -102,12 +102,12 @@ export const getParcelOverviewString = (
         return (
             (addressPostcode ?? displayPostcodeForHomelessClient) +
             (fullName && ` - ${fullName}`) +
-            (collectionDatetime && ` @ ${dayjs(collectionDatetime).format("DD/MM/YYYY")}`)
+            (collectionDatetime ? ` @ ${dayjs(collectionDatetime).format("DD/MM/YYYY")}` : "")
         );
     }
     return (
         displayNameForDeletedClient +
-        (collectionDatetime && ` @ ${dayjs(collectionDatetime).format("DD/MM/YYYY")}`)
+        (collectionDatetime ? ` @ ${dayjs(collectionDatetime).format("DD/MM/YYYY")}` : "")
     );
 };
 


### PR DESCRIPTION
…tion modals

## What's changed
On the parcel details on the parcel action modal, a null datetime will result in an empty string after the name of the client.

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/b8b3eb61-9d8e-40a6-99f4-a551fa26f42f)

After
![image](https://github.com/user-attachments/assets/d2f1ae1e-12d0-48d8-a6ef-b50289d2957e)


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of date formatting by ensuring that an empty string is returned when the collection date is not provided, enhancing output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->