### PR TITLE
VFB-88 Fix styling warnings

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
         setupNodeEvents(on: Cypress.PluginEvents, config: Cypress.PluginConfigOptions) {
             on("task", {
                 readPdf,
+                log: (message: unknown) => {
+                    console.log(message);
+                    return null;
+                },
             });
             return config;
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "@types/react-dom": "18.2.6",
         "@types/react-fontawesome": "^1.6.5",
         "@types/react-modal": "^3.16.0",
-        "@types/styled-components": "^5.1.26",
         "@types/uuid": "^9.0.8",
         "dayjs": "^1.11.9",
         "dotenv": "^16.3.1",
@@ -6376,14 +6375,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0"
-      }
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -6547,15 +6538,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.26",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/@types/stylis": {
       "version": "4.2.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@types/react-dom": "18.2.6",
     "@types/react-fontawesome": "^1.6.5",
     "@types/react-modal": "^3.16.0",
-    "@types/styled-components": "^5.1.26",
     "@types/uuid": "^9.0.8",
     "dayjs": "^1.11.9",
     "dotenv": "^16.3.1",

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -11,7 +11,7 @@ import {
     ExpandedClientParcelDetails,
     getClientParcelsDetails,
 } from "@/app/clients/getClientParcelsData";
-import { styled } from "styled-components";
+import styled from "styled-components";
 import { ErrorSecondaryText } from "../errorStylingandMessages";
 import { CircularProgress } from "@mui/material";
 import { Centerer } from "@/components/Modal/ModalFormStyles";

--- a/src/app/global_styles.tsx
+++ b/src/app/global_styles.tsx
@@ -80,7 +80,7 @@ const materialTheme = (chosenTheme: DefaultTheme): Theme =>
                         },
                         "&:focus": {
                             opacity: 0.7,
-                            boxShadow: `inset 0 0 0 2px ${chosenTheme.accent.foreground}`,
+                            boxShadow: `inset 0 0 0 2px ${chosenTheme.main.foreground[0]}`,
                         },
                     },
                 },

--- a/src/app/global_styles.tsx
+++ b/src/app/global_styles.tsx
@@ -75,14 +75,12 @@ const materialTheme = (chosenTheme: DefaultTheme): Theme =>
                         transition: "none",
                         textTransform: "none",
                         boxSizing: "border-box",
-                        border: "2px solid transparent",
                         "&:hover": {
                             opacity: 0.7,
-                            borderWidth: "2px",
                         },
                         "&:focus": {
                             opacity: 0.7,
-                            borderColor: `${chosenTheme.primary.foreground[0]}`,
+                            boxShadow: `inset 0 0 0 2px ${chosenTheme.accent.foreground}`,
                         },
                     },
                 },

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -9,7 +9,7 @@ import getExpandedParcelDetails, {
 } from "@/app/parcels/getExpandedParcelDetails";
 import EventTable, { EventTableRow } from "./EventTable";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 const DeletedText = styled.div`
     font-weight: 600;

--- a/src/app/themes.tsx
+++ b/src/app/themes.tsx
@@ -174,6 +174,13 @@ const preferenceIsDark = (themePreference: ThemePreference, systemTheme: SystemT
     }
 };
 
+const shouldForwardProp = (propName: string, target: unknown): boolean => {
+    if (typeof target === "string") {
+        return isPropValid(propName) as boolean;
+    }
+    return true;
+};
+
 /*
  * Makes a styled-components global registry to get server-side inserted CSS
  * Adapted from https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components
@@ -210,9 +217,12 @@ const StyleManager: React.FC<Props> = ({ children }) => {
 
     const themedChildren =
         typeof window !== "undefined" ? (
-            children
+            <StyleSheetManager shouldForwardProp={shouldForwardProp}>{children}</StyleSheetManager>
         ) : (
-            <StyleSheetManager sheet={serverStyleSheet.instance} shouldForwardProp={isPropValid}>
+            <StyleSheetManager
+                sheet={serverStyleSheet.instance}
+                shouldForwardProp={shouldForwardProp}
+            >
                 {children}
             </StyleSheetManager>
         );

--- a/src/app/themes.tsx
+++ b/src/app/themes.tsx
@@ -114,7 +114,7 @@ export const lightTheme: DefaultTheme = {
     },
     accent: {
         background: "#1b385f",
-        foreground: BLACK,
+        foreground: WHITE,
         largeForeground: WHITE,
     },
     error: "#c01622",
@@ -139,7 +139,7 @@ export const darkTheme: DefaultTheme = {
     },
     accent: {
         background: "#b8cbe9",
-        foreground: WHITE,
+        foreground: "#2d2d2d",
         largeForeground: "#2d2d2d",
     },
     shadow: "#282828",

--- a/src/app/themes.tsx
+++ b/src/app/themes.tsx
@@ -114,7 +114,7 @@ export const lightTheme: DefaultTheme = {
     },
     accent: {
         background: "#1b385f",
-        foreground: WHITE,
+        foreground: BLACK,
         largeForeground: WHITE,
     },
     error: "#c01622",
@@ -139,7 +139,7 @@ export const darkTheme: DefaultTheme = {
     },
     accent: {
         background: "#b8cbe9",
-        foreground: "#2d2d2d",
+        foreground: WHITE,
         largeForeground: "#2d2d2d",
     },
     shadow: "#282828",
@@ -214,13 +214,6 @@ const StyleManager: React.FC<Props> = ({ children }) => {
     const themeToggle = (dark: boolean): void => {
         setThemePreference(dark ? "dark" : "light");
     };
-
-    const themedChildren =
-        typeof window !== "undefined" ? (
-            <StyleSheetManager shouldForwardProp={shouldForwardProp}>{children}</StyleSheetManager>
-        ) : (
-            <StyleSheetManager sheet={serverStyleSheet.instance}>{children}</StyleSheetManager>
-        );
 
     return (
         <ThemeUpdateContext.Provider value={themeToggle}>

--- a/src/app/themes.tsx
+++ b/src/app/themes.tsx
@@ -219,12 +219,7 @@ const StyleManager: React.FC<Props> = ({ children }) => {
         typeof window !== "undefined" ? (
             <StyleSheetManager shouldForwardProp={shouldForwardProp}>{children}</StyleSheetManager>
         ) : (
-            <StyleSheetManager
-                sheet={serverStyleSheet.instance}
-                shouldForwardProp={shouldForwardProp}
-            >
-                {children}
-            </StyleSheetManager>
+            <StyleSheetManager sheet={serverStyleSheet.instance}>{children}</StyleSheetManager>
         );
 
     return (
@@ -232,7 +227,16 @@ const StyleManager: React.FC<Props> = ({ children }) => {
             <ThemeProvider
                 theme={preferenceIsDark(themePreference, systemTheme) ? darkTheme : lightTheme}
             >
-                <MaterialAndGlobalStyle>{themedChildren}</MaterialAndGlobalStyle>
+                <MaterialAndGlobalStyle>
+                    <StyleSheetManager
+                        shouldForwardProp={shouldForwardProp}
+                        sheet={
+                            typeof window === "undefined" ? serverStyleSheet.instance : undefined
+                        }
+                    >
+                        {children}
+                    </StyleSheetManager>
+                </MaterialAndGlobalStyle>
             </ThemeProvider>
         </ThemeUpdateContext.Provider>
     );

--- a/src/components/Buttons/NavBarButton.tsx
+++ b/src/components/Buttons/NavBarButton.tsx
@@ -15,7 +15,6 @@ interface Props {
 const NavBarStyledButton = styled(Button)`
     padding: 0.2rem 0.6rem;
     white-space: nowrap;
-    border-color: ${(props) => props.theme.primary.background[0]};
 `;
 
 const NavBarButton: React.FC<Props> = (props) => {

--- a/src/components/Buttons/NavBarButton.tsx
+++ b/src/components/Buttons/NavBarButton.tsx
@@ -15,6 +15,7 @@ interface Props {
 const NavBarStyledButton = styled(Button)`
     padding: 0.2rem 0.6rem;
     white-space: nowrap;
+    border-color: ${(props) => props.theme.primary.background[0]};
 `;
 
 const NavBarButton: React.FC<Props> = (props) => {

--- a/src/components/DataInput/FreeFormTextInput.tsx
+++ b/src/components/DataInput/FreeFormTextInput.tsx
@@ -17,19 +17,12 @@ interface Props {
     className?: string;
     fullWidth?: boolean;
     margin?: "dense" | "normal" | "none";
-    isDisabled?: boolean;
+    disabled?: boolean;
     tabIndex?: number;
 }
 
 const FreeFormTextInput = React.forwardRef<HTMLInputElement, Props>((props, focusRef) => {
-    return (
-        <TextField
-            {...props}
-            inputRef={focusRef}
-            disabled={props.isDisabled}
-            tabIndex={props.tabIndex}
-        />
-    );
+    return <TextField {...props} inputRef={focusRef} />;
 });
 export default FreeFormTextInput;
 

--- a/src/components/Modal/ModalFormStyles.ts
+++ b/src/components/Modal/ModalFormStyles.ts
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import styled from "styled-components";
 
 export const Centerer = styled.div`
     display: flex;

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -51,7 +51,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
                         onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
                             setState(event.target.value);
                         }}
-                        isDisabled={isDisabled}
+                        disabled={isDisabled}
                     />
                 </TextFilterStyling>
             );

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -56,5 +56,6 @@ declare module "styled-components" {
         error: string;
         shadow: string;
         rainbow: RainbowPalette;
+        text: string;
     }
 }


### PR DESCRIPTION
## What's changed
Fix the warnings in dev about props and styled components, as well as a few other styling pattern improvements

The fix for VFB-88 was that we were only using a `StyleSheetManager` (which handles prop forwarding) for server rendering, and it needed to be added for client rendering as well.

In addition:

- Remove @types/styled-components - it's not required for styled-components v6 and above, and is in fact not up to date with v6 changes.
- standardised import pattern for styled (named vs default import)
- Fixed a bug on the FreeFormTextInput Component where an invalid prop was being passed to the DOM
- updated the DefaultTheme definition to include the text property

## Notes:
- This does mean some styles that were previously not being properly applied are now handled correctly. Whilst this may make a few things visually different, it overall means that what we're seeing now lines up with what the CSS says, so any changes are positive. 
  - The only changes I noticed are subtle ones to the nav bar, but I can't guarantee there aren't others.
  - Those changes have been fixed in this PR by altering the CSS