### PR TITLE
#518 Change dietary requirements responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ You can regenerate the types
 
 #### Useful links
 - [Local Development](https://supabase.com/docs/guides/cli/local-development)
+- [Migration commmands](https://supabase.com/docs/reference/cli/supabase-migration)
 - [Managing Environments](https://supabase.com/docs/guides/cli/managing-environments)
 - [Deploy a migration](https://supabase.com/docs/guides/cli/managing-environments?environment=ci#deploy-a-migration)
 

--- a/src/app/batch-create/getCenteredBatchGridDisplayColumns.tsx
+++ b/src/app/batch-create/getCenteredBatchGridDisplayColumns.tsx
@@ -25,10 +25,10 @@ import {
 import AddressEditCell from "@/app/batch-create/inputComponents/AddressEditCell";
 import ListTypeEditCell from "@/app/batch-create/inputComponents/ListTypeEditCell";
 import BooleanGroupEditCell from "@/app/batch-create/inputComponents/BooleanGroupEditCell";
-import { DIETARY_REQS_LABELS_AND_KEYS } from "@/app/clients/form/formSections/DietaryRequirementCard";
-import { FEMININE_PRODUCTS_LABELS_AND_KEYS } from "@/app/clients/form/formSections/FeminineProductCard";
-import { PET_FOOD_LABELS_AND_KEYS } from "@/app/clients/form/formSections/PetFoodCard";
-import { OTHER_ITEMS_LABELS_AND_KEYS } from "@/app/clients/form/formSections/OtherItemsCard";
+import { dietaryRequirementLabelsAndKeys } from "@/app/clients/form/formSections/DietaryRequirementCard";
+import { feminineProductLabelsAndKeys } from "@/app/clients/form/formSections/FeminineProductCard";
+import { petFoodLabelsAndKeys } from "@/app/clients/form/formSections/PetFoodCard";
+import { otherItemsLabelsAndKeys } from "@/app/clients/form/formSections/OtherItemsCard";
 import BabyProductsEditCell from "@/app/batch-create/inputComponents/BabyProductsEditCell";
 import TextFieldEditCell from "@/app/batch-create/inputComponents/MultilinePopoverEditCell";
 import BooleanClientEditCell from "@/app/batch-create/inputComponents/BooleanClientEditCell";
@@ -172,7 +172,7 @@ const getCenteredBatchGridDisplayColumns = (
                         tableState={tableState}
                         clientField="dietaryRequirements"
                         fieldWidth={DIETARY_REQUIREMENTS_WIDTH}
-                        booleanGroupLabelAndKeys={DIETARY_REQS_LABELS_AND_KEYS}
+                        booleanGroupLabelAndKeys={dietaryRequirementLabelsAndKeys}
                     />
                 );
             },
@@ -190,7 +190,7 @@ const getCenteredBatchGridDisplayColumns = (
                         tableState={tableState}
                         clientField="feminineProducts"
                         fieldWidth={FEMININE_PRODUCTS_WIDTH}
-                        booleanGroupLabelAndKeys={FEMININE_PRODUCTS_LABELS_AND_KEYS}
+                        booleanGroupLabelAndKeys={feminineProductLabelsAndKeys}
                     />
                 );
             },
@@ -223,7 +223,7 @@ const getCenteredBatchGridDisplayColumns = (
                         tableState={tableState}
                         clientField="petFood"
                         fieldWidth={PET_FOOD_WIDTH}
-                        booleanGroupLabelAndKeys={PET_FOOD_LABELS_AND_KEYS}
+                        booleanGroupLabelAndKeys={petFoodLabelsAndKeys}
                     />
                 );
             },
@@ -241,7 +241,7 @@ const getCenteredBatchGridDisplayColumns = (
                         tableState={tableState}
                         clientField="otherItems"
                         fieldWidth={OTHER_ITEMS_WIDTH}
-                        booleanGroupLabelAndKeys={OTHER_ITEMS_LABELS_AND_KEYS}
+                        booleanGroupLabelAndKeys={otherItemsLabelsAndKeys}
                     />
                 );
             },

--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -17,7 +17,7 @@ const AddClients: () => React.ReactElement = () => {
         numberOfChildren: 0,
         children: [],
         listType: null,
-        dietaryRequirements: {},
+        dietaryRequirements: null,
         feminineProducts: {},
         babyProducts: null,
         nappySize: "",

--- a/src/app/clients/edit/[id]/autofill.ts
+++ b/src/app/clients/edit/[id]/autofill.ts
@@ -38,7 +38,10 @@ const autofill = (
         numberOfChildren: children.length,
         children: children,
         listType: clientData.default_list,
-        dietaryRequirements: arrayToBooleanGroup(clientData.dietary_requirements ?? []),
+        dietaryRequirements:
+            clientData.dietary_requirements !== null
+                ? arrayToBooleanGroup(clientData.dietary_requirements)
+                : null,
         feminineProducts: arrayToBooleanGroup(clientData.feminine_products ?? []),
         babyProducts: clientData.baby_food,
         nappySize: nappySize.replace("Nappy Size: ", ""),

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -61,7 +61,7 @@ export interface ClientFields extends Fields {
     children: Person[];
     numberOfChildren: number;
     listType: ListType | null;
-    dietaryRequirements: BooleanGroup;
+    dietaryRequirements: BooleanGroup | null;
     feminineProducts: BooleanGroup;
     babyProducts: boolean | null;
     nappySize: string;

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -181,6 +181,7 @@ const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editCon
                         );
                         break;
                 }
+                setSubmitDisabled(false);
                 return;
             }
             router.push(`/clients?clientId=${clientId}`);
@@ -194,6 +195,7 @@ const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editCon
                         );
                         break;
                 }
+                setSubmitDisabled(false);
                 return;
             }
             router.push(`/parcels/add/${clientId}`);

--- a/src/app/clients/form/formSections/DietaryRequirementCard.tsx
+++ b/src/app/clients/form/formSections/DietaryRequirementCard.tsx
@@ -1,38 +1,79 @@
-import React from "react";
+import React, { useState } from "react";
 import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
 import { checkboxGroupToArray, onChangeCheckbox } from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
+import { Checkbox, FormControlLabel } from "@mui/material";
+import { FormElementWithSpacing } from "@/components/Form/formStyling";
 
-export const DIETARY_REQS_LABELS_AND_KEYS: [string, string][] = [
-    ["Gluten Free", "Gluten Free"],
-    ["Dairy Free", "Dairy Free"],
-    ["Vegetarian", "Vegetarian"],
-    ["Vegan", "Vegan"],
-    ["Pescatarian", "Pescatarian"],
-    ["Halal", "Halal"],
-    ["Diabetic", "Diabetic"],
-    ["Nut Allergy", "Nut Allergy"],
-    ["Seafood Allergy", "Seafood Allergy"],
-    ["No Bread", "No Bread"],
-    ["No Pasta", "No Pasta"],
-    ["No Rice", "No Rice"],
-    ["No Pork", "No Pork"],
-    ["No Beef", "No Beef"],
+export const dietaryRequirementOptions: string[] = [
+    "Fresh Fruit",
+    "Fresh Veg",
+    "Garlic",
+    "Ginger",
+    "Chillies",
+    "Spices",
+    "Bread",
+    "Tea",
+    "Coffee",
+    "Pasta",
+    "Rice",
+    "Meat (No Pork)",
+    "Meat & Pork",
+    "Gluten Free",
+    "Dairy Free",
+    "Vegetarian",
+    "Vegan",
+    "Pescatarian",
+    "Halal",
+    "Diabetic",
+    "Nut Allergy",
+    "Seafood Allergy",
 ];
 
+export const dietaryRequirementLabelsAndKeys: [string, string][] = dietaryRequirementOptions.map(
+    (optionName) => [optionName, optionName]
+);
+
 const DietaryRequirementCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
+    const [unknownDietaryRequirements, setUnknownDietaryRequirements] = useState(
+        fields["dietaryRequirements"] === null
+    );
+
+    const handleCheckCheckboxForUnknown = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        setUnknownDietaryRequirements(event.target.checked);
+
+        fieldSetter({ dietaryRequirements: null });
+    };
+
     return (
-        <GenericFormCard title="Dietary Requirements" required={false} text="Tick all that apply">
-            <CheckboxGroupInput
-                labelsAndKeys={DIETARY_REQS_LABELS_AND_KEYS}
-                onChange={onChangeCheckbox(
-                    fieldSetter,
-                    fields.dietaryRequirements,
-                    "dietaryRequirements"
-                )}
-                checkedKeys={checkboxGroupToArray(fields.dietaryRequirements)}
+        <GenericFormCard title="Dietary Requirements" required={false}>
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={unknownDietaryRequirements}
+                        onChange={handleCheckCheckboxForUnknown}
+                    />
+                }
+                label="Don't Know"
             />
+            <FormElementWithSpacing>
+                <CheckboxGroupInput
+                    groupLabel="Tick all that apply"
+                    labelsAndKeys={dietaryRequirementLabelsAndKeys}
+                    onChange={onChangeCheckbox(
+                        fieldSetter,
+                        fields.dietaryRequirements ?? {},
+                        "dietaryRequirements"
+                    )}
+                    checkedKeys={
+                        fields.dietaryRequirements
+                            ? checkboxGroupToArray(fields.dietaryRequirements)
+                            : []
+                    }
+                    disabled={!!unknownDietaryRequirements}
+                />
+            </FormElementWithSpacing>
         </GenericFormCard>
     );
 };

--- a/src/app/clients/form/formSections/FeminineProductCard.tsx
+++ b/src/app/clients/form/formSections/FeminineProductCard.tsx
@@ -4,17 +4,17 @@ import { checkboxGroupToArray, onChangeCheckbox } from "@/components/Form/formFu
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
 
-export const FEMININE_PRODUCTS_LABELS_AND_KEYS: [string, string][] = [
-    ["Tampons", "Tampons"],
-    ["Pads", "Pads"],
-    ["Incontinence Pads", "Incontinence Pads"],
-];
+export const feminineProductOptions: string[] = ["Tampons", "Pads", "Incontinence Pads"];
+
+export const feminineProductLabelsAndKeys: [string, string][] = feminineProductOptions.map(
+    (optionName) => [optionName, optionName]
+);
 
 const FeminineProductCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
     return (
         <GenericFormCard title="Feminine Products" required={false}>
             <CheckboxGroupInput
-                labelsAndKeys={FEMININE_PRODUCTS_LABELS_AND_KEYS}
+                labelsAndKeys={feminineProductLabelsAndKeys}
                 onChange={onChangeCheckbox(
                     fieldSetter,
                     fields.feminineProducts,

--- a/src/app/clients/form/formSections/OtherItemsCard.tsx
+++ b/src/app/clients/form/formSections/OtherItemsCard.tsx
@@ -4,20 +4,17 @@ import { checkboxGroupToArray, onChangeCheckbox } from "@/components/Form/formFu
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
 
-export const OTHER_ITEMS_LABELS_AND_KEYS: [string, string][] = [
-    ["Garlic", "Garlic"],
-    ["Ginger", "Ginger"],
-    ["Chillies", "Chillies"],
-    ["Spices", "Spices"],
-    ["Hot Water Bottles", "Hot Water Bottles"],
-    ["Blankets", "Blankets"],
-];
+export const otherRequirementOptions: string[] = ["Hot Water Bottle", "Blanket"];
+
+export const otherItemsLabelsAndKeys: [string, string][] = otherRequirementOptions.map(
+    (optionName) => [optionName, optionName]
+);
 
 const OtherItemsCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
     return (
         <GenericFormCard title="Other Items" required={false}>
             <CheckboxGroupInput
-                labelsAndKeys={OTHER_ITEMS_LABELS_AND_KEYS}
+                labelsAndKeys={otherItemsLabelsAndKeys}
                 onChange={onChangeCheckbox(fieldSetter, fields.otherItems, "otherItems")}
                 checkedKeys={checkboxGroupToArray(fields.otherItems)}
             />

--- a/src/app/clients/form/formSections/PetFoodCard.tsx
+++ b/src/app/clients/form/formSections/PetFoodCard.tsx
@@ -4,10 +4,12 @@ import { checkboxGroupToArray, onChangeCheckbox } from "@/components/Form/formFu
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
 
-export const PET_FOOD_LABELS_AND_KEYS: [string, string][] = [
-    ["Cat", "Cat"],
-    ["Dog", "Dog"],
-];
+export const petFoodOptions = ["Cat", "Dog"];
+
+export const petFoodLabelsAndKeys: [string, string][] = petFoodOptions.map((optionName) => [
+    optionName,
+    optionName,
+]);
 
 const PetFoodCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
     return (
@@ -17,7 +19,7 @@ const PetFoodCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
             text="Tick all that apply. Specify any other requests in the 'Extra Information' section."
         >
             <CheckboxGroupInput
-                labelsAndKeys={PET_FOOD_LABELS_AND_KEYS}
+                labelsAndKeys={petFoodLabelsAndKeys}
                 onChange={onChangeCheckbox(fieldSetter, fields.petFood, "petFood")}
                 checkedKeys={checkboxGroupToArray(fields.petFood)}
             />

--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -6,10 +6,6 @@ import { ClientFields } from "./ClientForm";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 import { ListType } from "@/common/databaseListTypes";
 import { EXTRA_INFORMATION_LABEL, NAPPY_SIZE_LABEL } from "@/app/clients/form/labels";
-import { dietaryRequirementOptions } from "./formSections/DietaryRequirementCard";
-import { otherRequirementOptions } from "./formSections/OtherItemsCard";
-import { feminineProductOptions } from "./formSections/FeminineProductCard";
-import { petFoodOptions } from "./formSections/PetFoodCard";
 
 export type FamilyDatabaseInsertRecord = Omit<InsertSchema["families"], "family_id">;
 export type ClientDatabaseInsertRecord = InsertSchema["clients"];
@@ -52,12 +48,12 @@ export const formatClientRecord = (
         default_list: fields.listType as ListType,
         dietary_requirements:
             fields.dietaryRequirements !== null
-                ? checkboxGroupToArray(fields.dietaryRequirements, dietaryRequirementOptions)
+                ? checkboxGroupToArray(fields.dietaryRequirements)
                 : null,
-        feminine_products: checkboxGroupToArray(fields.feminineProducts, feminineProductOptions),
+        feminine_products: checkboxGroupToArray(fields.feminineProducts),
         baby_food: fields.babyProducts,
-        pet_food: checkboxGroupToArray(fields.petFood, petFoodOptions),
-        other_items: checkboxGroupToArray(fields.otherItems, otherRequirementOptions),
+        pet_food: checkboxGroupToArray(fields.petFood),
+        other_items: checkboxGroupToArray(fields.otherItems),
         delivery_instructions: fields.deliveryInstructions,
         extra_information: extraInformationWithNappy,
         signposting_call_required: fields.signpostingCall,

--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -6,6 +6,10 @@ import { ClientFields } from "./ClientForm";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 import { ListType } from "@/common/databaseListTypes";
 import { EXTRA_INFORMATION_LABEL, NAPPY_SIZE_LABEL } from "@/app/clients/form/labels";
+import { dietaryRequirementOptions } from "./formSections/DietaryRequirementCard";
+import { otherRequirementOptions } from "./formSections/OtherItemsCard";
+import { feminineProductOptions } from "./formSections/FeminineProductCard";
+import { petFoodOptions } from "./formSections/PetFoodCard";
 
 export type FamilyDatabaseInsertRecord = Omit<InsertSchema["families"], "family_id">;
 export type ClientDatabaseInsertRecord = InsertSchema["clients"];
@@ -46,11 +50,14 @@ export const formatClientRecord = (
         address_county: fields.addressCounty,
         address_postcode: fields.addressPostcode,
         default_list: fields.listType as ListType,
-        dietary_requirements: checkboxGroupToArray(fields.dietaryRequirements),
-        feminine_products: checkboxGroupToArray(fields.feminineProducts),
+        dietary_requirements:
+            fields.dietaryRequirements !== null
+                ? checkboxGroupToArray(fields.dietaryRequirements, dietaryRequirementOptions)
+                : null,
+        feminine_products: checkboxGroupToArray(fields.feminineProducts, feminineProductOptions),
         baby_food: fields.babyProducts,
-        pet_food: checkboxGroupToArray(fields.petFood),
-        other_items: checkboxGroupToArray(fields.otherItems),
+        pet_food: checkboxGroupToArray(fields.petFood, petFoodOptions),
+        other_items: checkboxGroupToArray(fields.otherItems, otherRequirementOptions),
         delivery_instructions: fields.deliveryInstructions,
         extra_information: extraInformationWithNappy,
         signposting_call_required: fields.signpostingCall,

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -11,6 +11,11 @@ import {
 } from "@/common/getAgesOfFamily";
 import { ListType } from "@/common/databaseListTypes";
 import { getGenderStringFromGenderField } from "@/common/getGendersOfFamily";
+import { dietaryRequirementOptions } from "./form/formSections/DietaryRequirementCard";
+import { sortArrayByCanonicalOrder } from "@/components/Form/formFunctions";
+import { otherRequirementOptions } from "./form/formSections/OtherItemsCard";
+import { feminineProductOptions } from "./form/formSections/FeminineProductCard";
+import { petFoodOptions } from "./form/formSections/PetFoodCard";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);
@@ -104,11 +109,20 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
         household: formatHouseholdFromFamilyDetails(client.family),
         adults: formatBreakdownOfAdultsFromFamilyDetails(client.family),
         children: formatBreakdownOfChildrenFromFamilyDetails(client.family),
-        dietaryRequirements: client.dietary_requirements?.join(", ") ?? "",
-        feminineProducts: client.feminine_products?.join(", ") ?? "",
+        dietaryRequirements: formatRequirementsByCanonicalOrder(
+            client.dietary_requirements,
+            dietaryRequirementOptions
+        ),
+        feminineProducts: formatRequirementsByCanonicalOrder(
+            client.feminine_products,
+            feminineProductOptions
+        ),
         babyProducts: client.baby_food,
-        petFood: client.pet_food?.join(", ") ?? "",
-        otherRequirements: client.other_items?.join(", ") ?? "",
+        petFood: formatRequirementsByCanonicalOrder(client.pet_food, petFoodOptions),
+        otherRequirements: formatRequirementsByCanonicalOrder(
+            client.other_items,
+            otherRequirementOptions
+        ),
         extraInformation: client.extra_information ?? "",
         notes: client.notes,
         isActive: client.is_active,
@@ -216,6 +230,19 @@ export const formatBreakdownOfChildrenFromFamilyDetails = (
     }
 
     return childDetails.join(", ");
+};
+
+export const formatRequirementsByCanonicalOrder = (
+    requirementsArray: string[] | null,
+    canonicalOrder: string[]
+): string => {
+    if (requirementsArray === null) {
+        return "Don't Know";
+    } else if (requirementsArray.length === 0) {
+        return "None";
+    }
+
+    return sortArrayByCanonicalOrder(requirementsArray, canonicalOrder).join(", ");
 };
 
 type IsClientActiveErrorType = "failedClientIsActiveFetch";

--- a/src/app/global_styles.tsx
+++ b/src/app/global_styles.tsx
@@ -47,9 +47,9 @@ const materialTheme = (chosenTheme: DefaultTheme): Theme =>
                 default: chosenTheme.main.background[1],
                 paper: chosenTheme.main.background[0],
             },
-
             text: {
                 primary: chosenTheme.main.foreground[1],
+                disabled: chosenTheme.main.lighterForeground[1],
             },
         },
         typography: {

--- a/src/common/formatClientsData.ts
+++ b/src/common/formatClientsData.ts
@@ -1,5 +1,10 @@
 import { Schema } from "@/databaseUtils";
 import { displayList, displayPostcodeForHomelessClient } from "@/common/format";
+import { formatRequirementsByCanonicalOrder } from "@/app/clients/getExpandedClientDetails";
+import { dietaryRequirementOptions } from "@/app/clients/form/formSections/DietaryRequirementCard";
+import { otherRequirementOptions } from "@/app/clients/form/formSections/OtherItemsCard";
+import { feminineProductOptions } from "@/app/clients/form/formSections/FeminineProductCard";
+import { petFoodOptions } from "@/app/clients/form/formSections/PetFoodCard";
 interface NappySizeAndExtraInformation {
     nappySize: string;
     extraInformation: string;
@@ -61,7 +66,10 @@ export const prepareRequirementSummary = (clientData: Schema["clients"]): Requir
 
     switch (clientData.baby_food) {
         case true:
-            babyProduct = `Yes (${nappySize})`;
+            babyProduct = "Yes";
+            if (nappySize.length > 0) {
+                babyProduct += ` (${nappySize})`;
+            }
             break;
         case false:
             babyProduct = "No";
@@ -72,10 +80,19 @@ export const prepareRequirementSummary = (clientData: Schema["clients"]): Requir
     }
 
     return {
-        feminineProductsRequired: displayList(clientData.feminine_products ?? []),
+        feminineProductsRequired: formatRequirementsByCanonicalOrder(
+            clientData.feminine_products,
+            feminineProductOptions
+        ),
         babyProductsRequired: babyProduct,
-        petFoodRequired: displayList(clientData.pet_food ?? []),
-        dietaryRequirements: displayList(clientData.dietary_requirements ?? []),
-        otherItems: displayList(clientData.other_items ?? []),
+        petFoodRequired: formatRequirementsByCanonicalOrder(clientData.pet_food, petFoodOptions),
+        dietaryRequirements: formatRequirementsByCanonicalOrder(
+            clientData.dietary_requirements,
+            dietaryRequirementOptions
+        ),
+        otherItems: formatRequirementsByCanonicalOrder(
+            clientData.other_items,
+            otherRequirementOptions
+        ),
     };
 };

--- a/src/common/formatClientsData.ts
+++ b/src/common/formatClientsData.ts
@@ -1,5 +1,5 @@
 import { Schema } from "@/databaseUtils";
-import { displayList, displayPostcodeForHomelessClient } from "@/common/format";
+import { displayPostcodeForHomelessClient } from "@/common/format";
 import { formatRequirementsByCanonicalOrder } from "@/app/clients/getExpandedClientDetails";
 import { dietaryRequirementOptions } from "@/app/clients/form/formSections/DietaryRequirementCard";
 import { otherRequirementOptions } from "@/app/clients/form/formSections/OtherItemsCard";

--- a/src/components/DataInput/CheckboxGroupInput.tsx
+++ b/src/components/DataInput/CheckboxGroupInput.tsx
@@ -8,12 +8,13 @@ interface Props {
     defaultCheckedKeys?: string[];
     labelsAndKeys: [string, string][];
     groupLabel?: string;
+    disabled?: boolean;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const CheckboxGroupInput: React.FC<Props> = (props) => {
     return (
-        <FormControl>
+        <FormControl disabled={!!props.disabled}>
             {props.groupLabel && <FormLabel>{props.groupLabel}</FormLabel>}
             <FormGroup>
                 {props.labelsAndKeys.map(([label, key]) => {

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -256,8 +256,42 @@ export const getErrorText = (errorType: Errors, maxCharacters?: number): string 
     }
 };
 
-export const checkboxGroupToArray = (checkedBoxes: BooleanGroup): string[] => {
-    return Object.keys(checkedBoxes).filter((key) => checkedBoxes[key]);
+export const sortArrayByCanonicalOrder = (
+    listToSort: string[],
+    canonicalOrder: string[]
+): string[] => {
+    return listToSort.sort((firstKey, secondKey) => {
+        const firstIndex = canonicalOrder.indexOf(firstKey);
+        const secondIndex = canonicalOrder.indexOf(secondKey);
+
+        // Unrecognised strings to the end, in alphabetical order
+        if (firstIndex === -1) {
+            if (secondIndex === -1) {
+                if (firstKey < secondKey) {
+                    return -1;
+                } else if (firstKey > secondKey) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            } else {
+                return 1;
+            }
+        } else if (firstIndex !== -1 && secondIndex === -1) {
+            return -1;
+        }
+
+        return firstIndex - secondIndex;
+    });
+};
+
+export const checkboxGroupToArray = (
+    checkedBoxes: BooleanGroup,
+    canonicalOrder?: string[]
+): string[] => {
+    const selectedKeys = Object.keys(checkedBoxes).filter((key) => checkedBoxes[key]);
+
+    return canonicalOrder ? sortArrayByCanonicalOrder(selectedKeys, canonicalOrder) : selectedKeys;
 };
 
 export const checkErrorOnSubmit = <

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -285,13 +285,8 @@ export const sortArrayByCanonicalOrder = (
     });
 };
 
-export const checkboxGroupToArray = (
-    checkedBoxes: BooleanGroup,
-    canonicalOrder?: string[]
-): string[] => {
-    const selectedKeys = Object.keys(checkedBoxes).filter((key) => checkedBoxes[key]);
-
-    return canonicalOrder ? sortArrayByCanonicalOrder(selectedKeys, canonicalOrder) : selectedKeys;
+export const checkboxGroupToArray = (checkedBoxes: BooleanGroup): string[] => {
+    return Object.keys(checkedBoxes).filter((key) => checkedBoxes[key]);
 };
 
 export const checkErrorOnSubmit = <

--- a/src/components/Form/formStyling.tsx
+++ b/src/components/Form/formStyling.tsx
@@ -40,7 +40,6 @@ export const StyledCard = styled(Paper)<{ $compact?: boolean }>`
         width: 100%;
         margin: 0.15em 0;
     }
-}
 `;
 
 export const RequiredAsterisk = styled.span`
@@ -86,17 +85,22 @@ export const ErrorText = styled.p`
 `;
 
 export const FormText = styled.p`
-    padding-bottom: 1em;
+    margin-bottom: 1em;
 `;
 
 export const FormSubheading = styled.h2`
-    padding-bottom: 1em;
+    margin-bottom: 1em;
 `;
 
 export const FormErrorText = styled(FormText)`
     color: ${(props) => props.theme.error};
     margin-bottom: 3em;
     text-align: center;
+`;
+
+export const FormElementWithSpacing = styled.div`
+    margin-top: 1em;
+    margin-bottom: 1em;
 `;
 
 export const GappedDiv = styled.div`

--- a/supabase/migrations/20241103143732_change_insert_client_and_family_fn_for_null_dietary_requirements.sql
+++ b/supabase/migrations/20241103143732_change_insert_client_and_family_fn_for_null_dietary_requirements.sql
@@ -1,0 +1,113 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.insert_client_and_family(clientrecord jsonb, familymembers jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+AS $function$DECLARE
+    created_family_id UUID;
+    member JSONB;
+    inserted_client_id UUID;
+BEGIN 
+    INSERT INTO clients (
+        full_name,
+        phone_number,
+        address_1,
+        address_2,
+        address_town,
+        address_county,
+        address_postcode,
+        delivery_instructions,
+        dietary_requirements,
+        feminine_products,
+        baby_food,
+        pet_food,
+        other_items,
+        extra_information,
+        flagged_for_attention,
+        signposting_call_required,
+        notes,
+        default_list
+    )
+    VALUES (
+        clientRecord->>'full_name',
+        clientRecord->>'phone_number',
+        clientRecord->>'address_1',
+        clientRecord->>'address_2',
+        clientRecord->>'address_town',
+        clientRecord->>'address_county',
+        clientRecord->>'address_postcode',
+        clientRecord->>'delivery_instructions',
+        CASE
+            WHEN jsonb_typeof(clientRecord->'dietary_requirements') = 'array'
+                THEN array(select * from jsonb_array_elements_text(clientRecord->'dietary_requirements'))
+            ELSE NULL
+        END,
+        CASE
+            WHEN jsonb_typeof(clientRecord->'feminine_products') = 'array'
+                THEN array(select * from jsonb_array_elements_text(clientRecord->'feminine_products'))
+            ELSE NULL
+        END,
+        CASE
+            WHEN clientRecord->>'baby_food' = 'true' THEN TRUE
+            WHEN clientRecord->>'baby_food' = 'false' THEN FALSE
+            ELSE NULL
+        END,
+        CASE
+            WHEN jsonb_typeof(clientRecord->'pet_food') = 'array'
+                THEN array(select * from jsonb_array_elements_text(clientRecord->'pet_food'))
+            ELSE NULL
+        END,
+        CASE
+            WHEN jsonb_typeof(clientRecord->'other_items') = 'array'
+                THEN array(select * from jsonb_array_elements_text(clientRecord->'other_items'))
+            ELSE NULL
+        END,
+        clientRecord->>'extra_information',
+        CASE
+            WHEN clientRecord->>'flagged_for_attention' = 'true' THEN TRUE
+            WHEN clientRecord->>'flagged_for_attention' = 'false' THEN FALSE
+            ELSE NULL
+        END,
+        CASE
+            WHEN clientRecord->>'signposting_call_required' = 'true' THEN TRUE
+            WHEN clientRecord->>'signposting_call_required' = 'false' THEN FALSE
+            ELSE NULL
+        END,
+        clientRecord->>'notes',
+        CAST(clientRecord->>'default_list' as list_type)
+    )
+    RETURNING primary_key into inserted_client_id; 
+
+    raise log 'inserted client id %', inserted_client_id;
+
+     IF inserted_client_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+     
+    SELECT family_id INTO created_family_id
+        FROM clients
+        WHERE primary_key = inserted_client_id;
+
+    raise log 'created_family_id: %', created_family_id;
+
+    FOR member IN SELECT * FROM jsonb_array_elements(familyMembers)
+    LOOP
+        INSERT INTO families (
+            family_id,
+            birth_year,
+            birth_month,
+            recorded_as_child,
+            gender
+        )
+        VALUES (
+            created_family_id,
+            (member->>'birth_year')::numeric,
+            (member->>'birth_month')::numeric,
+            (member->>'recorded_as_child')::boolean,
+            (member->>'gender')::gender
+        );
+    END LOOP;
+
+    RETURN inserted_client_id;
+END;$function$
+;

--- a/supabase/migrations/20241103153953_change_update_client_and_family_fn_for_null_dietary_requirements.sql
+++ b/supabase/migrations/20241103153953_change_update_client_and_family_fn_for_null_dietary_requirements.sql
@@ -1,0 +1,101 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.update_client_and_family(clientrecord jsonb, clientid uuid, familymembers jsonb)
+ RETURNS update_client_result
+ LANGUAGE plpgsql
+AS $function$DECLARE
+    updated_family_id UUID;
+    member JSONB;
+    rows_updated INTEGER;
+    return_values update_client_result;
+BEGIN  
+    UPDATE clients 
+    SET 
+        full_name = clientRecord->>'full_name',
+        phone_number = clientRecord->>'phone_number',
+        address_1 = clientRecord->>'address_1',
+        address_2 = clientRecord->>'address_2',
+        address_town = clientRecord->>'address_town',
+        address_county = clientRecord->>'address_county',
+        address_postcode = clientRecord->>'address_postcode',
+        delivery_instructions = clientRecord->>'delivery_instructions',
+        dietary_requirements = 
+            CASE 
+                WHEN jsonb_typeof(clientRecord->'dietary_requirements') = 'array'
+                    THEN ARRAY(SELECT * FROM jsonb_array_elements_text(clientRecord->'dietary_requirements'))
+                ELSE NULL
+            END,
+        feminine_products = 
+            CASE
+                WHEN jsonb_typeof(clientRecord->'feminine_products') = 'array'
+                    THEN ARRAY(SELECT * FROM jsonb_array_elements_text(clientRecord->'feminine_products'))
+                ELSE NULL
+            END,
+        baby_food = 
+            CASE
+                WHEN clientRecord->>'baby_food' = 'true' THEN TRUE
+                WHEN clientRecord->>'baby_food' = 'false' THEN FALSE
+                ELSE NULL
+            END,
+        pet_food = 
+            CASE
+                WHEN jsonb_typeof(clientRecord->'pet_food') = 'array'
+                    THEN ARRAY(SELECT * FROM jsonb_array_elements_text(clientRecord->'pet_food'))
+                ELSE NULL
+            END,
+        other_items =
+            CASE
+                WHEN jsonb_typeof(clientRecord->'other_items') = 'array'
+                    THEN ARRAY(SELECT * FROM jsonb_array_elements_text(clientRecord->'other_items'))
+                ELSE NULL
+            END,
+        extra_information = clientRecord->>'extra_information',
+        flagged_for_attention = 
+            CASE
+                WHEN clientRecord->>'flagged_for_attention' = 'true' THEN TRUE
+                WHEN clientRecord->>'flagged_for_attention' = 'false' THEN FALSE
+                ELSE NULL
+            END,
+        signposting_call_required = 
+            CASE
+                WHEN clientRecord->>'signposting_call_required' = 'true' THEN TRUE
+                WHEN clientRecord->>'signposting_call_required' = 'false' THEN FALSE
+                ELSE NULL
+            END,
+        notes = clientRecord->>'notes',
+        default_list = CAST(clientRecord->>'default_list' as list_type)
+    WHERE 
+        primary_key = clientId 
+        AND last_updated = (clientRecord->>'last_updated')::timestamp with time zone;
+     
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+
+    SELECT family_id INTO updated_family_id
+    FROM clients
+    WHERE primary_key = clientId;
+
+    DELETE FROM families WHERE family_id = updated_family_id;
+
+    FOR member IN SELECT * FROM jsonb_array_elements(familyMembers)
+    LOOP
+        INSERT INTO families (
+            family_id,
+            birth_year,
+            birth_month,
+            recorded_as_child,
+            gender
+        )
+        VALUES (
+            updated_family_id,
+            (member->>'birth_year')::numeric,
+            (member->>'birth_month')::numeric,
+            (member->>'recorded_as_child')::boolean,
+            (member->>'gender')::gender
+        );
+    END LOOP;
+
+    return_values := ROW(clientId, rows_updated);
+
+    RETURN return_values;
+END;$function$
+;

--- a/supabase/migrations/20241103155908_convert_data_for_dietary_requirements_changes.sql
+++ b/supabase/migrations/20241103155908_convert_data_for_dietary_requirements_changes.sql
@@ -1,0 +1,151 @@
+-- This is a data conversion script for the following things related to client dietary & other requirements.
+-- Currently we only have test/seed data, but these changes need to be spread across the spectrum.
+
+
+-- in other_requirements, "Hot Water Bottles" and "Blankets" are now singular
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_replace(other_items, 'Hot Water Bottles', 'Hot Water Bottle')
+        ELSE other_items
+    END;
+
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_replace(other_items, 'Blankets', 'Blanket')
+        ELSE other_items
+    END;
+
+
+-- if dietary_requirements was not an empty array, then add "Fresh Fruit" and "Fresh Veg"
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL
+            AND array_length(dietary_requirements, 1) IS NOT NULL
+            AND array_length(dietary_requirements, 1) > 0
+            THEN dietary_requirements || ARRAY['Fresh Fruit', 'Fresh Veg']
+        ELSE dietary_requirements
+    END;
+
+
+-- moving from other_requirements to dietary_requirements: Garlic, Ginger, Chillies, Spices
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND other_items IS NOT NULL AND other_items @> ARRAY['Garlic']
+            THEN array_append(dietary_requirements, 'Garlic')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_remove(other_items, 'Garlic')
+        ELSE other_items
+    END;
+
+
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND other_items IS NOT NULL AND other_items @> ARRAY['Ginger']
+            THEN array_append(dietary_requirements, 'Ginger')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_remove(other_items, 'Ginger')
+        ELSE other_items
+    END;
+
+
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND other_items IS NOT NULL AND other_items @> ARRAY['Chillies']
+            THEN array_append(dietary_requirements, 'Chillies')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_remove(other_items, 'Chillies')
+        ELSE other_items
+    END;
+
+
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND other_items IS NOT NULL AND other_items @> ARRAY['Spices']
+            THEN array_append(dietary_requirements, 'Spices')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET other_items = CASE
+        WHEN other_items IS NOT NULL THEN array_remove(other_items, 'Spices')
+        ELSE other_items
+    END;
+
+
+-- invert 'No Rice': add 'Rice' iff 'No Rice' was not present; also remove 'No Rice'
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND NOT dietary_requirements @> ARRAY['No Rice']
+            THEN array_append(dietary_requirements, 'Rice')
+        WHEN dietary_requirements IS NOT NULL
+            THEN array_remove(dietary_requirements, 'No Rice')
+        ELSE dietary_requirements
+    END;
+
+
+-- invert 'No Pasta' and 'No Bread' for clients without 'Gluten Free'
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND NOT dietary_requirements && ARRAY['No Pasta', 'Gluten Free'] 
+            THEN array_append(dietary_requirements, 'Pasta')
+        WHEN dietary_requirements IS NOT NULL
+            THEN array_remove(dietary_requirements, 'No Pasta')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND NOT dietary_requirements && ARRAY['No Bread', 'Gluten Free'] 
+            THEN array_append(dietary_requirements, 'Bread')
+        WHEN dietary_requirements IS NOT NULL
+            THEN array_remove(dietary_requirements, 'No Bread')
+        ELSE dietary_requirements
+    END;
+
+
+-- if "No Pork" is absent then add "Meat & Pork"; also replace "No Pork" by "Meat (No Pork)"
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND NOT dietary_requirements @> ARRAY['No Pork']
+            THEN array_append(dietary_requirements, 'Meat & Pork')
+        WHEN dietary_requirements IS NOT NULL
+            THEN array_replace(dietary_requirements, 'No Pork', 'Meat (No Pork)')
+        ELSE dietary_requirements
+    END;
+
+
+-- remove "No Beef"
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL THEN array_remove(dietary_requirements, 'No Beef')
+        ELSE dietary_requirements
+    END;
+
+
+--  if previously "Vegan" or "Vegetarian" was there, add "Tea"
+--  if previously "Vegan", "Pescatarian" and "Halal" were absent, add "Coffee"
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND dietary_requirements && ARRAY['Vegan', 'Vegetarian']
+            THEN array_append(dietary_requirements, 'Tea')
+        ELSE dietary_requirements
+    END;
+
+UPDATE clients
+    SET dietary_requirements = CASE
+        WHEN dietary_requirements IS NOT NULL AND NOT dietary_requirements && ARRAY['Vegan', 'Pescatarian', 'Halal'] 
+            THEN array_append(dietary_requirements, 'Coffee')
+        ELSE dietary_requirements
+    END;

--- a/supabase/seed/clientsSeed.ts
+++ b/supabase/seed/clientsSeed.ts
@@ -1,4 +1,17 @@
 export const possibleDietaryRequirements = [
+    "Fresh Fruit",
+    "Fresh Veg",
+    "Garlic",
+    "Ginger",
+    "Chillies",
+    "Spices",
+    "Bread",
+    "Tea",
+    "Coffee",
+    "Pasta",
+    "Rice",
+    "Meat (No Pork)",
+    "Meat & Pork",
     "Gluten Free",
     "Dairy Free",
     "Vegetarian",
@@ -8,25 +21,13 @@ export const possibleDietaryRequirements = [
     "Diabetic",
     "Nut Allergy",
     "Seafood Allergy",
-    "No Bread",
-    "No Pasta",
-    "No Rice",
-    "No Pork",
-    "No Beef",
 ];
 
 export const possibleFeminineProducts = ["Tampons", "Pads", "Incontinence Pads"];
 
 export const possiblePets = ["Cat", "Dog"];
 
-export const possibleOtherItems = [
-    "Garlic",
-    "Ginger",
-    "Chillies",
-    "Spices",
-    "Hot Water Bottles",
-    "Blankets",
-];
+export const possibleOtherItems = ["Hot Water Bottle", "Blanket"];
 
 export const possibleParcelPostCodes = [
     "E1 6AA",


### PR DESCRIPTION
## What's changed
This ticket specified changes for the responses for "dietary requirements" and "other items" in client records. They're defined in the code (although that would change when we implement #519).
Notable other changes are the addition of a "Don't Know" response for dietary requirements (represented by NULL in the DB) and ordering the entries for all the similar questions (dietary, feminine, pet, other) based on a given canonical ordering.

Note that because snaplet doesn't work, I haven't regenerated the seed data or done the checks that involve regenerating the db.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [ ] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [ ] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [ ] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

