### PR TITLE
#558: Stop "Day Overview Downloaded" status being added to parcels

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
@@ -5,7 +5,6 @@ import GeneralActionModal, { ActionModalProps, maxParcelsToShow } from "./Genera
 import DayOverviewPdfButton, {
     DayOverviewPdfError,
 } from "@/app/parcels/ActionBar/ActionButtons/DayOverviewPdfButton";
-import { getStatusErrorMessageWithLogId } from "../Statuses";
 import { sendAuditLog } from "@/server/auditLog";
 import SelectedParcelsOverview from "../SelectedParcelsOverview";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
@@ -62,13 +61,6 @@ const DayOverviewModal: React.FC<ActionModalProps> = (props) => {
     };
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await props.updateParcelStatuses(
-            props.selectedParcels,
-            "Day Overview Downloaded"
-        );
-        if (error) {
-            setErrorMessage(getStatusErrorMessageWithLogId(error));
-        }
         setSuccessMessage("Day Overview Created");
         setActionShown(false);
         void sendAuditLog({

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -28,6 +28,14 @@ export const displayList = (data: string[]): string => {
     return data.length === 0 ? "None" : data.join(", ");
 };
 
+export const formatTodayAsDate = (): string => {
+    return new Date().toLocaleString(localeCode, {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+    });
+};
+
 export const formatDateToDate = (dateString: string | null): string => {
     if (dateString === null) {
         return "";

--- a/src/pdf/DayOverview/DayOverviewPdf.tsx
+++ b/src/pdf/DayOverview/DayOverviewPdf.tsx
@@ -8,7 +8,7 @@ import {
     ParcelForDayOverview,
 } from "@/app/parcels/ActionBar/ActionButtons/DayOverviewPdfButton";
 import FontAwesomeIconPdfComponent from "../FontAwesomeIconPdfComponent";
-import { displayPostcodeForHomelessClient } from "@/common/format";
+import { displayPostcodeForHomelessClient, formatTodayAsDate } from "@/common/format";
 
 interface DayOverviewRowProps {
     parcel: ParcelForDayOverview;
@@ -152,11 +152,6 @@ const DayOverviewContent: React.FC<DayOverviewContentProps> = ({ parcels }) => {
     );
 };
 
-const dateStringForToday = (): string => {
-    const today = new Date();
-    return today.toLocaleDateString();
-};
-
 const DayOverviewPdf: React.FC<DayOverviewPdfProps> = ({ data }) => {
     return (
         <Document>
@@ -164,7 +159,7 @@ const DayOverviewPdf: React.FC<DayOverviewPdfProps> = ({ data }) => {
                 <DayOverviewMargin />
                 <View style={styles.titleRow}>
                     <Text style={styles.title}>Day Overview</Text>
-                    <Text style={styles.title}>{dateStringForToday()}</Text>
+                    <Text style={styles.title}>{formatTodayAsDate()}</Text>
                 </View>
                 <DayOverviewContent parcels={data.parcels} />
                 <DayOverviewMargin />

--- a/supabase/migrations/20250112134112_remove_day_overview_status.sql
+++ b/supabase/migrations/20250112134112_remove_day_overview_status.sql
@@ -1,0 +1,30 @@
+update public.audit_log
+  set event_id = null
+  from public.events
+  where audit_log.event_id = events.primary_key
+    and events.new_parcel_status = 'Day Overview Downloaded';
+
+delete from public.events where new_parcel_status = 'Day Overview Downloaded';
+
+delete from public.status_order where event_name = 'Day Overview Downloaded';
+
+
+update public.status_order set workflow_order = 0 where event_name = '';
+update public.status_order set workflow_order = 1 where event_name = 'Parcel Denied';
+update public.status_order set workflow_order = 2 where event_name = 'Pending More Info';
+update public.status_order set workflow_order = 3 where event_name = 'Called and Confirmed';
+update public.status_order set workflow_order = 4 where event_name = 'Called and No Response';
+update public.status_order set workflow_order = 5 where event_name = 'Shopping List Downloaded';
+update public.status_order set workflow_order = 6 where event_name = 'Ready to Dispatch';
+update public.status_order set workflow_order = 7 where event_name = 'Received by Centre';
+update public.status_order set workflow_order = 8 where event_name = 'Collection Failed';
+update public.status_order set workflow_order = 9 where event_name = 'Parcel Collected';
+update public.status_order set workflow_order = 10 where event_name = 'Shipping Labels Downloaded';
+update public.status_order set workflow_order = 11 where event_name = 'Packing Date Changed';
+update public.status_order set workflow_order = 12 where event_name = 'Packing Slot Changed';
+update public.status_order set workflow_order = 13 where event_name = 'Out for Delivery';
+update public.status_order set workflow_order = 14 where event_name = 'Delivered';
+update public.status_order set workflow_order = 15 where event_name = 'Delivery Failed';
+update public.status_order set workflow_order = 16 where event_name = 'Delivery Cancelled';
+update public.status_order set workflow_order = 17 where event_name = 'Fulfilled with Trussell Trust';
+update public.status_order set workflow_order = 18 where event_name = 'Parcel Deleted';

--- a/supabase/seed/eventsSeed.ts
+++ b/supabase/seed/eventsSeed.ts
@@ -9,7 +9,6 @@ export const eventNamesWithNoData = [
     "Called and Confirmed",
     "Called and No Response",
     "Shopping List Downloaded",
-    "Day Overview Downloaded",
     "Ready to Dispatch",
     "Received by Centre",
     "Collection Failed",


### PR DESCRIPTION
## What's changed
Generating a Day Overview PDF should not generate a parcel status event. Events with this status are also removed from the DB.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [X] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [X] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [X] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [ ] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [ ] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [X] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

