### PR TITLE
VFB-344: Remove environment restriction on staging workflow so can run on cron

### DIFF
--- a/.github/workflows/dump-staging-database.yml
+++ b/.github/workflows/dump-staging-database.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   dump-staging-database:
     name: Dump staging database
-    environment: staging
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What's changed
The cron workflow to dump the db needs to run as dev environment so it's not forced to wait for approval
