### PR TITLE
VFB 307 prevent overlapping names on shipping labels

### DIFF
--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -40,6 +40,7 @@ const AddClients: () => React.ReactElement = () => {
         numberOfChildren: Errors.initial,
         listType: Errors.initial,
         nappySize: Errors.none,
+        deliveryInstructions: Errors.none,
     };
 
     return (

--- a/src/app/clients/edit/[id]/page.tsx
+++ b/src/app/clients/edit/[id]/page.tsx
@@ -67,6 +67,7 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
         numberOfChildren: Errors.none,
         nappySize: Errors.none,
         listType: Errors.none,
+        deliveryInstructions: Errors.none,
     };
 
     return (

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -39,7 +39,7 @@ import Title from "@/components/Title/Title";
 import ClientNotesCard from "@/app/clients/form/formSections/ClientNotes";
 import { getCurrentYear } from "@/common/date";
 import { youngestAdultBirthYear } from "@/app/clients/form/birthYearDropdown";
-import ListTypeCard from "./formSections/ListTypeCard";
+import ListTypeCard from "@/app/clients/form/formSections/ListTypeCard";
 import { ListType } from "@/common/fetch";
 
 interface Props {

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -86,6 +86,7 @@ export interface ClientErrors extends FormErrors<ClientFields> {
     numberOfChildren: Errors;
     listType: Errors;
     nappySize: Errors;
+    deliveryInstructions: Errors;
 }
 
 export type ClientSetter = Setter<ClientFields>;

--- a/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
+++ b/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
@@ -7,7 +7,7 @@ import {
     onChangeText,
 } from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
-import { ClientCardProps } from "../ClientForm";
+import { ClientCardProps } from "@/app/clients/form/ClientForm";
 
 const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
     formErrors,
@@ -22,7 +22,17 @@ const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
                 defaultValue={getDefaultTextValue(fields, "deliveryInstructions")}
                 error={errorExists(formErrors.deliveryInstructions)}
                 helperText={errorText(formErrors.deliveryInstructions)}
-                onChange={onChangeText(fieldSetter, errorSetter, "deliveryInstructions")}
+                onChange={onChangeText(
+                    fieldSetter,
+                    errorSetter,
+                    "deliveryInstructions",
+                    undefined,
+                    undefined,
+                    undefined,
+                    (input) => {
+                        return input.length <= 320;
+                    }
+                )}
             />
         </GenericFormCard>
     );

--- a/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
+++ b/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
@@ -9,6 +9,8 @@ import {
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "@/app/clients/form/ClientForm";
 
+const MAX_CHARACTERS = 320;
+
 const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
     formErrors,
     errorSetter,
@@ -16,7 +18,11 @@ const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
     fields,
 }) => {
     return (
-        <GenericFormCard title="Delivery Instructions" required={false}>
+        <GenericFormCard
+            title="Delivery Instructions"
+            required={false}
+            text="Please input not more than 320 characters."
+        >
             <FreeFormTextInput
                 label="For example, The doorbell does not work. Use the door code: xxxx."
                 defaultValue={getDefaultTextValue(fields, "deliveryInstructions")}
@@ -29,8 +35,8 @@ const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
                     undefined,
                     undefined,
                     undefined,
-                    (input) => {
-                        return input.length <= 320;
+                    (input, maxCharacters = MAX_CHARACTERS) => {
+                        return input.length <= maxCharacters;
                     }
                 )}
             />

--- a/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
+++ b/src/app/clients/form/formSections/DeliveryInstructionsCard.tsx
@@ -1,10 +1,16 @@
 import React from "react";
 import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
-import { getDefaultTextValue, onChangeText } from "@/components/Form/formFunctions";
+import {
+    errorExists,
+    errorText,
+    getDefaultTextValue,
+    onChangeText,
+} from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
 
 const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
+    formErrors,
     errorSetter,
     fieldSetter,
     fields,
@@ -14,6 +20,8 @@ const DeliveryInstructionsCard: React.FC<ClientCardProps> = ({
             <FreeFormTextInput
                 label="For example, The doorbell does not work. Use the door code: xxxx."
                 defaultValue={getDefaultTextValue(fields, "deliveryInstructions")}
+                error={errorExists(formErrors.deliveryInstructions)}
+                helperText={errorText(formErrors.deliveryInstructions)}
                 onChange={onChangeText(fieldSetter, errorSetter, "deliveryInstructions")}
             />
         </GenericFormCard>

--- a/src/app/clients/form/formSections/FullNameCard.tsx
+++ b/src/app/clients/form/formSections/FullNameCard.tsx
@@ -7,7 +7,7 @@ import {
     onChangeText,
 } from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
-import { ClientCardProps } from "../ClientForm";
+import { ClientCardProps } from "@/app/clients/form/ClientForm";
 
 const FullNameCard: React.FC<ClientCardProps> = ({
     formErrors,

--- a/src/app/clients/form/formSections/ListTypeCard.tsx
+++ b/src/app/clients/form/formSections/ListTypeCard.tsx
@@ -3,7 +3,7 @@ import { errorText, valueOnChangeDropdownList } from "@/components/Form/formFunc
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ErrorText } from "@/components/Form/formStyling";
 import { UncontrolledSelect } from "@/components/DataInput/DropDownSelect";
-import { ClientCardProps } from "../ClientForm";
+import { ClientCardProps } from "@/app/clients/form/ClientForm";
 import { LIST_TYPES_ARRAY } from "@/common/fetch";
 import { capitaliseWords } from "@/common/format";
 

--- a/src/app/clients/form/formSections/NumberAdultsCard.tsx
+++ b/src/app/clients/form/formSections/NumberAdultsCard.tsx
@@ -11,7 +11,7 @@ import {
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { SelectChangeEventHandler } from "@/components/DataInput/inputHandlerFactories";
 import { FormText, StyledCard } from "@/components/Form/formStyling";
-import { ClientCardProps, ClientSetter } from "../ClientForm";
+import { ClientCardProps, ClientSetter } from "@/app/clients/form/ClientForm";
 import { UncontrolledSelect } from "@/components/DataInput/DropDownSelect";
 import { getAdultBirthYears } from "@/app/clients/form/birthYearDropdown";
 

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -6,12 +6,12 @@ import GeneralActionModal, {
     maxParcelsToShow,
     ActionModalProps,
 } from "./GeneralActionModal";
-import SelectedParcelsOverview from "../SelectedParcelsOverview";
+import SelectedParcelsOverview from "@/app/parcels/ActionBar/SelectedParcelsOverview";
 import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
 import ShippingLabelsPdfButton, {
     ShippingLabelError,
 } from "@/pdf/ShippingLabels/ShippingLabelsPdfButton";
-import { getStatusErrorMessageWithLogId } from "../Statuses";
+import { getStatusErrorMessageWithLogId } from "@/app/parcels/ActionBar/Statuses";
 import { sendAuditLog } from "@/server/auditLog";
 import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadWarning";
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from "react";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import dayjs, { Dayjs } from "dayjs";
-import { ParcelsTableRow } from "../parcelsTable/types";
+import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import StatusesModal from "@/app/parcels/ActionBar/StatusesModal";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { sendAuditLog } from "@/server/auditLog";

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -66,12 +66,11 @@ export const createSetter = <SpecificFields extends Fields>(
     };
 };
 
-export const getErrorType = <SpecificFields extends Fields>(
+export const getErrorType = (
     input: string,
-    key: keyof SpecificFields,
     required?: boolean,
     regex?: RegExp,
-    additionalCondition?: (value: string) => boolean
+    additionalCondition?: (value: string, maxCharacters?: number) => boolean
 ): Errors => {
     if (input == "") {
         return required ? Errors.required : Errors.none;
@@ -80,9 +79,6 @@ export const getErrorType = <SpecificFields extends Fields>(
         (regex !== undefined && !input.match(regex)) ||
         (additionalCondition !== undefined && !additionalCondition(input))
     ) {
-        if (key === "deliveryInstructions") {
-            return Errors.deliveryInstructions;
-        }
         return Errors.invalid;
     }
 
@@ -96,7 +92,7 @@ export const onChangeText = <SpecificFields extends Fields>(
     required?: boolean,
     regex?: RegExp,
     formattingFunction?: (value: string) => SpecificFields[keyof SpecificFields],
-    additionalCondition?: (value: string) => boolean
+    additionalCondition?: (value: string, maxCharacters?: number) => boolean
 ): SelectChangeEventHandler => {
     return (event) => {
         const input = event.target.value;
@@ -104,7 +100,6 @@ export const onChangeText = <SpecificFields extends Fields>(
             key === "telephoneNumber" || key === "phoneNumber"
                 ? input.replaceAll(phoneNumberFormatSymbolsRegex, "")
                 : input,
-            key,
             required,
             regex,
             additionalCondition
@@ -134,7 +129,7 @@ export const onChangeTextDeferredError = <SpecificFields extends Fields>(
             clearInvitedUser();
         }
         const input = event.target.value;
-        const errorType = getErrorType(input, key, required, regex, additionalCondition);
+        const errorType = getErrorType(input, required, regex, additionalCondition);
         errorSetter({ [key]: errorType } as {
             [key in keyof FormErrors<SpecificFields>]: Errors;
         });

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -23,6 +23,7 @@ export enum Errors {
     invalidPackingSlot = "The previous packing slot is no longer available, please select a new packing slot.",
     invalidCollectionCentre = "The previous collection centre is no longer available, please select a new collection centre.",
     noCollectionSlotsSet = "There are no collection slots set for this collection centre, please select a different collection centre or contact admin.",
+    deliveryInstructions = "Please enter delivery instructions below 320 words.",
 }
 
 export const numberRegex = /^\d+$/;
@@ -69,12 +70,15 @@ export const getErrorType = (
     input: string,
     required?: boolean,
     regex?: RegExp,
-    additionalCondition?: (value: string) => boolean
+    additionalCondition?: (value: string) => boolean,
+    deliveryInstructionsOverflow?: boolean
 ): Errors => {
     if (input == "") {
         return required ? Errors.required : Errors.none;
     }
-
+    if (deliveryInstructionsOverflow) {
+        return Errors.deliveryInstructions;
+    }
     if (
         (regex !== undefined && !input.match(regex)) ||
         (additionalCondition !== undefined && !additionalCondition(input))
@@ -102,7 +106,8 @@ export const onChangeText = <SpecificFields extends Fields>(
                 : input,
             required,
             regex,
-            additionalCondition
+            additionalCondition,
+            key === "deliveryInstructions" && input.length > 320
         );
         errorSetter({ [key]: errorType } as { [key in keyof FormErrors<SpecificFields>]: Errors });
         if (errorType === Errors.none) {

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -23,7 +23,7 @@ export enum Errors {
     invalidPackingSlot = "The previous packing slot is no longer available, please select a new packing slot.",
     invalidCollectionCentre = "The previous collection centre is no longer available, please select a new collection centre.",
     noCollectionSlotsSet = "There are no collection slots set for this collection centre, please select a different collection centre or contact admin.",
-    deliveryInstructions = "Please enter delivery instructions below 320 words.",
+    deliveryInstructions = "Please enter delivery instructions below 320 characters.",
 }
 
 export const numberRegex = /^\d+$/;
@@ -66,23 +66,23 @@ export const createSetter = <SpecificFields extends Fields>(
     };
 };
 
-export const getErrorType = (
+export const getErrorType = <SpecificFields extends Fields>(
     input: string,
+    key: keyof SpecificFields,
     required?: boolean,
     regex?: RegExp,
-    additionalCondition?: (value: string) => boolean,
-    deliveryInstructionsOverflow?: boolean
+    additionalCondition?: (value: string) => boolean
 ): Errors => {
     if (input == "") {
         return required ? Errors.required : Errors.none;
-    }
-    if (deliveryInstructionsOverflow) {
-        return Errors.deliveryInstructions;
     }
     if (
         (regex !== undefined && !input.match(regex)) ||
         (additionalCondition !== undefined && !additionalCondition(input))
     ) {
+        if (key === "deliveryInstructions") {
+            return Errors.deliveryInstructions;
+        }
         return Errors.invalid;
     }
 
@@ -104,10 +104,10 @@ export const onChangeText = <SpecificFields extends Fields>(
             key === "telephoneNumber" || key === "phoneNumber"
                 ? input.replaceAll(phoneNumberFormatSymbolsRegex, "")
                 : input,
+            key,
             required,
             regex,
-            additionalCondition,
-            key === "deliveryInstructions" && input.length > 320
+            additionalCondition
         );
         errorSetter({ [key]: errorType } as { [key in keyof FormErrors<SpecificFields>]: Errors });
         if (errorType === Errors.none) {
@@ -134,7 +134,7 @@ export const onChangeTextDeferredError = <SpecificFields extends Fields>(
             clearInvitedUser();
         }
         const input = event.target.value;
-        const errorType = getErrorType(input, required, regex, additionalCondition);
+        const errorType = getErrorType(input, key, required, regex, additionalCondition);
         errorSetter({ [key]: errorType } as {
             [key in keyof FormErrors<SpecificFields>]: Errors;
         });

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -23,7 +23,6 @@ export enum Errors {
     invalidPackingSlot = "The previous packing slot is no longer available, please select a new packing slot.",
     invalidCollectionCentre = "The previous collection centre is no longer available, please select a new collection centre.",
     noCollectionSlotsSet = "There are no collection slots set for this collection centre, please select a different collection centre or contact admin.",
-    deliveryInstructions = "Please enter delivery instructions below 320 characters.",
 }
 
 export const numberRegex = /^\d+$/;

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -21,7 +21,7 @@ export interface ShippingLabelData {
     delivery_instructions?: string;
 }
 
-// This is a hard requirement because of the foodbank's printer settings, note that height is adjustable but preferably set at 62mm
+// The height is a hard requirement, fixed at 62mm, the width is technically adjustable but preferred at 150mm
 const LABEL_SIZE_MM = { width: 150, height: 62 };
 
 const pixelsPerMmAt72Dpi = 72 / 25.4;
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
     },
-    leftCol: { flexBasis: "33%", textAlign: "left" },
+    leftCol: { flexBasis: "32%", textAlign: "left" },
     middleCol: { flex: 1, textAlign: "left" },
     headingText: { fontFamily: "Helvetica-Bold", textTransform: "uppercase" },
     largeText: {
@@ -86,7 +86,7 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
     return (
         <Page size={LABEL_SIZE_PIXELS} style={styles.page}>
             <View style={styles.cardWrapper} wrap={true}>
-                <View style={[styles.leftCol, { flexDirection: "column" }]}>
+                <View style={[styles.leftCol, { flexDirection: "column", marginRight: "3px" }]}>
                     <View style={styles.firstRow}>
                         <Text style={[styles.headingText, { flexWrap: "wrap" }]}>Name: </Text>
                     </View>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdf.tsx
@@ -21,12 +21,15 @@ export interface ShippingLabelData {
     delivery_instructions?: string;
 }
 
-const mmToPixels = (mm: number): number => {
-    const pixelsPerMmAt72Dpi = 72 / 25.4;
-    return mm * pixelsPerMmAt72Dpi;
-};
+// This is a hard requirement because of the foodbank's printer settings, note that height is adjustable but preferably set at 62mm
+const LABEL_SIZE_MM = { width: 150, height: 62 };
 
-const labelSizePixels = { width: mmToPixels(150), height: mmToPixels(62) };
+const pixelsPerMmAt72Dpi = 72 / 25.4;
+
+const LABEL_SIZE_PIXELS = {
+    width: LABEL_SIZE_MM.width * pixelsPerMmAt72Dpi,
+    height: LABEL_SIZE_MM.height * pixelsPerMmAt72Dpi,
+};
 
 const styles = StyleSheet.create({
     page: {
@@ -39,26 +42,23 @@ const styles = StyleSheet.create({
         border: "1.5pt solid black",
         height: "100%",
         display: "flex",
-        flexDirection: "column",
+        flexDirection: "row",
         padding: "0.2cm",
     },
-    topRow: {
+    firstRow: {
         justifyContent: "space-between",
-        flexBasis: "20%",
+        display: "flex",
+        flexDirection: "row",
+        maxHeight: "38%",
+    },
+    secondRow: { display: "flex" },
+    thirdRow: { flex: 1, display: "flex", flexDirection: "column" },
+    fourthRow: {
         display: "flex",
         flexDirection: "row",
     },
-    middleRow: { flex: 1, display: "flex", flexDirection: "row" },
-    bottomRow: {
-        justifyContent: "space-between",
-        flexBasis: "30%",
-        display: "flex",
-        flexDirection: "row",
-    },
-    leftCol: { flexBasis: "32%", textAlign: "left" },
+    leftCol: { flexBasis: "33%", textAlign: "left" },
     middleCol: { flex: 1, textAlign: "left" },
-    rightCol: { flexBasis: "28%", textAlign: "right" },
-    bottomAlign: { marginTop: "21px" },
     headingText: { fontFamily: "Helvetica-Bold", textTransform: "uppercase" },
     largeText: {
         fontSize: "26pt",
@@ -67,6 +67,12 @@ const styles = StyleSheet.create({
     mediumText: {
         fontSize: "19pt",
         lineHeight: 1,
+    },
+    fullNameText: { display: "flex", flexDirection: "row", flexWrap: "wrap", maxWidth: "100%" },
+    deliveryInstructionText: {
+        display: "flex",
+        flexDirection: "row",
+        flexWrap: "wrap",
     },
 });
 
@@ -78,27 +84,18 @@ interface LabelCardProps {
 
 const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) => {
     return (
-        <Page size={labelSizePixels} style={styles.page}>
+        <Page size={LABEL_SIZE_PIXELS} style={styles.page}>
             <View style={styles.cardWrapper} wrap={true}>
-                <View style={[styles.topRow]}>
-                    <View style={[styles.leftCol, { flexDirection: "row" }]}>
-                        <Text style={styles.headingText}>Name: </Text>
-                        <Text>{data.full_name}</Text>
+                <View style={[styles.leftCol, { flexDirection: "column" }]}>
+                    <View style={styles.firstRow}>
+                        <Text style={[styles.headingText, { flexWrap: "wrap" }]}>Name: </Text>
                     </View>
-                    <View style={[styles.middleCol, { flexDirection: "row" }]}>
-                        <Text style={styles.headingText}>Contact: </Text>
-                        <Text>{data.phone_number}</Text>
+                    <View style={[styles.secondRow, { marginBottom: "10px" }]}>
+                        <Text style={[styles.fullNameText, { flexWrap: "wrap" }]}>
+                            {data.full_name}
+                        </Text>
                     </View>
-                    <View style={[styles.rightCol]}>
-                        <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
-                            <Text style={[styles.headingText]}>Packed:</Text>
-                            <Text> </Text>
-                            <Text>{data.packing_date}</Text>
-                        </View>
-                    </View>
-                </View>
-                <View style={styles.middleRow}>
-                    <View style={styles.leftCol}>
+                    <View style={styles.thirdRow}>
                         {data.address_postcode && (
                             <>
                                 <Text>
@@ -120,25 +117,37 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                             </>
                         )}
                     </View>
-                    <View style={styles.middleCol}>
-                        <Text style={styles.headingText}>Delivery Instructions: </Text>
-                        <Text>{data.delivery_instructions}</Text>
-                    </View>
-                </View>
-                <View style={[styles.bottomRow]}>
-                    <View style={[styles.leftCol, { marginTop: "15px" }]}>
+                    <View style={styles.fourthRow}>
                         <Text style={styles.largeText}>
                             {data.address_postcode ?? displayPostcodeForHomelessClient}
                         </Text>
                     </View>
-                    <View style={[styles.middleCol, { flexDirection: "row" }]}>
-                        <View style={[styles.bottomAlign]}>
+                </View>
+                <View style={[styles.middleCol, { flexDirection: "column" }]}>
+                    <View style={styles.firstRow}>
+                        <Text style={styles.headingText}>Contact: </Text>
+                        <Text>{data.phone_number}</Text>
+                        <View style={{ flexDirection: "row" }}>
+                            <Text style={styles.headingText}>Packed: </Text>
+                            <Text>{data.packing_date}</Text>
+                        </View>
+                    </View>
+                    <View style={[styles.secondRow, { marginTop: "3px" }]}>
+                        <Text style={[styles.headingText, { right: 0 }]}>
+                            Delivery Instructions:{" "}
+                        </Text>
+                    </View>
+                    <View style={styles.thirdRow}>
+                        <Text style={styles.deliveryInstructionText}>
+                            {data.delivery_instructions}
+                        </Text>
+                    </View>
+                    <View
+                        style={[styles.fourthRow, { bottom: 0, justifyContent: "space-between" }]}
+                    >
+                        <View style={{ flexDirection: "row" }}>
                             <Text style={styles.mediumText}>{data.packing_slot} </Text>
-                        </View>
-                        <View style={{ marginTop: "auto" }}>
-                            <Text style={{ fontWeight: "bold", fontSize: "25pt" }}>|</Text>
-                        </View>
-                        <View style={[styles.bottomAlign, { flexDirection: "row" }]}>
+                            <Text style={{ fontWeight: "bold", fontSize: "20pt" }}>|</Text>
                             <Text style={styles.mediumText}>
                                 {" "}
                                 {data.collection_centre === "DLVR"
@@ -149,11 +158,11 @@ const SingleLabelCard: React.FC<LabelCardProps> = ({ data, index, quantity }) =>
                                 faIcon={data.collection_centre === "DLVR" ? faTruck : faShoePrints}
                             ></FontAwesomeIconPdfComponent>
                         </View>
-                    </View>
-                    <View style={[styles.rightCol, styles.bottomAlign]}>
-                        <Text style={styles.mediumText}>
-                            {index + 1} of {quantity}
-                        </Text>
+                        <View style={{ alignSelf: "flex-end" }}>
+                            <Text style={styles.mediumText}>
+                                {index + 1} of {quantity}
+                            </Text>
+                        </View>
                     </View>
                 </View>
             </View>

--- a/src/pdf/ShippingLabels/ShippingLabelsPdfButton.tsx
+++ b/src/pdf/ShippingLabels/ShippingLabelsPdfButton.tsx
@@ -5,7 +5,7 @@ import supabase from "@/supabaseClient";
 import PdfButton from "@/components/PdfButton/PdfButton";
 import ShippingLabelsPdf, { ShippingLabelData } from "@/pdf/ShippingLabels/ShippingLabelsPdf";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
-import { PdfDataFetchResponse } from "../common";
+import { PdfDataFetchResponse } from "@/pdf/common";
 import { Schema } from "@/databaseUtils";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { displayNameForDeletedClient } from "@/common/format";


### PR DESCRIPTION
## What's changed
The names on shipping labels can now be displayed without overlapping with other texts. Meanwhile all the information will remain on the shipping label. The format of the label has been refactored so that the delivery instructions can be as large as possible. Note that the delivery instruction has a limit of 320 characters.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|![image](https://github.com/user-attachments/assets/5d462bf9-09b1-4efa-950c-c60fd24f61cb)|![image](https://github.com/user-attachments/assets/a429dab4-c7ff-4114-954d-d78464c9c753)|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling of the card component for better flexibility and layout.
	- Improved visual presentation of shipping labels with new styles for recipient information.
	- Added delivery instructions field to forms, enhancing error tracking and validation.
	- Introduced real-time error feedback for delivery instructions in input forms.

- **Bug Fixes**
	- Adjusted height and spacing in the card component to enhance responsiveness.
	- Streamlined layout of the shipping label components for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->