### PR TITLE
Vfb 365 Make the 'error fetching data' messages float at the top of tables rather than push them down

### DIFF
--- a/docs/disaster-recovery-plan.md
+++ b/docs/disaster-recovery-plan.md
@@ -23,8 +23,12 @@ The data backup file is encrypted to protect sensitive information. The encrypte
   ```
 - Deploy edge functions (see GitHub workflow for commands)
 - Upload the congestion charge text file to bucket manually
-- Update the email provider settings to match the original Supabase instance
-- Update the email templates to match the original Supabase instance
+- Update the following project settings to match the original Supabase instance:
+  - auth, notably time-box user sessions
+  - SMTP
+- Update the auth configuration settings to match the original Supabase instance:
+  - email provider settings
+  - email templates
 - Update .env.local and add this to Keeper
 - Change the environment variables on Amplify and redeploy the code.
 

--- a/src/app/admin/auditLogTable/AuditLogTable.tsx
+++ b/src/app/admin/auditLogTable/AuditLogTable.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useEffect, useState } from "react";
 import { Row, ServerPaginatedTable } from "@/components/Tables/Table";
 import supabase from "@/supabaseClient";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { fetchAuditLog, fetchAuditLogCount } from "./fetchAuditLogData";
 import { auditLogTableHeaderKeysAndLabels } from "./columns";
 import { getAuditLogErrorMessage, auditLogTableColumnDisplayFunctions } from "./format";
@@ -16,6 +15,7 @@ import { AuditLogRow, AuditLogSortState, convertAuditLogPlusRowsToAuditLogRows }
 import { auditLogTableSortableColumns } from "./sortFunctions";
 import AuditLogModal from "./auditLogModal/AuditLogModal";
 import { DbAuditLogRow } from "@/databaseUtils";
+import FloatingToast from "@/components/FloatingToast";
 
 const AuditLogTable: React.FC = () => {
     const [auditLogDataPortion, setAuditLogDataPortion] = useState<AuditLogRow[]>([]);
@@ -80,7 +80,13 @@ const AuditLogTable: React.FC = () => {
 
     return (
         <>
-            {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+            {errorMessage && (
+                <FloatingToast
+                    message={errorMessage}
+                    severity="warning"
+                    variant="filled"
+                ></FloatingToast>
+            )}
             <ServerPaginatedTable<AuditLogRow, DbAuditLogRow, never>
                 dataPortion={auditLogDataPortion}
                 headerKeysAndLabels={auditLogTableHeaderKeysAndLabels}

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -46,6 +46,7 @@ import { useTheme } from "styled-components";
 import { formatDayjsToHoursAndMinutes, formatTimeStringToHoursAndMinutes } from "@/common/format";
 import { DesktopTimePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
+import FloatingToast from "@/components/FloatingToast";
 
 export interface CollectionCentresTableRow {
     acronym: Schema["collection_centres"]["acronym"];
@@ -503,7 +504,13 @@ const CollectionCentresTable: React.FC = () => {
 
     return (
         <>
-            {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+            {errorMessage && (
+                <FloatingToast
+                    message={errorMessage}
+                    severity="warning"
+                    variant="filled"
+                ></FloatingToast>
+            )}
             {rows && (
                 <StyledDataGrid
                     rows={rows}

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -29,10 +29,10 @@ import {
 import { LinearProgress } from "@mui/material";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Header from "../websiteDataTable/Header";
 import StyledDataGrid from "../common/StyledDataGrid";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
+import FloatingToast from "@/components/FloatingToast";
 
 interface EditToolbarProps {
     setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void;
@@ -420,7 +420,13 @@ const PackingSlotsTable: React.FC = () => {
 
     return (
         <>
-            {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+            {errorMessage && (
+                <FloatingToast
+                    message={errorMessage}
+                    severity="warning"
+                    variant="filled"
+                ></FloatingToast>
+            )}
             {rows && (
                 <StyledDataGrid
                     rows={rows}

--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -8,7 +8,6 @@ import OptionButtonsDiv from "@/app/admin/common/OptionButtonsDiv";
 import SuccessFailureAlert, { AlertOptions } from "@/app/admin/common/SuccessFailureAlert";
 import supabase from "@/supabaseClient";
 import { getUsersDataAndCount } from "@/app/admin/usersTable/getUsersData";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { usersFilters } from "@/app/admin/usersTable/filters";
 import { getCurrentUser } from "@/server/getCurrentUser";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
@@ -18,6 +17,7 @@ import { UserRow, UsersFilters, UsersSortState } from "./types";
 import { usersSortableColumns } from "./sortableColumns";
 import { userTableColumnDisplayFunctions } from "./format";
 import { Schema } from "@/databaseUtils";
+import FloatingToast from "@/components/FloatingToast";
 
 const UsersTable: React.FC = () => {
     const [userToDelete, setUserToDelete] = useState<UserRow | null>(null);
@@ -128,7 +128,13 @@ const UsersTable: React.FC = () => {
 
     return (
         <>
-            {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+            {errorMessage && (
+                <FloatingToast
+                    message={errorMessage}
+                    severity="warning"
+                    variant="filled"
+                ></FloatingToast>
+            )}
             <ServerPaginatedTable<UserRow, Schema["profiles"], string | string[]>
                 dataPortion={users}
                 headerKeysAndLabels={usersTableHeaderKeysAndLabels}

--- a/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
+++ b/src/app/admin/websiteDataTable/WebsiteDataTable.tsx
@@ -20,10 +20,10 @@ import { LinearProgress } from "@mui/material";
 import { fetchWebsiteData, updateDbWebsiteData } from "./fetchWebsiteData";
 import EditableTextAreaForDataGrid from "./EditableTextAreaForDataGrid";
 import { logErrorReturnLogId } from "@/logger/logger";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
 import Header from "./Header";
 import StyledDataGrid from "../common/StyledDataGrid";
+import FloatingToast from "@/components/FloatingToast";
 
 export interface WebsiteDataRow {
     dbName: string;
@@ -225,7 +225,13 @@ const WebsiteDataTable: React.FC = () => {
 
     return (
         <>
-            {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+            {errorMessage && (
+                <FloatingToast
+                    message={errorMessage}
+                    severity="warning"
+                    variant="filled"
+                ></FloatingToast>
+            )}
             {rows && (
                 <StyledDataGrid
                     rows={rows}

--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -32,6 +32,7 @@ import { getIsClientActiveErrorMessage, getDeleteClientErrorMessage } from "./fo
 import { getClientParcelsDetails } from "../getClientParcelsData";
 import { saveParcelStatus } from "@/app/parcels/ActionBar/Statuses";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
+import FloatingToast from "@/components/FloatingToast";
 
 const ClientsPage: React.FC = () => {
     const [isLoadingForFirstTime, setIsLoadingForFirstTime] = useState(true);
@@ -181,7 +182,13 @@ const ClientsPage: React.FC = () => {
                 </Centerer>
             ) : (
                 <>
-                    {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+                    {errorMessage && (
+                        <FloatingToast
+                            message={errorMessage}
+                            severity="warning"
+                            variant="filled"
+                        ></FloatingToast>
+                    )}
                     <TableSurface>
                         <ServerPaginatedTable<ClientsTableRow, DbClientRow, string>
                             dataPortion={clientsDataPortion}

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -23,7 +23,7 @@ import ParcelsTable from "@/app/parcels/parcelsTable/ParcelsTable";
 import ParcelsModal from "@/app/parcels/parcelsTable/ParcelsModal";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
 import { CircularProgress } from "@mui/material";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
+import FloatingToast from "@/components/FloatingToast";
 
 const ParcelsPage: React.FC = () => {
     const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
@@ -110,7 +110,13 @@ const ParcelsPage: React.FC = () => {
                 </Centerer>
             ) : (
                 <>
-                    {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+                    {errorMessage && (
+                        <FloatingToast
+                            message={errorMessage}
+                            severity="warning"
+                            variant="filled"
+                        ></FloatingToast>
+                    )}
                     <ParcelsTable
                         setSelectedParcelId={setSelectedParcelId}
                         setSelectedClientDetails={setSelectedClientDetails}

--- a/src/app/reports/reportsTable/ReportsPage.tsx
+++ b/src/app/reports/reportsTable/ReportsPage.tsx
@@ -6,7 +6,6 @@ import TableSurface from "@/components/Tables/TableSurface";
 import supabase from "@/supabaseClient";
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { CircularProgress } from "@mui/material";
-import { ErrorSecondaryText } from "../../errorStylingandMessages";
 import reportsHeaders from "./headers";
 import { ReportsTableRow, ReportsSortState } from "./types";
 import { DbReportRow } from "@/databaseUtils";
@@ -14,6 +13,7 @@ import getReportsDataAndCount from "./getReportsData";
 import reportsSortableColumns from "./sortableColumns";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
 import { reportsTableColumnStyleOptions } from "@/app/reports/reportsTable/styles";
+import FloatingToast from "@/components/FloatingToast";
 
 const ReportsPage: React.FC = () => {
     const [isLoadingForFirstTime, setIsLoadingForFirstTime] = useState(true);
@@ -98,7 +98,13 @@ const ReportsPage: React.FC = () => {
                 </Centerer>
             ) : (
                 <>
-                    {errorMessage && <ErrorSecondaryText>{errorMessage}</ErrorSecondaryText>}
+                    {errorMessage && (
+                        <FloatingToast
+                            message={errorMessage}
+                            severity="warning"
+                            variant="filled"
+                        ></FloatingToast>
+                    )}
                     <TableSurface>
                         <ServerPaginatedTable<ReportsTableRow, DbReportRow, never>
                             dataPortion={reportsDataPortion}

--- a/src/components/FloatingToast.tsx
+++ b/src/components/FloatingToast.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+import {
+    Alert,
+    AlertColor,
+    AlertPropsColorOverrides,
+    AlertPropsVariantOverrides,
+} from "@mui/material";
+import { OverridableStringUnion } from "@mui/types";
+
+export const FloatingToastVerticalContainer = styled.div`
+    position: relative;
+`;
+
+export const FloatingToastContainer = styled.div`
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    z-index: 100;
+`;
+
+interface Props {
+    message?: string;
+    severity?: OverridableStringUnion<AlertColor, AlertPropsColorOverrides>;
+    variant?: OverridableStringUnion<
+        "standard" | "filled" | "outlined",
+        AlertPropsVariantOverrides
+    >;
+}
+
+const FloatingToast: React.FC<Props> = ({ message, severity, variant }) => {
+    return (
+        <FloatingToastVerticalContainer>
+            <FloatingToastContainer>
+                <Alert severity={severity} variant={variant}>
+                    {message}
+                </Alert>
+            </FloatingToastContainer>
+        </FloatingToastVerticalContainer>
+    );
+};
+
+export default FloatingToast;

--- a/src/components/FloatingToast.tsx
+++ b/src/components/FloatingToast.tsx
@@ -8,17 +8,6 @@ import {
 } from "@mui/material";
 import { OverridableStringUnion } from "@mui/types";
 
-export const FloatingToastVerticalContainer = styled.div`
-    position: relative;
-`;
-
-export const FloatingToastContainer = styled.div`
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
-    z-index: 100;
-`;
-
 interface Props {
     message?: string;
     severity?: OverridableStringUnion<AlertColor, AlertPropsColorOverrides>;
@@ -27,6 +16,17 @@ interface Props {
         AlertPropsVariantOverrides
     >;
 }
+
+const FloatingToastVerticalContainer = styled.div`
+    position: relative;
+`;
+
+const FloatingToastContainer = styled.div`
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    z-index: 100;
+`;
 
 const FloatingToast: React.FC<Props> = ({ message, severity, variant }) => {
     return (


### PR DESCRIPTION
## Screenshots / Videos
| Before     | After      |
|------------|------------|
| ![{8A285926-D58E-4195-9DF4-CA02CEA53D66}](https://github.com/user-attachments/assets/27cacbbe-4326-4e50-bb26-d0e82a4ddae9) | ![{B3CA01CB-EA72-407F-AFB3-6237DC6284D2}](https://github.com/user-attachments/assets/3f5063b2-42f4-4d9e-ab33-0860e38b1378) |

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
