### PR TITLE
VFB-360: Session heartbeat gets timing values from env vars

### DIFF
--- a/src/common/useSessionHeartbeat.ts
+++ b/src/common/useSessionHeartbeat.ts
@@ -13,8 +13,10 @@ export const useSessionHeartbeat = (
     isUserLogOutInProgress: boolean,
     setSessionErrorMessage: (message: string | null) => void
 ): void => {
-    const heartbeatMs = 20000;
-    const delayBeforeRedirectMs = 10000;
+    const heartbeatMs = Number.parseInt(process.env.NEXT_PUBLIC_HEARTBEAT_MS ?? "20000");
+    const delayBeforeRedirectMs = Number.parseInt(
+        process.env.NEXT_PUBLIC_REDIRECT_DELAY_MS ?? "10000"
+    );
 
     useEffect(() => {
         const checkSession = async (): Promise<sessionCheckResult> => {
@@ -76,5 +78,12 @@ export const useSessionHeartbeat = (
             const intervalId = setInterval(heartbeatSessionCheck, heartbeatMs);
             return () => clearInterval(intervalId);
         }
-    }, [isUserLogOutInProgress, pageRequiresSession, router, setSessionErrorMessage]);
+    }, [
+        delayBeforeRedirectMs,
+        heartbeatMs,
+        isUserLogOutInProgress,
+        pageRequiresSession,
+        router,
+        setSessionErrorMessage,
+    ]);
 };


### PR DESCRIPTION
## What's changed
The heartbeat time values are now accessed from environment variables, but have defaults in the code (for tests etc.)


## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
