### PR TITLE
#456 info page ignoring paragraph breaks

### DIFF
--- a/src/app/info/StyleComponents.tsx
+++ b/src/app/info/StyleComponents.tsx
@@ -12,6 +12,7 @@ export const WikiItemPositioner = styled.div`
 
 export const WikiItemDetailsTextBreaker = styled.div`
     word-break: break-all;
+    white-space: pre-line;
 `;
 
 export const WikiUpdateDataButton = styled.button`


### PR DESCRIPTION
## What's changed
Line breaks are now shown in the content of wiki items.

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/068b54ef-77b6-4e8f-b46b-5bf027e25c13)
After
![image](https://github.com/user-attachments/assets/e18ee464-8411-4156-8dac-f1745bb0a9ed)

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved text rendering in the WikiItemDetails component to enhance readability by preserving line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->