### PR TITLE
#525 Tighten layout of Shopping List PDFs

### DIFF
--- a/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
+++ b/src/app/parcels/ActionBar/SelectedParcelsOverview.tsx
@@ -8,9 +8,13 @@ const Heading = styled.div`
     margin: 0.3rem;
 `;
 
+const ListContainer = styled.div`
+    max-height: 40vh;
+    overflow-y: auto;
+`;
+
 const ListItem = styled.p<{ emphasised?: boolean }>`
-    margin-left: 1rem;
-    padding: 0.5rem 0;
+    margin: 0.5rem 0 0.5rem 1rem;
     ${(props) =>
         props.emphasised &&
         `
@@ -26,18 +30,22 @@ interface ShowParcelsProps {
 const SelectedParcelsOverview: React.FC<ShowParcelsProps> = (props) => {
     return (
         <>
-            <Heading>{props.parcels.length === 1 ? "Parcel" : "Parcels"} selected:</Heading>
-            {props.parcels.slice(0, props.maxParcelsToShow).map((parcel) => (
-                <ListItem key={parcel.parcelId}>
-                    {getParcelOverviewString(
-                        parcel.addressPostcode,
-                        parcel.fullName,
-                        parcel.collectionDatetime,
-                        parcel.clientIsActive
-                    )}
-                </ListItem>
-            ))}
-            {props.parcels.length > props.maxParcelsToShow && <ListItem emphasised>...</ListItem>}
+            <Heading>
+                {props.parcels.length.toString()}{" "}
+                {props.parcels.length === 1 ? "Parcel" : "Parcels"} selected:
+            </Heading>
+            <ListContainer>
+                {props.parcels.map((parcel) => (
+                    <ListItem key={parcel.parcelId}>
+                        {getParcelOverviewString(
+                            parcel.addressPostcode,
+                            parcel.fullName,
+                            parcel.collectionDatetime,
+                            parcel.clientIsActive
+                        )}
+                    </ListItem>
+                ))}
+            </ListContainer>
         </>
     );
 };

--- a/src/common/formatFamiliesData.ts
+++ b/src/common/formatFamiliesData.ts
@@ -11,7 +11,6 @@ import { getCurrentYear } from "@/common/date";
 
 export interface HouseholdSummary {
     householdSize: string;
-    genderBreakdown: string;
     ageAndGenderOfAdults: string;
     numberOfBabies: string;
     ageAndGenderOfChildren: string;
@@ -58,21 +57,15 @@ export const prepareHouseholdSummary = (familyData: Schema["families"][]): House
     const numberBabies = familyData.filter(
         (member) => member.birth_year === getCurrentYear()
     ).length;
-    const numberFemales = familyData.filter((member) => member.gender === "female").length;
-    const numberMales = familyData.filter((member) => member.gender === "male").length;
 
     const adultText = `${householdSize} (${convertPlural(
         householdSize - formattedChildren.length,
         "Adult"
     )}`;
-    const childText = `${formattedChildren.length} Child${formattedChildren.length ? "ren" : ""})`;
-    const femaleText = `${convertPlural(numberFemales, "Female")}`;
-    const maleText = `${convertPlural(numberMales, "Male")}`;
-    const otherText = `${convertPlural(householdSize - numberFemales - numberMales, "Other")}`;
+    const childText = `${formattedChildren.length} Child${formattedChildren.length === 1 ? "" : "ren"})`;
 
     return {
         householdSize: `${adultText} ${childText}`,
-        genderBreakdown: `${femaleText} ${maleText} ${otherText}`,
         ageAndGenderOfAdults: displayList(
             formattedAdults.map((adult) =>
                 getPerson(adult, getAdultAgeUsingBirthYear(adult.birthYear, true))

--- a/src/pdf/ShoppingList/ShoppingListPdf.tsx
+++ b/src/pdf/ShoppingList/ShoppingListPdf.tsx
@@ -12,7 +12,10 @@ import { Item, ShoppingListPdfData } from "@/pdf/ShoppingList/shoppingListPdfDat
 import { faTruck, faShoePrints } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
 
-export type BlockProps = ParcelInfo | HouseholdSummary | RequirementSummary;
+type BlockProps = {
+    data: ParcelInfo | HouseholdSummary | RequirementSummary;
+    noWrap?: boolean;
+};
 
 const styles = StyleSheet.create({
     sheet: {
@@ -35,7 +38,7 @@ const styles = StyleSheet.create({
     },
     pdfInfoSection: {
         flexDirection: "row",
-        marginBottom: "15px",
+        marginBottom: "5px",
     },
     pdfInfoLeftColumn: {
         width: "80%",
@@ -53,7 +56,7 @@ const styles = StyleSheet.create({
     },
     infoCell: {
         width: "100%",
-        padding: "5pt",
+        padding: "1pt",
         borderStyle: "solid",
         border: "1pt",
     },
@@ -61,27 +64,27 @@ const styles = StyleSheet.create({
         textAlign: "left",
     },
     tableItemDescription: {
-        paddingVertical: "2pt",
-        width: "30%",
-        border: "1pt",
+        paddingVertical: "1pt",
+        width: "34%",
+        border: "0.5pt",
         borderStyle: "solid",
     },
     tableQuantity: {
-        paddingVertical: "2pt",
+        paddingVertical: "1pt",
         width: "20%",
-        border: "1pt",
+        border: "0.5pt",
         borderStyle: "solid",
     },
     tableNotes: {
-        paddingVertical: "2pt",
+        paddingVertical: "1pt",
         width: "40%",
-        border: "1pt",
+        border: "0.5pt",
         borderStyle: "solid",
     },
     tableDone: {
-        paddingVertical: "2pt",
-        width: "10%",
-        border: "1pt",
+        paddingVertical: "1pt",
+        width: "6%",
+        border: "0.5pt",
         borderStyle: "solid",
     },
     title: {
@@ -92,7 +95,8 @@ const styles = StyleSheet.create({
     subtitle: {
         fontSize: "16pt",
         fontFamily: "Helvetica-Bold",
-        paddingTop: "2pt",
+        marginTop: "5px",
+        marginBottom: "5px",
     },
     keyText: {
         fontSize: "11pt",
@@ -104,9 +108,13 @@ const styles = StyleSheet.create({
         fontFamily: "Helvetica",
         paddingLeft: "2pt",
     },
+    nonWrappingText: {
+        maxLines: 1,
+        textOverflow: "ellipsis",
+    },
     tableCell: {
         borderStyle: "solid",
-        border: "1pt",
+        border: "0.5pt",
     },
     itemList: {
         alignItems: "center",
@@ -117,6 +125,7 @@ const styles = StyleSheet.create({
 interface OneLineProps {
     header: string;
     value: string;
+    noWrap?: boolean;
 }
 
 const shouldDisplay = (header: string, value: string): boolean => {
@@ -142,10 +151,12 @@ const getDisplayValue = (header: string, value: string): string => {
     }
 };
 
-const OneLine: React.FC<OneLineProps> = ({ header, value }) => {
+const OneLine: React.FC<OneLineProps> = ({ header, value, noWrap }) => {
     const displayValue = getDisplayValue(header, value);
+    const lineStyles = noWrap === true ? [styles.keyText, styles.nonWrappingText] : styles.keyText;
+
     return (
-        <Text style={styles.keyText}>
+        <Text style={lineStyles}>
             {header}: <Text style={styles.normalText}>{displayValue}</Text>
         </Text>
     );
@@ -201,29 +212,39 @@ const DisplayItemsList: React.FC<DisplayItemsListProps> = ({ itemsList }) => {
     );
 };
 
-const DisplayAsBlockNoBorder: React.FC<BlockProps> = (data: BlockProps) => {
+const DisplayAsBlockNoBorder: React.FC<BlockProps> = (props: BlockProps) => {
     return (
         <View style={styles.infoCellNoBorder}>
-            {Object.entries(data)
+            {Object.entries(props.data)
                 .filter(([propKey, propValue]) =>
                     shouldDisplay(formatCamelCaseKey(propKey), propValue)
                 )
                 .map(([propKey, propValue]) => (
-                    <OneLine key={propKey} header={formatCamelCaseKey(propKey)} value={propValue} />
+                    <OneLine
+                        key={propKey}
+                        header={formatCamelCaseKey(propKey)}
+                        value={propValue}
+                        noWrap={props.noWrap}
+                    />
                 ))}
         </View>
     );
 };
 
-const DisplayAsBlock: React.FC<BlockProps> = (data: BlockProps) => {
+const DisplayAsBlock: React.FC<BlockProps> = (props: BlockProps) => {
     return (
         <View style={styles.infoCell}>
-            {Object.entries(data)
+            {Object.entries(props.data)
                 .filter(([propKey, propValue]) =>
                     shouldDisplay(formatCamelCaseKey(propKey), propValue)
                 )
                 .map(([propKey, propValue]) => (
-                    <OneLine key={propKey} header={formatCamelCaseKey(propKey)} value={propValue} />
+                    <OneLine
+                        key={propKey}
+                        header={formatCamelCaseKey(propKey)}
+                        value={propValue}
+                        noWrap={props.noWrap}
+                    />
                 ))}
         </View>
     );
@@ -290,15 +311,15 @@ const SingleShoppingList: React.FC<SingleShoppingListProps> = ({ parcelData }) =
                                 </Text>
                             </View>
                         </View>
-                        <DisplayAsBlockNoBorder {...parcelData.parcelInfo} />
+                        <DisplayAsBlockNoBorder data={parcelData.parcelInfo} noWrap={true} />
                     </View>
                     {/* eslint-disable-next-line jsx-a11y/alt-text -- React-PDF Image doesn't  have alt text property*/}
                     <Image src="/logo.png" style={[styles.flexRow, styles.logoStyling]} />
                 </View>
                 <DisplayClientSummary {...parcelData.clientSummary} />
                 <View style={styles.flexRow}>
-                    <DisplayAsBlock {...parcelData.householdSummary} />
-                    <DisplayAsBlock {...parcelData.requirementSummary} />
+                    <DisplayAsBlock data={parcelData.householdSummary} />
+                    <DisplayAsBlock data={parcelData.requirementSummary} />
                 </View>
                 <View>
                     <TableHeadings />


### PR DESCRIPTION
## What's changed
The Shopping List PDFs have been frequently extending to 3 pages - they should fit in 2 pages. After a few layout changes, I checked with Dan that the result is acceptable.
Also the list of parcels in each Parcel Action modal now has a scrollable list of all parcels rather than only 5 parcels and an ellipsis. Also the number of selected parcels is shown.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
