### PR TITLE
VFB-362: Show env label in navbar if set

### DIFF
--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useContext, useState } from "react";
-import { AppBar, Button, SwipeableDrawer } from "@mui/material";
+import { Alert, AppBar, Button, SwipeableDrawer } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import LogoutIcon from "@mui/icons-material/Logout";
 import Link from "next/link";
@@ -146,6 +146,8 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
     const [islogOutModalOpen, setIslogOutModalOpen] = useState(false);
     const supabase = createClientComponentClient<DatabaseAutoType>();
 
+    const envLabel = process.env.NEXT_PUBLIC_ENV_VISIBLE_LABEL;
+
     const openDrawer = (): void => {
         setDrawer(true);
     };
@@ -208,6 +210,11 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                         ))}
                     </DesktopButtonContainer>
                     <SignOutButtonContainer>
+                        {envLabel && (
+                            <Alert icon={false} color="warning">
+                                {envLabel}
+                            </Alert>
+                        )}
                         <LightDarkSlider />
                         <LoginDependent>
                             <SignOutButton onClick={handleLogOutClick} />


### PR DESCRIPTION
## What's changed
An environment variable has been added to indicate which environment is being used (should be unset on Production).

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`

