### PR TITLE
VFB-341 change driver overview pdf to show most recent number of shipping labels

### DIFF
--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -73,13 +73,11 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             return { data: null, error: { type: "noCollectionCentre", logId: logId } };
         }
 
-        let labelCount = 0;
-        if (parcel.events && parcel.events.length > 0) {
-            const lastEventDataValue = parcel.events.slice(-1)[0].event_data;
-            if (lastEventDataValue) {
-                labelCount = Number.parseInt(lastEventDataValue);
-            }
-        }
+        const lastEventDataValue =
+            parcel.events && parcel.events.length > 0 && parcel.events.slice(-1)[0].event_data
+                ? parcel.events.slice(-1)[0].event_data
+                : null;
+        const labelCount = lastEventDataValue ? Number.parseInt(lastEventDataValue) : 0;
 
         dataWithNonNullClients.push({
             ...parcel,

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -74,8 +74,11 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
         }
 
         let labelCount = 0;
-        if (parcel.events && parcel.events.length > 0 && parcel.events[0].event_data) {
-            labelCount = Number.parseInt(parcel.events[0].event_data);
+        if (parcel.events && parcel.events.length > 0) {
+            const lastEventDataValue = parcel.events.slice(-1)[0].event_data;
+            if (lastEventDataValue) {
+                labelCount = Number.parseInt(lastEventDataValue);
+            }
         }
 
         dataWithNonNullClients.push({

--- a/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdfButton.tsx
@@ -73,11 +73,8 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             return { data: null, error: { type: "noCollectionCentre", logId: logId } };
         }
 
-        const lastEventDataValue =
-            parcel.events && parcel.events.length > 0 && parcel.events.slice(-1)[0].event_data
-                ? parcel.events.slice(-1)[0].event_data
-                : null;
-        const labelCount = lastEventDataValue ? Number.parseInt(lastEventDataValue) : 0;
+        const event_data = parcel.events?.[parcel.events.length - 1].event_data;
+        const labelCount = event_data !== null ? Number.parseInt(event_data) : 0;
 
         dataWithNonNullClients.push({
             ...parcel,


### PR DESCRIPTION
## What's changed
Changed the value of labelCount in the driver overview pdf to be the most recent number of shipping labels created, rather than the first.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved logic for determining label count in parcel delivery, enhancing accuracy by considering the latest event data.
  
- **Bug Fixes**
	- Resolved issues related to label count accuracy by shifting focus from the first to the last event in the parcel's history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->