### PR TITLE
VFB-314 fix pagination in packing manager view and fix areDatesIdenti…

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -224,13 +224,13 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         }
     }, [areFiltersLoadingForFirstTime, fetchAndDisplayParcelsData]);
 
-    const packingManagerViewDataPortion = useMemo(() => {
-        return parcelsDataPortion.filter((parcel) => {
-            if (shouldBeInPackingManagerView(parcel, today, yesterday)) {
-                return parcel;
-            }
-        });
-    }, [parcelsDataPortion, today, yesterday]);
+    const packingManagerViewDataPortion = useMemo(
+        () =>
+            parcelsDataPortion.filter((parcel) =>
+                shouldBeInPackingManagerView(parcel, today, yesterday)
+            ),
+        [parcelsDataPortion, today, yesterday]
+    );
 
     const filteredParcelCount = isPackingManagerView
         ? packingManagerViewDataPortion.length

--- a/src/components/Tables/DateFilter.tsx
+++ b/src/components/Tables/DateFilter.tsx
@@ -23,7 +23,7 @@ const areDateRangesIdentical = (
 };
 
 export const areDaysIdentical = (dayA: dayjs.Dayjs | null, dayB: dayjs.Dayjs | null): boolean => {
-    return dayA && dayB ? dayA.isSame(dayB) : dayA === dayB;
+    return dayA && dayB ? dayA.isSame(dayB, "day") : dayA === dayB;
 };
 
 export const serverSideDateFilter = <Data, DbData extends Record<string, unknown>>({


### PR DESCRIPTION
## What's changed
Fixed the pagination on the packing manager view table, and disabled the row breaks. Fixed the areDaysIdentical function to check if two days are the same, rather than checking if two date times are the same.

## Screenshots / Videos
Before
![image](https://github.com/user-attachments/assets/3bc2f175-c1d2-4aa7-a578-a708b1853bf5)
After
![image](https://github.com/user-attachments/assets/56c993e7-5517-4671-a9c0-6ebfd1da1e7b)

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
