### PR TITLE
#526: Fix Info page to work on Safari 13, and update issue assignee

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -2,7 +2,7 @@ name: Bug Report
 description: File a bug report
 labels: ["bug"]
 assignees:
-  - Stuart-Knowles-SW
+  - stonelink
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest a feature
 labels: ["enhancement"]
 assignees:
-  - Stuart-Knowles-SW
+  - stonelink
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -2,7 +2,7 @@ name: Question
 description: Ask a question to the team
 labels: ["question"]
 assignees:
-  - Stuart-Knowles-SW
+  - stonelink
 body:
   - type: textarea
     id: question

--- a/src/app/info/WikiItemEdit.tsx
+++ b/src/app/info/WikiItemEdit.tsx
@@ -137,7 +137,9 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
     const deleteWikiItemWithConfirmation = async (): Promise<void> => {
         if (!rowData.title && !rowData.content) {
             const confirmation: boolean = confirm("Confirm discard of this item?");
-            deleteWikiItem();
+            if (confirmation) {
+                deleteWikiItem();
+            }
         } else {
             const confirmation: boolean = confirm("Confirm deletion of this item?");
             if (confirmation) {

--- a/src/app/info/WikiItemEdit.tsx
+++ b/src/app/info/WikiItemEdit.tsx
@@ -18,6 +18,7 @@ import KeyboardDoubleArrowDownIcon from "@mui/icons-material/KeyboardDoubleArrow
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 import { DirectionString } from "@/app/info/WikiItems";
 import { deleteItemInWikiTable, updateItemInWikiTable } from "@/app/info/supabaseHelpers";
+import { useTheme } from "styled-components";
 
 interface WikiItemEditProps {
     rowData: DbWikiRow;
@@ -40,6 +41,8 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
 }) => {
     const [titleValue, setTitleValue] = React.useState(rowData.title);
     const [contentValue, setContentValue] = React.useState(rowData.content);
+
+    const theme = useTheme();
 
     const deleteWikiItem = async (): Promise<void> => {
         const deleteError = await deleteItemInWikiTable(rowData.wiki_key);
@@ -133,6 +136,7 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
 
     const deleteWikiItemWithConfirmation = async (): Promise<void> => {
         if (!rowData.title && !rowData.content) {
+            const confirmation: boolean = confirm("Confirm discard of this item?");
             deleteWikiItem();
         } else {
             const confirmation: boolean = confirm("Confirm deletion of this item?");
@@ -200,12 +204,6 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
                 />
 
                 <WikiEditModeButton
-                    onClick={deleteWikiItemWithConfirmation}
-                    data-testid={`#delete-${rowData.row_order}`}
-                >
-                    <DeleteIcon />
-                </WikiEditModeButton>
-                <WikiEditModeButton
                     onClick={() => {
                         const title_input = document.getElementById(
                             `title_input_${rowData.wiki_key}`
@@ -217,7 +215,13 @@ const WikiItemEdit: React.FC<WikiItemEditProps> = ({
                     }}
                     data-testid={`#update-${rowData.row_order}`}
                 >
-                    <SaveIcon />
+                    <SaveIcon sx={{ color: theme.primary.background[3] }} />
+                </WikiEditModeButton>
+                <WikiEditModeButton
+                    onClick={deleteWikiItemWithConfirmation}
+                    data-testid={`#delete-${rowData.row_order}`}
+                >
+                    <DeleteIcon />
                 </WikiEditModeButton>
             </WikiItemAccordionSurface>
         </>

--- a/src/app/info/WikiItems.test.tsx
+++ b/src/app/info/WikiItems.test.tsx
@@ -43,9 +43,9 @@ jest.mock("@/app/info/supabaseHelpers", () => ({
 }));
 
 const mRandomUUID = jest.fn().mockReturnValue("058049b5-7a7f-4f81-bf56-6dc9654e4a40");
-Object.defineProperty(window, "crypto", {
-    value: { randomUUID: mRandomUUID },
-});
+jest.mock("uuid", () => ({
+    v4: jest.fn(() => mRandomUUID),
+}));
 
 const mScrollIntoViewMock = jest.fn();
 window.HTMLElement.prototype.scrollIntoView = mScrollIntoViewMock;

--- a/src/app/info/WikiItems.tsx
+++ b/src/app/info/WikiItems.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { v4 as uuidv4 } from "uuid";
 import { DbWikiRow } from "@/databaseUtils";
 import { WikiItemPositioner } from "@/app/info/StyleComponents";
 import React, { useEffect, useMemo, useRef } from "react";
@@ -39,12 +40,12 @@ export const convertContentToElements = (rowContent: string): React.JSX.Element[
             const plainPart = part.slice(1, -1);
             if (plainPart.includes("](")) {
                 const items = plainPart.split(/\]\(/);
-                return { content: items[0], href: items[1], key: crypto.randomUUID() };
+                return { content: items[0], href: items[1], key: uuidv4() };
             } else {
-                return { content: plainPart, href: plainPart, key: crypto.randomUUID() };
+                return { content: plainPart, href: plainPart, key: uuidv4() };
             }
         } else {
-            return { content: part, key: crypto.randomUUID() };
+            return { content: part, key: uuidv4() };
         }
     });
     return contentParts.map((part: ContentPart) => {


### PR DESCRIPTION
## What's changed
The Info/Wiki page used to use crypto.randomUUID, which isn't supported on Safari 13, so it's been replaced by an npm package. I've also tweaked the usability, by making the Save and Delete controls in the same order and colouring as the Collection Centres table.
Also I've changed the initial assignee for new Issues to be me.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [X] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`

