### PR TITLE
VFB-None Improvements to styling that were found while investigating VFB-88

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@types/react-dom": "18.2.6",
         "@types/react-fontawesome": "^1.6.5",
         "@types/react-modal": "^3.16.0",
-        "@types/styled-components": "^5.1.26",
         "@types/uuid": "^9.0.8",
         "dayjs": "^1.11.9",
         "dotenv": "^16.3.1",
@@ -6376,14 +6375,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6547,15 +6538,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.26",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/stylis": {
       "version": "4.2.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@types/react-dom": "18.2.6",
     "@types/react-fontawesome": "^1.6.5",
     "@types/react-modal": "^3.16.0",
-    "@types/styled-components": "^5.1.26",
     "@types/uuid": "^9.0.8",
     "dayjs": "^1.11.9",
     "dotenv": "^16.3.1",

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -11,7 +11,7 @@ import {
     ExpandedClientParcelDetails,
     getClientParcelsDetails,
 } from "@/app/clients/getClientParcelsData";
-import { styled } from "styled-components";
+import styled from "styled-components";
 import { ErrorSecondaryText } from "../errorStylingandMessages";
 import { CircularProgress } from "@mui/material";
 import { Centerer } from "@/components/Modal/ModalFormStyles";

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -9,7 +9,7 @@ import getExpandedParcelDetails, {
 } from "@/app/parcels/getExpandedParcelDetails";
 import EventTable, { EventTableRow } from "./EventTable";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 const DeletedText = styled.div`
     font-weight: 600;

--- a/src/components/DataInput/FreeFormTextInput.tsx
+++ b/src/components/DataInput/FreeFormTextInput.tsx
@@ -17,19 +17,12 @@ interface Props {
     className?: string;
     fullWidth?: boolean;
     margin?: "dense" | "normal" | "none";
-    isDisabled?: boolean;
+    disabled?: boolean;
     tabIndex?: number;
 }
 
 const FreeFormTextInput = React.forwardRef<HTMLInputElement, Props>((props, focusRef) => {
-    return (
-        <TextField
-            {...props}
-            inputRef={focusRef}
-            disabled={props.isDisabled}
-            tabIndex={props.tabIndex}
-        />
-    );
+    return <TextField {...props} inputRef={focusRef} />;
 });
 export default FreeFormTextInput;
 

--- a/src/components/Modal/ModalFormStyles.ts
+++ b/src/components/Modal/ModalFormStyles.ts
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 export const Centerer = styled.div`
     display: flex;

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -51,7 +51,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
                         onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                             setState(event.target.value);
                         }}
-                        isDisabled={isDisabled}
+                        disabled={isDisabled}
                     />
                 </TextFilterStyling>
             );

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -56,5 +56,6 @@ declare module "styled-components" {
         error: string;
         shadow: string;
         rainbow: RainbowPalette;
+        text: string;
     }
 }


### PR DESCRIPTION
## What's changed

Whilst investigating [VFB-88](https://softwiretech.atlassian.net/browse/VFB-88), a few chore-level improvements to styling were found.

- Remove `@types/styled-components` - it's not required for `styled-components` v6 and above, and is in fact not up to date with v6 changes.
- standardised import pattern for `styled` (named vs default import)
- Fixed a bug on the `FreeFormTextInput` Component where an invalid prop was being passed to the DOM
- updated the `DefaultTheme` definition to include the text property