### PR TITLE
VFB-360: Check session validity on heartbeat and redirect to login

### DIFF
--- a/src/common/fetchUserRole.ts
+++ b/src/common/fetchUserRole.ts
@@ -6,11 +6,14 @@ type fetchRoleResult =
     | {
           role: UserRole;
           error: null;
+          userMissing: boolean;
       }
     | {
           role: null;
           error: PostgrestError;
+          userMissing: boolean;
       };
+
 export const fetchUserRole = async (userId: string): Promise<fetchRoleResult> => {
     const { data, error } = await supabase
         .from("profiles")
@@ -22,8 +25,9 @@ export const fetchUserRole = async (userId: string): Promise<fetchRoleResult> =>
         return {
             role: null,
             error: error,
+            userMissing: error.code === "PGRST116",
         };
     }
 
-    return { role: data.role, error: null };
+    return { role: data.role, error: null, userMissing: false };
 };

--- a/src/common/useSessionHeartbeat.ts
+++ b/src/common/useSessionHeartbeat.ts
@@ -1,0 +1,90 @@
+"use client";
+
+import supabase from "@/supabaseClient";
+import { useEffect } from "react";
+import { fetchUserRole } from "./fetchUserRole";
+import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+
+type sessionCheckResult = "Logged in" | "No session" | "User missing" | "Failed query";
+
+export const useSessionHeartbeat = (
+    router: AppRouterInstance,
+    pageRequiresSession: boolean,
+    setSessionErrorMessage: (message: string | null) => void
+): void => {
+    const heartbeatMs = 20000;
+    const delayBeforeRedirectMs = 10000;
+
+    useEffect(() => {
+        const checkSession = async (): Promise<sessionCheckResult> => {
+            const sessionUser = await supabase.auth
+                .getSession()
+                .then((response) => response.data.session?.user ?? null);
+
+            console.log("--> user: " + JSON.stringify(sessionUser));
+
+            if (sessionUser) {
+                const { role, error, userMissing } = await fetchUserRole(sessionUser.id);
+
+                // QQ
+                console.log("--> role & error: " + JSON.stringify([role, error]));
+                if (error) {
+                    console.dir(error);
+                }
+
+                if (role !== null && !error) {
+                    return "Logged in";
+                } else if (userMissing) {
+                    return "User missing";
+                } else {
+                    return "Failed query";
+                }
+            }
+
+            return "No session";
+        };
+
+        const redirectToLoginIfNoSession = async (): Promise<void> => {
+            console.log("--> in redirectToLoginIfNoSession");
+
+            if (pageRequiresSession) {
+                // One final check before redirect
+                const sessionCheckResult = await checkSession();
+                setSessionErrorMessage(null);
+                if (sessionCheckResult !== "Logged in") {
+                    console.log("--> router.push(/login)");
+
+                    router.push("/login");
+                }
+            }
+        };
+
+        const heartbeatSessionCheck = async (): Promise<void> => {
+            console.log("QQ useSessionHeartbeat: start");
+
+            const sessionCheckResult = await checkSession();
+
+            if (sessionCheckResult === "No session" || sessionCheckResult === "User missing") {
+                console.log("--> rerouting");
+
+                if (pageRequiresSession) {
+                    setSessionErrorMessage(
+                        "Your session has expired, so you are about to be logged out"
+                    );
+
+                    setTimeout(redirectToLoginIfNoSession, delayBeforeRedirectMs);
+                }
+            } else if (sessionCheckResult === "Failed query") {
+                // For this heartbeat, assume that the failure is due to network drop
+                setSessionErrorMessage("Network connection problem when checking session");
+            } else {
+                setSessionErrorMessage(null);
+            }
+        };
+
+        if (pageRequiresSession) {
+            const intervalId = setInterval(heartbeatSessionCheck, heartbeatMs);
+            return () => clearInterval(intervalId);
+        }
+    }, [pageRequiresSession, router, setSessionErrorMessage]);
+};

--- a/src/components/FixedToast.tsx
+++ b/src/components/FixedToast.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components";
+import {
+    Alert,
+    AlertColor,
+    AlertPropsColorOverrides,
+    AlertPropsVariantOverrides,
+} from "@mui/material";
+import { OverridableStringUnion } from "@mui/types";
+
+interface Props {
+    message?: string;
+    severity?: OverridableStringUnion<AlertColor, AlertPropsColorOverrides>;
+    variant?: OverridableStringUnion<
+        "standard" | "filled" | "outlined",
+        AlertPropsVariantOverrides
+    >;
+}
+
+const FixedToastContainer = styled.div`
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    z-index: 100;
+`;
+
+const FixedToast: React.FC<Props> = ({ message, severity, variant }) => {
+    return (
+        <FixedToastContainer>
+            <Alert severity={severity} variant={variant}>
+                {message}
+            </Alert>
+        </FixedToastContainer>
+    );
+};
+
+export default FixedToast;


### PR DESCRIPTION
## What's changed
When the user's session expires or a user is deleted, then this heartbeat (checking user's role every 20 seconds) will redirect to login after a warning. It distinguishes between the user check failing because of user/session deletion and other failed requests (assumed to indicate dropped network).
This version has some `console.log` messages so I can test on an old Mac.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`

