### PR TITLE
#549: Remove navbar links to Batch Create and Calendar pages

### DIFF
--- a/cypress/e2e/accessibility.cy.ts
+++ b/cypress/e2e/accessibility.cy.ts
@@ -46,18 +46,6 @@ describe("Accessibility tests in light mode", () => {
         cy.checkAccessibility();
     });
 
-    it("Checks calendar page", () => {
-        cy.login();
-        cy.visit("/calendar");
-        cy.get("table").should("be.visible");
-
-        cy.checkAccessibility({
-            rules: {
-                "aria-allowed-attr": { enabled: false },
-            },
-        });
-    });
-
     it("Checks admin page", () => {
         cy.login();
         cy.visit("/admin");
@@ -124,19 +112,6 @@ describe("Accessibility tests in dark mode", () => {
         cy.get("label[aria-label='Theme Switch']").click();
 
         cy.checkAccessibility();
-    });
-
-    it("Checks calendar page", () => {
-        cy.login();
-        cy.visit("/calendar");
-        cy.get("label[aria-label='Theme Switch']").click();
-        cy.get("table").should("be.visible");
-
-        cy.checkAccessibility({
-            rules: {
-                "aria-allowed-attr": { enabled: false },
-            },
-        });
     });
 
     it("Checks admin page", () => {

--- a/cypress/e2e/auth.cy.ts
+++ b/cypress/e2e/auth.cy.ts
@@ -4,7 +4,7 @@ describe("Authentication tests", () => {
 
     const extendedTimeout = { timeout: 10000 };
 
-    const buttonReachablePaths = ["/", "/parcels", "/clients", "/lists", "/calendar", "/reports"];
+    const buttonReachablePaths = ["/", "/parcels", "/clients", "/lists", "/reports"];
     const allPaths = [...buttonReachablePaths, "/parcels/add"];
 
     it("Redirected to login page", () => {

--- a/cypress/e2e/rendering.cy.ts
+++ b/cypress/e2e/rendering.cy.ts
@@ -15,12 +15,6 @@ describe("Rendering tests", () => {
         cy.get("h1").should("contain.text", "Lists");
     });
 
-    it("Renders calendar page", () => {
-        cy.visit("/calendar");
-
-        cy.get("h1").should("contain.text", "Collection Time for Parcels");
-    });
-
     it("Renders parcels page", () => {
         cy.visit("/parcels");
 

--- a/src/app/roles.tsx
+++ b/src/app/roles.tsx
@@ -15,8 +15,6 @@ export const pathsNotRequiringLogin = [
 ] as const;
 
 const pathsShownToAllAuthenticatedUsers = [
-    "/batch-create",
-    "/calendar",
     "/clients",
     "/info",
     "/parcels",

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -135,9 +135,7 @@ const RoleDependent: React.FC<RoleProps> = ({ children, pathname }) => {
 const PAGES = [
     ["Parcels", "/parcels"],
     ["Clients", "/clients"],
-    ["Batch Creation", "/batch-create"],
     ["Lists", "/lists"],
-    ["Calendar", "/calendar"],
     ["Info", "/info"],
     ["Admin", "/admin"],
     ["Reports", "/reports"],


### PR DESCRIPTION
## What's changed
The Batch Create and Calendar pages are being hidden temporarily, by removing the links from the navbar

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
