### PR TITLE
VFB-345 set security_invoker true on audit_log_plus view

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ You can either
   ```
   and write sql queries yourself (not recommended)
 
+*WARNING*: If you're recreating a view in your migration, make sure you create it `with(security_invoker = true)`, or the view is publicly available.
+
 #### Update the TypeScript database type definition
 You can regenerate the types
 - from the local database

--- a/supabase/migrations/20240820135004_set_security_invoker_on_audit_log_plus.sql
+++ b/supabase/migrations/20240820135004_set_security_invoker_on_audit_log_plus.sql
@@ -1,0 +1,1 @@
+alter view public.audit_log_plus set (security_invoker = true);


### PR DESCRIPTION
## What's changed

Simple migration to fix the security policy on the audit log plus table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a warning in the README to emphasize the significance of using the `with(security_invoker = true)` option during view recreation.
  - Enhanced the `audit_log_plus` view's security model by setting the `security_invoker` property to `true`, ensuring that access permissions align with individual user privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->