### PR TITLE
VFB-285: Parcel modal for a deleted client no longer has client fields

### DIFF
--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -147,20 +147,13 @@ const getExpandedParcelDetails = async (
             expandedParcelData: {
                 isActive: false,
                 voucherNumber: rawParcelDetails.voucher_number ?? "",
-                fullName: client.full_name,
-                address: formatAddressFromClientDetails(client),
-                deliveryInstructions: client.delivery_instructions,
-                phoneNumber: client.phone_number,
                 listType: rawParcelDetails.list_type,
-                household: formatHouseholdFromFamilyDetails(client.family),
-                adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
-                children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
                 packingDate: formatDatetimeAsDate(rawParcelDetails.packing_date),
                 packingSlot: rawParcelDetails.packing_slot?.name ?? "",
                 method: rawParcelDetails.collection_centre?.is_shown
                     ? rawParcelDetails.collection_centre?.name
                     : `${rawParcelDetails.collection_centre?.name} (inactive)`,
-                collectionDateTime: rawParcelDetails.collection_datetime,
+                collectionDateTime: formatDateTime(rawParcelDetails.collection_datetime),
                 createdAt: formatDateTime(rawParcelDetails.created_at),
             },
             events: processEventsDetails(rawParcelDetails.events),
@@ -174,6 +167,7 @@ interface ParcelDataIndependentOfClient extends Data {
     packingDate: string;
     packingSlot: string;
     method: string;
+    collectionDateTime: string;
     createdAt: string;
     listType: ListType;
 }


### PR DESCRIPTION
## What's changed
The Parcel Details modal for a parcel with a deleted client used to have misleading client-related fields, that have been removed.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![{4D665C32-FAB1-412E-8DB1-ADB471409971}](https://github.com/user-attachments/assets/fadddb99-3cae-4785-8c15-70328bb376ea) | ![{66B25199-7EC4-4FD2-B90E-A265CA7445A5}](https://github.com/user-attachments/assets/cdcf29dc-abd2-4e63-8911-925af98777c5) |

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`


