### PR TITLE
#380: Add Resend Invitation option to Admin User modal

### DIFF
--- a/src/app/admin/createUser/CreateUserForm.tsx
+++ b/src/app/admin/createUser/CreateUserForm.tsx
@@ -18,7 +18,7 @@ import Alert from "@mui/material/Alert/Alert";
 import { User } from "@supabase/gotrue-js";
 import { logInfoReturnLogId } from "@/logger/logger";
 import UserDetailsCard from "@/app/admin/createUser/UserDetailsCard";
-import { InviteUserError, adminInviteUser } from "@/server/adminInviteUser";
+import { InviteUserError, adminInviteAndCreateUser } from "@/server/adminInviteUser";
 import { UserRole } from "@/databaseUtils";
 
 export interface InviteUserFields extends Record<string, UserRole | string> {
@@ -91,7 +91,7 @@ const CreateUserForm: React.FC = () => {
 
         const redirectUrl = `${window.location.origin}/set-password`;
 
-        const { data, error } = await adminInviteUser(fields, redirectUrl);
+        const { data, error } = await adminInviteAndCreateUser(fields, redirectUrl);
 
         if (error) {
             setServerError(error);

--- a/src/app/admin/manageUser/EditUserForm.tsx
+++ b/src/app/admin/manageUser/EditUserForm.tsx
@@ -1,9 +1,9 @@
 import { UserRole } from "@/databaseUtils";
 import React, { useState } from "react";
-import { EditHeader, EditOption } from "@/app/admin/manageUser/ManageUserModal";
+import { EditOption, EditSubheading } from "@/app/admin/manageUser/ManageUserModal";
 import UserRoleSelect from "@/app/admin/common/UserRoleSelect";
 import { getDropdownListHandler } from "@/components/DataInput/inputHandlerFactories";
-import { DisplayedUserRole, UserRow } from "@/app/admin/usersTable/types";
+import { UserRow } from "@/app/admin/usersTable/types";
 import Button from "@mui/material/Button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import OptionButtonsDiv from "@/app/admin/common/OptionButtonsDiv";
@@ -31,10 +31,6 @@ interface Props {
     onConfirm: (alertOptions: AlertOptions) => void;
 }
 
-function isValidUserRole(userRole: DisplayedUserRole): userRole is UserRole {
-    return userRole !== "UNKNOWN";
-}
-
 const initialFormErrors: InviteUserErrors = {
     email: Errors.none,
     role: Errors.none,
@@ -46,9 +42,7 @@ const initialFormErrors: InviteUserErrors = {
 type InviteUserErrors = Required<FormErrors<InviteUserFields>>;
 
 const EditUserForm: React.FC<Props> = (props) => {
-    const initialRole: UserRole = isValidUserRole(props.userToEdit.userRole)
-        ? props.userToEdit.userRole
-        : "volunteer";
+    const initialRole: UserRole = props.userToEdit.userRole ?? "volunteer";
 
     const initialFirstName: string = props.userToEdit.firstName ?? "";
 
@@ -113,7 +107,7 @@ const EditUserForm: React.FC<Props> = (props) => {
     return (
         <>
             <EditOption>
-                <EditHeader>First Name</EditHeader>
+                <EditSubheading>First Name</EditSubheading>
                 <FreeFormTextInput
                     id="edit-user-first-name"
                     label="First Name"
@@ -127,7 +121,7 @@ const EditUserForm: React.FC<Props> = (props) => {
                 />
             </EditOption>
             <EditOption>
-                <EditHeader>Last Name</EditHeader>
+                <EditSubheading>Last Name</EditSubheading>
                 <FreeFormTextInput
                     id="edit-user-last-name"
                     label="Last Name"
@@ -141,7 +135,7 @@ const EditUserForm: React.FC<Props> = (props) => {
                 />
             </EditOption>
             <EditOption>
-                <EditHeader>Phone Number</EditHeader>
+                <EditSubheading>Phone Number</EditSubheading>
                 <FreeFormTextInput
                     id="edit-user-phone-number"
                     label="Phone Number"
@@ -157,7 +151,7 @@ const EditUserForm: React.FC<Props> = (props) => {
                 />
             </EditOption>
             <EditOption>
-                <EditHeader>Role</EditHeader>
+                <EditSubheading>Role</EditSubheading>
                 <UserRoleSelect
                     value={initialRole}
                     onChange={getDropdownListHandler<UserRole>(
@@ -177,7 +171,7 @@ const EditUserForm: React.FC<Props> = (props) => {
                 >
                     Confirm Edit
                 </Button>
-                <Button color="secondary" onClick={props.onCancel}>
+                <Button variant="outlined" color="secondary" onClick={props.onCancel}>
                     Cancel
                 </Button>
             </OptionButtonsDiv>

--- a/src/app/admin/manageUser/ManageUserModal.tsx
+++ b/src/app/admin/manageUser/ManageUserModal.tsx
@@ -6,6 +6,7 @@ import ResetPasswordForm from "@/app/admin/manageUser/ResetPasswordForm";
 import EditUserForm from "@/app/admin/manageUser/EditUserForm";
 import ManageUserOptions from "@/app/admin/manageUser/ManageUserOptions";
 import { AlertOptions, SetAlertOptions } from "@/app/admin/common/SuccessFailureAlert";
+import ResendInvitationForm from "./ResendInvitationForm";
 
 const ManageModalContent = styled.div`
     padding: 0 0.5rem;
@@ -19,7 +20,11 @@ export const EditHeader = styled.h2`
     margin-bottom: 0.5rem;
 `;
 
-export type ManageMode = "editDetails" | "resetPassword" | "options";
+export const EditSubheading = styled.h3`
+    margin-bottom: 0.5rem;
+`;
+
+export type ManageMode = "editDetails" | "resetPassword" | "resendInvitation" | "options";
 
 interface Props {
     userToEdit: UserRow | null;
@@ -66,9 +71,25 @@ const ManageUserModal: React.FC<Props> = (props) => {
                 />
             ),
         },
+        resendInvitation: {
+            header: "Resend Invitation",
+            content: (
+                <ResendInvitationForm
+                    userToEdit={props.userToEdit}
+                    onConfirm={onEditConfirm}
+                    onCancel={onCancel}
+                />
+            ),
+        },
         options: {
             header: "Manage User",
-            content: <ManageUserOptions setManageMode={setManageMode} onCancel={onCancel} />,
+            content: (
+                <ManageUserOptions
+                    userHasSignedIn={props.userToEdit.lastSignInAt !== null}
+                    setManageMode={setManageMode}
+                    onCancel={onCancel}
+                />
+            ),
         },
     };
 

--- a/src/app/admin/manageUser/ManageUserModal.tsx
+++ b/src/app/admin/manageUser/ManageUserModal.tsx
@@ -6,7 +6,7 @@ import ResetPasswordForm from "@/app/admin/manageUser/ResetPasswordForm";
 import EditUserForm from "@/app/admin/manageUser/EditUserForm";
 import ManageUserOptions from "@/app/admin/manageUser/ManageUserOptions";
 import { AlertOptions, SetAlertOptions } from "@/app/admin/common/SuccessFailureAlert";
-import ResendInvitationForm from "./ResendInvitationForm";
+import ResendInvitationForm from "@/app/admin/manageUser/ResendInvitationForm";
 
 const ManageModalContent = styled.div`
     padding: 0 0.5rem;

--- a/src/app/admin/manageUser/ManageUserOptions.tsx
+++ b/src/app/admin/manageUser/ManageUserOptions.tsx
@@ -2,8 +2,9 @@ import Button from "@mui/material/Button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUserPen } from "@fortawesome/free-solid-svg-icons/faUserPen";
 import { faKey } from "@fortawesome/free-solid-svg-icons/faKey";
+import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 import React from "react";
-import { EditHeader, ManageMode } from "@/app/admin/manageUser/ManageUserModal";
+import { EditSubheading, ManageMode } from "@/app/admin/manageUser/ManageUserModal";
 import styled from "styled-components";
 
 const OptionsSection = styled.div`
@@ -13,14 +14,15 @@ const OptionsSection = styled.div`
 `;
 
 interface Props {
+    userHasSignedIn: boolean;
     setManageMode: (mode: ManageMode) => void;
     onCancel: () => void;
 }
 
-const ManageUserOptions: React.FC<Props> = ({ setManageMode, onCancel }) => {
+const ManageUserOptions: React.FC<Props> = ({ userHasSignedIn, setManageMode, onCancel }) => {
     return (
         <>
-            <EditHeader>Options</EditHeader>
+            <EditSubheading>Options</EditSubheading>
             <OptionsSection>
                 <Button
                     variant="outlined"
@@ -29,13 +31,23 @@ const ManageUserOptions: React.FC<Props> = ({ setManageMode, onCancel }) => {
                 >
                     Edit Details
                 </Button>
-                <Button
-                    variant="outlined"
-                    startIcon={<FontAwesomeIcon icon={faKey} />}
-                    onClick={() => setManageMode("resetPassword")}
-                >
-                    Reset Password
-                </Button>
+                {userHasSignedIn ? (
+                    <Button
+                        variant="outlined"
+                        startIcon={<FontAwesomeIcon icon={faKey} />}
+                        onClick={() => setManageMode("resetPassword")}
+                    >
+                        Reset Password
+                    </Button>
+                ) : (
+                    <Button
+                        variant="outlined"
+                        startIcon={<FontAwesomeIcon icon={faEnvelope} />}
+                        onClick={() => setManageMode("resendInvitation")}
+                    >
+                        Resend Invitation
+                    </Button>
+                )}
                 <Button variant="outlined" color="secondary" onClick={onCancel}>
                     Cancel
                 </Button>

--- a/src/app/admin/manageUser/ResendInvitationForm.tsx
+++ b/src/app/admin/manageUser/ResendInvitationForm.tsx
@@ -4,12 +4,12 @@ import React, { useCallback, useState } from "react";
 import { EditOption, EditSubheading } from "@/app/admin/manageUser/ManageUserModal";
 import Button from "@mui/material/Button";
 import OptionButtonsDiv from "@/app/admin/common/OptionButtonsDiv";
-import { UserRow } from "../usersTable/types";
+import { UserRow } from "@/app/admin/usersTable/types";
 import { AlertOptions } from "@/app/admin/common/SuccessFailureAlert";
 import { logErrorReturnLogId, logInfoReturnLogId } from "@/logger/logger";
 import styled, { DefaultTheme } from "styled-components";
 import { adminInviteUser } from "@/server/adminInviteUser";
-import { InviteUserFields } from "../createUser/CreateUserForm";
+import { InviteUserFields } from "@/app/admin/createUser/CreateUserForm";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
 
@@ -19,7 +19,7 @@ interface Props {
     onConfirm: (alertOptions: AlertOptions) => void;
 }
 
-interface UpdatePasswordResponse {
+interface ResendInvitationResponse {
     errorMessage: string | null;
 }
 
@@ -27,7 +27,7 @@ const ErrorMessage = styled.span<{ theme: DefaultTheme }>`
     color: ${(props) => props.theme.error};
 `;
 
-const sendInvitation = async (userToInvite: UserRow): Promise<UpdatePasswordResponse> => {
+const sendInvitation = async (userToInvite: UserRow): Promise<ResendInvitationResponse> => {
     const invitableUser: InviteUserFields = {
         email: userToInvite.email,
         role: userToInvite.userRole,

--- a/src/app/admin/usersTable/getUsersData.ts
+++ b/src/app/admin/usersTable/getUsersData.ts
@@ -59,7 +59,7 @@ export const getUsersDataAndCount = async (
             profileId: user.primary_key ?? "",
             firstName: user.first_name ?? "",
             lastName: user.last_name ?? "",
-            userRole: user.role ?? "UNKNOWN",
+            userRole: user.role ?? null,
             email: user.email ?? "",
             telephoneNumber: user.telephone_number ?? "-",
             createdAt: user.created_at ? Date.parse(user.created_at) : null,

--- a/src/app/admin/usersTable/types.ts
+++ b/src/app/admin/usersTable/types.ts
@@ -39,13 +39,12 @@ export type GetUserCountReturnType =
           error: { type: GetUserDataAndCountErrorType; logId: string };
       };
 
-export type DisplayedUserRole = UserRole | "UNKNOWN";
 export interface UserRow {
     userId: string;
     profileId: string;
     firstName: string;
     lastName: string;
-    userRole: DisplayedUserRole;
+    userRole: UserRole;
     email: string;
     telephoneNumber: string;
     createdAt: number | null;


### PR DESCRIPTION
## What's changed
For users that haven't yet signed in, admins can now send them a new invitation. This is in place of the Reset Password option that admins see for users who have signed in.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

