### PR TITLE
VFB-359: Driver Overview PDF handles parcels without shipping label events

### DIFF
--- a/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getParcelsData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getParcelsData.ts
@@ -1,7 +1,7 @@
 import { FetchParcelError, fetchParcel } from "@/common/fetch";
 import { ListType } from "@/common/databaseListTypes";
 import supabase from "@/supabaseClient";
-import { formatDateToDate } from "@/common/format";
+import { formatDateStringAsDate } from "@/common/format";
 
 export interface ParcelInfo {
     voucherNumber: string;
@@ -49,7 +49,7 @@ export const prepareParcelInfo = async (
     }
     const parcelInfo: ParcelInfo = {
         voucherNumber: data.voucher_number ?? "",
-        packingDate: formatDateToDate(data.packing_date) ?? "",
+        packingDate: formatDateStringAsDate(data.packing_date) ?? "",
         packingSlot: data.packing_slot?.name ?? "",
         collectionDate: formatDateToDateTime(data.collection_datetime),
         collectionSite: data.collection_centre?.name ?? "",

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -28,23 +28,23 @@ export const displayList = (data: string[]): string => {
     return data.length === 0 ? "None" : data.join(", ");
 };
 
-export const formatTodayAsDate = (): string => {
-    return new Date().toLocaleString(localeCode, {
+export const formatDate = (date: Date): string => {
+    return date.toLocaleString(localeCode, {
         year: "numeric",
         month: "numeric",
         day: "numeric",
     });
 };
 
-export const formatDateToDate = (dateString: string | null): string => {
+export const formatTodayAsDate = (): string => {
+    return formatDate(new Date());
+};
+
+export const formatDateStringAsDate = (dateString: string | null): string => {
     if (dateString === null) {
         return "";
     }
-    return new Date(dateString).toLocaleString(localeCode, {
-        year: "numeric",
-        month: "numeric",
-        day: "numeric",
-    });
+    return formatDate(new Date(dateString));
 };
 
 export const formatTimestampAsDatetime = (timestamp: number): string => {

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -2,7 +2,11 @@
 
 import React from "react";
 import { Text, Document, Page, View, StyleSheet, Image } from "@react-pdf/renderer";
-import { displayNameForNullDriverName, displayPostcodeForHomelessClient } from "@/common/format";
+import {
+    displayNameForNullDriverName,
+    displayPostcodeForHomelessClient,
+    formatDate,
+} from "@/common/format";
 import { faTruck, faShoePrints, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
 
@@ -19,7 +23,7 @@ export interface DriverOverviewRowData {
     packingDate: string | null;
     instructions?: string;
     clientIsActive: boolean;
-    numberOfLabels: number;
+    numberOfLabels: number | null;
     collectionCentre: string;
     isDelivery: boolean;
 }
@@ -221,7 +225,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.packingDate || "No recorded date"}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.numberOfLabelsColumnWidth]}>
-                    <Text>{rowData.numberOfLabels || "No labels downloaded"}</Text>
+                    <Text>{rowData.numberOfLabels || "Unknown"}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.instructionsColumnWidth]}>
                     <Text>{rowData.instructions}</Text>
@@ -277,14 +281,14 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
             <Page size="A4" orientation="landscape" style={[styles.container, styles.flexColumn]}>
                 <View style={styles.DriverOverviewBoard}>
                     <View style={{ flexDirection: "column", fontFamily: "Helvetica-Bold" }}>
-                        <Text style={[styles.h1text, { marginBottom: "20px" }]}>
+                        <Text style={[styles.h1text, { marginBottom: "10px" }]}>
                             Driver Overview
                         </Text>
-                        <Text style={[styles.h2text, { marginBottom: "20px" }]}>
+                        <Text style={[styles.h2text, { marginBottom: "10px" }]}>
                             Driver Name: {data.driverName ?? displayNameForNullDriverName}
                         </Text>
-                        <Text style={[styles.h3text, { marginBottom: "20px" }]}>
-                            Date: {data.date.toLocaleDateString()}{" "}
+                        <Text style={[styles.h3text, { marginBottom: "10px" }]}>
+                            Date: {formatDate(data.date)}{" "}
                         </Text>
                     </View>
                     {/* eslint-disable-next-line -- needed to remove the need for alt text on the logo */}


### PR DESCRIPTION
## What's changed
Also #563 
Previously there was an assumption that all parcels in the Driver Overview would already have Shipping Label events, which was erroneous. Also a couple of tweaks to the PDF layout.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`

