### PR TITLE
#570: Driver Overview collections section now has client address in table but grouped by centre

### DIFF
--- a/src/app/parcels/ActionBar/ActionButtons/DriverOverview/DriverOverviewPdfButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/DriverOverview/DriverOverviewPdfButton.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+import supabase from "@/supabaseClient";
+import PdfButton from "@/components/FileGenerationButtons/PdfButton";
+import DriverOverviewPdf, { DriverOverviewPdfData } from "@/pdf/DriverOverview/DriverOverviewPdf";
+import getDriverPdfData, {
+    DriverOverviewError,
+    DriverOverviewErrorType,
+} from "@/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData";
+import { logErrorReturnLogId } from "@/logger/logger";
+import { Dayjs } from "dayjs";
+import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
+import { FileGenerationDataFetchResponse } from "@/components/FileGenerationButtons/common";
+
+interface Props {
+    parcels: ParcelsTableRow[];
+    driverName: string | null;
+    date: Dayjs;
+    onPdfCreationCompleted: () => void;
+    onPdfCreationFailed: (error: DriverOverviewError) => void;
+    disabled: boolean;
+}
+
+const DriverOverviewPdfButton = ({
+    parcels,
+    driverName,
+    date,
+    onPdfCreationCompleted,
+    onPdfCreationFailed,
+    disabled,
+}: Props): React.ReactElement => {
+    const fetchDataAndFileName = async (): Promise<
+        FileGenerationDataFetchResponse<DriverOverviewPdfData, DriverOverviewErrorType>
+    > => {
+        const parcelIds = parcels.map((parcel) => {
+            return parcel.parcelId;
+        });
+        const { data: driverPdfData, error: driverPdfError } = await getDriverPdfData(parcelIds);
+        if (driverPdfError) {
+            return { data: null, error: driverPdfError };
+        }
+
+        const { data: driverMessageData, error: driverMessageError } = await supabase
+            .from("website_data")
+            .select("name, value")
+            .eq("name", "driver_overview_message")
+            .single();
+        if (driverMessageError) {
+            const logId = await logErrorReturnLogId("Error with fetch: Driver overview message", {
+                error: driverMessageError,
+            });
+            return { data: null, error: { type: "driverMessageFetchFailed", logId: logId } };
+        }
+
+        return {
+            data: {
+                fileData: {
+                    driverName: driverName,
+                    date: date.toDate(),
+                    tableData: driverPdfData,
+                    message: driverMessageData.value,
+                },
+                fileName: "DriverOverview.pdf",
+            },
+            error: null,
+        };
+    };
+    return (
+        <PdfButton
+            fetchDataAndFileName={fetchDataAndFileName}
+            pdfComponent={DriverOverviewPdf}
+            onFileCreationCompleted={onPdfCreationCompleted}
+            onFileCreationFailed={onPdfCreationFailed}
+            disabled={disabled}
+            formSubmitButton={true}
+        />
+    );
+};
+
+export default DriverOverviewPdfButton;

--- a/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
@@ -1,26 +1,35 @@
-"use client";
-
-import React from "react";
-import supabase from "@/supabaseClient";
 import { Schema } from "@/databaseUtils";
-import PdfButton from "@/components/FileGenerationButtons/PdfButton";
-import DriverOverviewPdf, {
-    DriverOverviewTablesData,
-    DriverOverviewRowData,
-    DriverOverviewCollectionCentreData,
-} from "@/pdf/DriverOverview/DriverOverviewPdf";
+import supabase from "@/supabaseClient";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { displayNameForDeletedClient, formatDateStringAsDate } from "@/common/format";
-import { Dayjs } from "dayjs";
-import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
-import { FileGenerationDataFetchResponse } from "@/components/FileGenerationButtons/common";
 
-interface DriverOverviewData {
-    driverName: string | null;
-    date: Date;
-    tableData: DriverOverviewTablesData;
-    message: string;
+export interface DriverOverviewRowData {
+    name: string;
+    address: {
+        line1: string;
+        line2: string | null;
+        town: string | null;
+        county: string | null;
+        postcode: string | null;
+    };
+    contact?: string;
+    packingDate: string | null;
+    instructions?: string;
+    clientIsActive: boolean;
+    numberOfLabels: number | null;
+    collectionCentre: string;
+    isDelivery: boolean;
 }
+
+export type DriverOverviewTablesData = {
+    collections: DriverOverviewCollectionCentreData[];
+    deliveries: DriverOverviewRowData[];
+};
+
+export type DriverOverviewCollectionCentreData = {
+    collectionCentreName: string;
+    rowData: DriverOverviewRowData[];
+};
 
 type ParcelForDelivery = Schema["parcels"] & {
     client: Schema["clients"];
@@ -39,6 +48,21 @@ type ParcelsForDeliveryResponse =
       };
 
 type ParcelsForDeliveryErrorType = "parcelFetchFailed" | "noMatchingClient" | "noCollectionCentre";
+
+type DriverPdfResponse =
+    | {
+          data: DriverOverviewTablesData;
+          error: null;
+      }
+    | {
+          data: null;
+          error: { type: DriverPdfErrorType; logId: string };
+      };
+
+type DriverPdfErrorType = ParcelsForDeliveryErrorType;
+
+export type DriverOverviewErrorType = DriverPdfErrorType | "driverMessageFetchFailed";
+export type DriverOverviewError = { type: DriverOverviewErrorType; logId: string };
 
 const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDeliveryResponse> => {
     const { data, error } = await supabase
@@ -88,18 +112,6 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
 
     return { data: dataWithNonNullClients, error: null };
 };
-
-type DriverPdfResponse =
-    | {
-          data: DriverOverviewTablesData;
-          error: null;
-      }
-    | {
-          data: null;
-          error: { type: DriverPdfErrorType; logId: string };
-      };
-
-type DriverPdfErrorType = ParcelsForDeliveryErrorType;
 
 const transformRowToDriverOverviewTableData = (
     parcel: ParcelForDelivery
@@ -162,70 +174,4 @@ const getDriverPdfData = async (parcelIds: string[]): Promise<DriverPdfResponse>
     return { data: tableData, error: null };
 };
 
-interface Props {
-    parcels: ParcelsTableRow[];
-    driverName: string | null;
-    date: Dayjs;
-    onPdfCreationCompleted: () => void;
-    onPdfCreationFailed: (error: DriverOverviewError) => void;
-    disabled: boolean;
-}
-
-export type DriverOverviewErrorType = DriverPdfErrorType | "driverMessageFetchFailed";
-export type DriverOverviewError = { type: DriverOverviewErrorType; logId: string };
-
-const DriverOverviewPdfButton = ({
-    parcels,
-    driverName,
-    date,
-    onPdfCreationCompleted,
-    onPdfCreationFailed,
-    disabled,
-}: Props): React.ReactElement => {
-    const fetchDataAndFileName = async (): Promise<
-        FileGenerationDataFetchResponse<DriverOverviewData, DriverOverviewErrorType>
-    > => {
-        const parcelIds = parcels.map((parcel) => {
-            return parcel.parcelId;
-        });
-        const { data: driverPdfData, error: driverPdfError } = await getDriverPdfData(parcelIds);
-        if (driverPdfError) {
-            return { data: null, error: driverPdfError };
-        }
-        const { data: driverMessageData, error: driverMessageError } = await supabase
-            .from("website_data")
-            .select("name, value")
-            .eq("name", "driver_overview_message")
-            .single();
-        if (driverMessageError) {
-            const logId = await logErrorReturnLogId("Error with fetch: Driver overview message", {
-                error: driverMessageError,
-            });
-            return { data: null, error: { type: "driverMessageFetchFailed", logId: logId } };
-        }
-        return {
-            data: {
-                fileData: {
-                    driverName: driverName,
-                    date: date.toDate(),
-                    tableData: driverPdfData,
-                    message: driverMessageData.value,
-                },
-                fileName: "DriverOverview.pdf",
-            },
-            error: null,
-        };
-    };
-    return (
-        <PdfButton
-            fetchDataAndFileName={fetchDataAndFileName}
-            pdfComponent={DriverOverviewPdf}
-            onFileCreationCompleted={onPdfCreationCompleted}
-            onFileCreationFailed={onPdfCreationFailed}
-            disabled={disabled}
-            formSubmitButton={true}
-        />
-    );
-};
-
-export default DriverOverviewPdfButton;
+export default getDriverPdfData;

--- a/src/app/parcels/ActionBar/ActionButtons/DriverOverviewPdfButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/DriverOverviewPdfButton.tsx
@@ -7,6 +7,7 @@ import PdfButton from "@/components/FileGenerationButtons/PdfButton";
 import DriverOverviewPdf, {
     DriverOverviewTablesData,
     DriverOverviewRowData,
+    DriverOverviewCollectionCentreData,
 } from "@/pdf/DriverOverview/DriverOverviewPdf";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { displayNameForDeletedClient, formatDateStringAsDate } from "@/common/format";
@@ -125,12 +126,29 @@ const transformRowToDriverOverviewTableData = (
 };
 
 const transformParcelDataToTableData = (parcels: ParcelForDelivery[]): DriverOverviewTablesData => {
-    const transformedParcels = parcels.map((parcel) =>
-        transformRowToDriverOverviewTableData(parcel)
+    const transformedParcels = parcels
+        .map((parcel) => transformRowToDriverOverviewTableData(parcel))
+        .filter((parcel) => parcel.clientIsActive);
+
+    const collectionCentreNames = Array.from(
+        new Set(
+            transformedParcels
+                .filter((parcel) => !parcel.isDelivery)
+                .map((parcel) => parcel.collectionCentre)
+        )
+    ).sort();
+
+    const collectionCentreData: DriverOverviewCollectionCentreData[] = collectionCentreNames.map(
+        (ccName) => {
+            return {
+                collectionCentreName: ccName,
+                rowData: transformedParcels.filter((parcel) => parcel.collectionCentre === ccName),
+            };
+        }
     );
 
     return {
-        collections: transformedParcels.filter((parcel) => !parcel.isDelivery),
+        collections: collectionCentreData,
         deliveries: transformedParcels.filter((parcel) => parcel.isDelivery),
     };
 };

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -11,9 +11,8 @@ import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
 import dayjs, { Dayjs } from "dayjs";
 import { DatePicker } from "@mui/x-date-pickers";
 import { getStatusErrorMessageWithLogId } from "../Statuses";
-import DriverOverviewPdfButton, {
-    DriverOverviewError,
-} from "@/app/parcels/ActionBar/ActionButtons/DriverOverviewPdfButton";
+import DriverOverviewPdfButton from "@/app/parcels/ActionBar/ActionButtons/DriverOverview/DriverOverviewPdfButton";
+import { DriverOverviewError } from "../ActionButtons/DriverOverview/getDriverOverviewData";
 import { sendAuditLog } from "@/server/auditLog";
 import { displayNameForNullDriverName } from "@/common/format";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -9,26 +9,12 @@ import {
 } from "@/common/format";
 import { faTruck, faShoePrints, IconDefinition } from "@fortawesome/free-solid-svg-icons";
 import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
+import {
+    DriverOverviewRowData,
+    DriverOverviewTablesData,
+} from "@/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData";
 
-export interface DriverOverviewRowData {
-    name: string;
-    address: {
-        line1: string;
-        line2: string | null;
-        town: string | null;
-        county: string | null;
-        postcode: string | null;
-    };
-    contact?: string;
-    packingDate: string | null;
-    instructions?: string;
-    clientIsActive: boolean;
-    numberOfLabels: number | null;
-    collectionCentre: string;
-    isDelivery: boolean;
-}
-
-export interface DriverOverviewCardDataProps {
+export interface DriverOverviewPdfData {
     driverName: string | null;
     date: Date;
     tableData: DriverOverviewTablesData;
@@ -36,18 +22,8 @@ export interface DriverOverviewCardDataProps {
 }
 
 interface DriverOverviewCardProps {
-    data: DriverOverviewCardDataProps;
+    data: DriverOverviewPdfData;
 }
-
-export type DriverOverviewCollectionCentreData = {
-    collectionCentreName: string;
-    rowData: DriverOverviewRowData[];
-};
-
-export type DriverOverviewTablesData = {
-    collections: DriverOverviewCollectionCentreData[];
-    deliveries: DriverOverviewRowData[];
-};
 
 const styles = StyleSheet.create({
     container: {
@@ -120,7 +96,7 @@ const styles = StyleSheet.create({
         borderLeft: "1px solid black",
         borderBottom: "1px solid black",
         borderTop: "1px solid black",
-        height: 40,
+        height: 30,
     },
     nameColumnWidth: {
         width: "15%",
@@ -168,7 +144,6 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     {
                         textDecoration: "underline",
                         fontFamily: "Helvetica-Bold",
-                        fontSize: 13,
                     },
                 ]}
             >

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -39,13 +39,13 @@ interface DriverOverviewCardProps {
     data: DriverOverviewCardDataProps;
 }
 
-enum Method {
-    Delivery = "Delivery",
-    Collection = "Collection",
-}
+export type DriverOverviewCollectionCentreData = {
+    collectionCentreName: string;
+    rowData: DriverOverviewRowData[];
+};
 
 export type DriverOverviewTablesData = {
-    collections: DriverOverviewRowData[];
+    collections: DriverOverviewCollectionCentreData[];
     deliveries: DriverOverviewRowData[];
 };
 
@@ -140,6 +140,10 @@ const styles = StyleSheet.create({
     instructionsColumnWidth: {
         width: "40%",
     },
+    tableTitle: {
+        marginBottom: "5px",
+        fontSize: 12,
+    },
     collectionOrDeliveryHeader: {
         marginRight: "5px",
         marginBottom: "5px",
@@ -155,7 +159,7 @@ const styles = StyleSheet.create({
 });
 
 const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
-    const createHeader = (category: Method): React.JSX.Element => {
+    const createTableHeader = (): React.JSX.Element => {
         return (
             <View
                 style={[
@@ -172,7 +176,7 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>Name</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    <Text>{category === Method.Collection ? "Collection Centre" : "Address"}</Text>
+                    <Text>Address</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.contactColumnWidth]}>
                     <Text>Contact</Text>
@@ -198,24 +202,18 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     <Text>{rowData.name}</Text>
                 </View>
                 <View style={[styles.tableColumn, styles.addressColumnWidth]}>
-                    {rowData.isDelivery ? (
-                        rowData.address.postcode || rowData.clientIsActive ? (
-                            <>
-                                <Text>{rowData.address.line1}</Text>
-                                <Text>{rowData.address.line2}</Text>
-                                <Text>{rowData.address.town}</Text>
-                                <Text>{rowData.address.county}</Text>
-                                <Text>{rowData.address.postcode}</Text>
-                            </>
-                        ) : (
-                            <Text>
-                                {rowData.clientIsActive ? displayPostcodeForHomelessClient : "-"}
-                            </Text>
-                        )
-                    ) : (
+                    {rowData.address.postcode || rowData.clientIsActive ? (
                         <>
-                            <Text>{rowData.collectionCentre}</Text>
+                            <Text>{rowData.address.line1}</Text>
+                            <Text>{rowData.address.line2}</Text>
+                            <Text>{rowData.address.town}</Text>
+                            <Text>{rowData.address.county}</Text>
+                            <Text>{rowData.address.postcode}</Text>
                         </>
+                    ) : (
+                        <Text>
+                            {rowData.clientIsActive ? displayPostcodeForHomelessClient : "-"}
+                        </Text>
                     )}
                 </View>
                 <View style={[styles.tableColumn, styles.contactColumnWidth]}>
@@ -235,10 +233,26 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
     };
 
     const createTable = (
-        name: string,
-        header: React.JSX.Element,
-        tableRows: React.JSX.Element[],
-        icon: IconDefinition
+        tableName: string | null,
+        rows: DriverOverviewRowData[]
+    ): React.JSX.Element => {
+        return (
+            <View style={styles.tableContainer}>
+                {tableName && (
+                    <View style={styles.tableTitle}>
+                        <Text>{tableName}</Text>
+                    </View>
+                )}
+                <View style={[styles.flexColumn, { width: "100%" }]}>{createTableHeader()}</View>
+                <View style={[styles.tableSection, styles.flexColumn]}>{rows.map(createRow)}</View>
+            </View>
+        );
+    };
+
+    const createSection = (
+        sectionName: string,
+        icon: IconDefinition,
+        sectionTables: React.JSX.Element[]
     ): React.JSX.Element => {
         return (
             <View style={styles.tableContainer}>
@@ -249,32 +263,26 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                             { fontFamily: "Helvetica-Bold" },
                         ]}
                     >
-                        {name}
+                        {sectionName}
                     </Text>
                     <FontAwesomeIconPdfComponent faIcon={icon}></FontAwesomeIconPdfComponent>
                 </View>
-                <View style={[styles.flexColumn, { width: "100%" }]}>{header}</View>
-                <View style={[styles.tableSection, styles.flexColumn]}>{tableRows}</View>
+                {sectionTables}
             </View>
         );
     };
 
-    const deliveriesHeader: React.JSX.Element = createHeader(Method.Delivery);
-    const collectionsHeader: React.JSX.Element = createHeader(Method.Collection);
-    const collections: React.JSX.Element[] = data.tableData.collections
-        .filter((row) => row.name !== "Deleted Client")
-        .map(createRow);
-    const deliveries: React.JSX.Element[] = data.tableData.deliveries
-        .filter((row) => row.name !== "Deleted Client")
-        .map(createRow);
+    const deliveriesSection = createSection("Deliveries", faTruck, [
+        createTable(null, data.tableData.deliveries),
+    ]);
 
-    const collectionsTable = createTable(
+    const collectionsSection = createSection(
         "Collections",
-        collectionsHeader,
-        collections,
-        faShoePrints
+        faShoePrints,
+        data.tableData.collections.map((ccData) =>
+            createTable(ccData.collectionCentreName, ccData.rowData)
+        )
     );
-    const deliveriesTable = createTable("Deliveries", deliveriesHeader, deliveries, faTruck);
 
     return (
         <Document>
@@ -294,8 +302,8 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                     {/* eslint-disable-next-line -- needed to remove the need for alt text on the logo */}
                     <Image src="/logo.png" style={styles.logoStyling}></Image>
                 </View>
-                {deliveries.length && deliveriesTable}
-                {collections.length && collectionsTable}
+                {data.tableData.deliveries.length && deliveriesSection}
+                {data.tableData.collections.length && collectionsSection}
                 <View style={[styles.informationContainer, { alignSelf: "center" }]}>
                     <Text style={[styles.h3text, { textAlign: "center", marginBottom: "5px" }]}>
                         {data.message}


### PR DESCRIPTION
## What's changed
Previously the Collections part of the Driver Overview PDF had all collections in one table, with the collection centre name in place of the client address.

Now the Collections section has a table for each centre, with the client address in each row.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
