### PR TITLE
VFB-376: Fix the 'rows per page' control on the Parcels table

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -92,6 +92,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
 }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [parcelsDataPortion, setParcelsDataPortion] = useState<ParcelsTableRow[]>([]);
+    const [filteredParcelCount, setFilteredParcelCount] = useState<number>(0);
 
     const [parcelRowBreakPointConfig, setParcelRowBreakPointConfig] = useState<BreakPointConfig[]>(
         []
@@ -189,6 +190,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                 }
             } else {
                 setParcelsDataPortion(data.parcelTableRows);
+                setFilteredParcelCount(data.count);
                 if (sortState.sortEnabled && sortState.column.headerKey) {
                     setParcelRowBreakPointConfig(
                         searchForBreakPoints(sortState.column.headerKey, data.parcelTableRows)
@@ -231,10 +233,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             ),
         [parcelsDataPortion, today, yesterday]
     );
-
-    const filteredParcelCount = isPackingManagerView
-        ? packingManagerViewDataPortion.length
-        : parcelsDataPortion.length;
 
     const loadCountAndDataWithTimer = (): void => {
         if (fetchParcelsTimer.current) {
@@ -333,7 +331,9 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                 isLoading={isLoading}
                 paginationConfig={{
                     enablePagination: true,
-                    filteredCount: filteredParcelCount,
+                    filteredCount: isPackingManagerView
+                        ? packingManagerViewDataPortion.length
+                        : filteredParcelCount,
                     onPageChange: setCurrentPage,
                     onPerPageChange: setParcelCountPerPage,
                     defaultRowsPerPage: defaultNumberOfParcelsPerPage,


### PR DESCRIPTION
## What's changed
The Parcels rows per page & pagination was broken when the Packing Manager View was created in VFB-314.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
