### PR TITLE
#523: Replace webp logo by png

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -199,7 +199,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                     </MobileNavMenuContainer>
                     <LogoElementContainer>
                         <UnstyledLink href="/" prefetch={false}>
-                            <Logo alt="Lambeth Foodbank Logo" src="/logo.webp" />
+                            <Logo alt="Lambeth Foodbank Logo" src="/logo.png" />
                         </UnstyledLink>
                     </LogoElementContainer>
                     <DesktopButtonContainer data-testid="desktop-buttons">


### PR DESCRIPTION
## What's changed
The logo file was a WEBP, which isn't supported by Safari 13. There was already a PNG in the codebase, so using that instead. It didn't seem worth having a `<picture>` with multiple source files, because the live site will nearly always be running on old Safari, so having what's rendered be different on that environment seems like a risk.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

