### PR TITLE
#397: Add browserslist with mininmum target browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
       ".tsx"
     ]
   },
+  "browserslist": [
+    "defaults",
+    "Safari >= 13.1.2",
+    "Chrome >= 116"
+  ],
   "dependencies": {
     "@emotion/is-prop-valid": "^1.2.1",
     "@emotion/react": "^11.11.1",


### PR DESCRIPTION
Speculative fix for running on old browsers. According to NextJS docs, browerslist should just work. I can't acccess Browserstack atm but have a laptop with the appropriate version, so I'd like to deploy and test.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [X] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
