### PR TITLE
#592: Collection centre timeslot fixes

### DIFF
--- a/cypress/e2e/admin/collectionCentres.cy.ts
+++ b/cypress/e2e/admin/collectionCentres.cy.ts
@@ -48,6 +48,117 @@ describe("Edit a collection centre on admins page", () => {
             .find('[data-testid="CloseIcon"]') // eslint-disable-line quotes
             .should("exist");
     });
+
+    it("Adds a collection centre and edits collection slots successfully", () => {
+        toggleCollectionCentreSection();
+        cy.get('div[aria-label="Collection Centres Table"]') // eslint-disable-line quotes
+            .find(".MuiDataGrid-row", { timeout: 5000 })
+            .should("be.visible");
+
+        const newCollectionCentreName = `${uuidv4()}`;
+        cy.get('div[aria-label="Collection Centres Table"]') // eslint-disable-line quotes
+            .find(newCollectionCentreName)
+            .should("not.exist"); // If this fails then the random UUID is already there
+
+        startAddingNewCollectionCentre();
+        cy.get('div[aria-label="Collection Centres Table"]') // eslint-disable-line quotes
+            .find(".MuiDataGrid-row--editing", { timeout: 5000 })
+            .should("exist");
+
+        fillOutNewCollectionCentreRowAndSave(newCollectionCentreName);
+        cy.get('div[aria-label="Collection Centres Table"]') // eslint-disable-line quotes
+            .contains(".MuiDataGrid-cellContent", newCollectionCentreName, { timeout: 5000 })
+            .should("exist");
+
+        // Open modal
+        clickEditSlotsButtonForCentre(newCollectionCentreName);
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .should("be.visible");
+
+        // Add a slot
+        addNewTimeSlotInModal("13", "15");
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]', { timeout: 5000 }) // eslint-disable-line quotes
+            .find('[aria-label="Time slot"]', { timeout: 5000 }) // eslint-disable-line quotes
+            .as("timeSlots");
+        cy.get("@timeSlots").eq(0).should("have.text", "13:15");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+
+        // Check slot order
+        addNewTimeSlotInModal("12", "00");
+        addNewTimeSlotInModal("12", "30");
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]') // eslint-disable-line quotes
+            .find('[aria-label="Time slot"]') // eslint-disable-line quotes
+            .as("timeSlots");
+        cy.get("@timeSlots").eq(0).should("have.text", "12:00");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+        cy.get("@timeSlots").eq(1).should("have.text", "12:30");
+        cy.get("@timeSlots").eq(1).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+        cy.get("@timeSlots").eq(2).should("have.text", "13:15");
+        cy.get("@timeSlots").eq(2).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+
+        // Delete the middle timeslot
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]') // eslint-disable-line quotes
+            .find('[aria-label="Delete"]') // eslint-disable-line quotes
+            .eq(1)
+            .click();
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]') // eslint-disable-line quotes
+            .find('[aria-label="Time slot"]') // eslint-disable-line quotes
+            .as("timeSlots");
+        cy.get("@timeSlots").eq(0).should("have.text", "12:00");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+        cy.get("@timeSlots").eq(1).should("have.text", "13:15");
+        cy.get("@timeSlots").eq(1).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+
+        // Untick the first slot
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]') // eslint-disable-line quotes
+            .find('[aria-label="Time slot"]') // eslint-disable-line quotes
+            .as("timeSlots");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').uncheck(); // eslint-disable-line quotes
+
+        cy.get("@timeSlots").eq(0).should("have.text", "12:00");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').should("not.be.checked"); // eslint-disable-line quotes
+        cy.get("@timeSlots").eq(1).should("have.text", "13:15");
+        cy.get("@timeSlots").eq(1).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+
+        // Prepare to track update requests
+        cy.intercept("PATCH", "/rest/v1/collection_centres?primary_key=*").as(
+            "patchCollectionCentreRequest"
+        );
+        cy.intercept("GET", "/rest/v1/collection_centres?select=*").as(
+            "getCollectionCentresRequest"
+        );
+
+        // Save to close modal
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[data-testid="SaveSlotsCloseModal"]') // eslint-disable-line quotes
+            .click();
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .should("not.exist");
+
+        // Wait for background save to complete, then table update
+        cy.wait("@patchCollectionCentreRequest");
+        cy.wait("@getCollectionCentresRequest");
+
+        // Open modal for same collection centre
+        clickEditSlotsButtonForCentre(newCollectionCentreName);
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .should("be.visible");
+
+        // Check list of slots was saved
+        cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+            .find('[aria-label="List of defined time slots"]', { timeout: 5000 }) // eslint-disable-line quotes
+            .find('[aria-label="Time slot"]') // eslint-disable-line quotes
+            .as("timeSlots");
+        cy.get("@timeSlots").eq(0).should("have.text", "12:00");
+        cy.get("@timeSlots").eq(0).find('input[type="checkbox"]').should("not.be.checked"); // eslint-disable-line quotes
+        cy.get("@timeSlots").eq(1).should("have.text", "13:15");
+        cy.get("@timeSlots").eq(1).find('input[type="checkbox"]').should("be.checked"); // eslint-disable-line quotes
+    });
 });
 
 const toggleCollectionCentreSection = (): void => {
@@ -101,5 +212,27 @@ const uncheckIsShownInRowBeingEditedAndSave = (): void => {
 
     cy.get("@rowBeingEdited")
         .find('[data-testid="SaveIcon"]') // eslint-disable-line quotes
+        .click();
+};
+
+const clickEditSlotsButtonForCentre = (collectionCentreName: string): void => {
+    cy.get('div[aria-label="Collection Centres Table"]') // eslint-disable-line quotes
+        .find('[aria-label="Edit collection slots for ' + collectionCentreName + '"]') // eslint-disable-line quotes
+        .click();
+};
+
+const addNewTimeSlotInModal = (hrs: string, min: string): void => {
+    cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+        .find('[data-testid="DefineNewSlot"]') // eslint-disable-line quotes
+        .click();
+
+    cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+        .find('input[placeholder="hh:mm"]', { timeout: 5000 }) // eslint-disable-line quotes
+        .as("timeSlotInput");
+
+    cy.get("@timeSlotInput").type(hrs + min);
+
+    cy.get('div[data-testid="CollectionCentreTimeSlotsModal"]') // eslint-disable-line quotes
+        .find('[data-testid="AddSlot"]') // eslint-disable-line quotes
         .click();
 };

--- a/cypress/e2e/admin/collectionCentres.cy.ts
+++ b/cypress/e2e/admin/collectionCentres.cy.ts
@@ -143,6 +143,7 @@ describe("Edit a collection centre on admins page", () => {
         // Wait for background save to complete, then table update
         cy.wait("@patchCollectionCentreRequest");
         cy.wait("@getCollectionCentresRequest");
+        cy.wait(1000);
 
         // Open modal for same collection centre
         clickEditSlotsButtonForCentre(newCollectionCentreName);

--- a/cypress/e2e/admin/collectionCentres.cy.ts
+++ b/cypress/e2e/admin/collectionCentres.cy.ts
@@ -143,7 +143,7 @@ describe("Edit a collection centre on admins page", () => {
         // Wait for background save to complete, then table update
         cy.wait("@patchCollectionCentreRequest");
         cy.wait("@getCollectionCentresRequest");
-        cy.wait(1000);
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
 
         // Open modal for same collection centre
         clickEditSlotsButtonForCentre(newCollectionCentreName);

--- a/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
+++ b/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
@@ -2,12 +2,27 @@ import supabase from "@/supabaseClient";
 import { Tables } from "@/databaseTypesFile";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { PostgrestError } from "@supabase/supabase-js";
-import {
-    CollectionCentresTableRow,
-    FormattedTimeSlot,
-    FormattedTimeSlotsWithPrimaryKey,
-} from "@/app/admin/collectionCentresTable/CollectionCentresTable";
 import { Schema } from "@/databaseUtils";
+
+export interface CollectionCentresTableRow {
+    acronym: Schema["collection_centres"]["acronym"];
+    name: Schema["collection_centres"]["name"];
+    id: Schema["collection_centres"]["primary_key"];
+    isDelivery: Schema["collection_centres"]["is_delivery"];
+    isShown: Schema["collection_centres"]["is_shown"];
+    timeSlots: Schema["collection_centres"]["time_slots"];
+    isNew: boolean;
+}
+
+export interface FormattedTimeSlot {
+    time: string;
+    isActive: boolean;
+}
+
+export interface FormattedTimeSlotsWithPrimaryKey {
+    primaryKey: Schema["collection_centres"]["primary_key"];
+    timeSlots: FormattedTimeSlot[];
+}
 
 type DbCollectionCentre = Tables<"collection_centres">;
 type NewDbCollectionCentre = Omit<DbCollectionCentre, "primary_key">;

--- a/src/app/admin/collectionCentresTable/CollectionCentreTimeSlotsModal.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentreTimeSlotsModal.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import styled, { useTheme } from "styled-components";
+import { ErrorSecondaryText, ErrorTextModalFooter } from "@/app/errorStylingandMessages";
+import { FormGroup } from "@mui/material";
+import Icon from "@/components/Icons/Icon";
+import { faShoePrints, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import {
+    ButtonsDiv,
+    Centerer,
+    ContentDiv,
+    OutsideDiv,
+    SpaceBetween,
+} from "@/components/Modal/ModalFormStyles";
+import Modal from "@/components/Modal/Modal";
+import CheckboxInput from "@/components/DataInput/CheckboxInput";
+import { StyledIcon, StyledIconButton } from "@/components/Icons/IconButton";
+import { Heading } from "@/app/parcels/ActionBar/ActionModals/GeneralActionModal";
+import { DesktopTimePicker } from "@mui/x-date-pickers";
+import Button from "@mui/material/Button";
+import dayjs, { Dayjs } from "dayjs";
+import { formatDayjsToHoursAndMinutes, formatTimeStringToHoursAndMinutes } from "@/common/format";
+import {
+    CollectionCentresTableRow,
+    FormattedTimeSlot,
+    FormattedTimeSlotsWithPrimaryKey,
+    updateDbCollectionCentreTimeSlots,
+} from "@/app/admin/collectionCentresTable/CollectionCentreActions";
+import { AuditLog, sendAuditLog } from "@/server/auditLog";
+
+interface Props {
+    selectedCollectionCentreInfo: CollectionCentresTableRow | null;
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+const ModalTimeSlotsContainer = styled.div`
+    max-height: 40vh;
+    overflow-y: auto;
+`;
+
+const ModalTimeSlotRow = styled.div`
+    width: 15rem;
+`;
+
+function getBaseAuditLogForCollectionCentreTimeSlots(
+    action: string,
+    timeSlotsWithPrimaryKey: FormattedTimeSlotsWithPrimaryKey
+): Pick<AuditLog, "action" | "content" | "collectionCentreId"> {
+    const timeSlots = Object.fromEntries(
+        timeSlotsWithPrimaryKey.timeSlots.map((timeSlot) => [timeSlot.time, timeSlot.isActive])
+    );
+    return {
+        action,
+        content: {
+            timeSlots,
+        },
+        collectionCentreId: timeSlotsWithPrimaryKey.primaryKey,
+    };
+}
+
+const formatCollectionCentreTimeSlotDbData = (
+    row: CollectionCentresTableRow
+): FormattedTimeSlotsWithPrimaryKey => {
+    let formattedTimeSlots: FormattedTimeSlot[];
+
+    if (row.timeSlots === null) {
+        formattedTimeSlots = [];
+    } else {
+        formattedTimeSlots = row.timeSlots.map((timeSlot) => {
+            return {
+                time: formatTimeStringToHoursAndMinutes(
+                    timeSlot.time !== null ? timeSlot.time : ""
+                ),
+                isActive: timeSlot.is_active !== null ? timeSlot.is_active : false,
+            };
+        });
+    }
+
+    return {
+        primaryKey: row.id,
+        timeSlots: formattedTimeSlots,
+    };
+};
+
+const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
+    const [timeSlotModalData, setTimeSlotModalData] =
+        useState<FormattedTimeSlotsWithPrimaryKey | null>(null);
+    const [timeSlotModalErrorMessage, setTimeSlotModalErrorMessage] = useState<string | null>(null);
+    const [timeSlotEditIsShown, setTimeSlotEditIsShown] = useState<boolean>(false);
+    const [collectionTimeSlotValue, setCollectionTimeSlotValue] = useState<Dayjs>();
+    const [addCollectionTimeSlotError, setAddCollectionTimeSlotError] = useState<string | null>(
+        null
+    );
+
+    const theme = useTheme();
+
+    useEffect(() => {
+        if (props.selectedCollectionCentreInfo) {
+            setTimeSlotModalData(
+                formatCollectionCentreTimeSlotDbData(props.selectedCollectionCentreInfo)
+            );
+        }
+    }, [props.selectedCollectionCentreInfo]);
+
+    const handleModalSaveClick = async (): Promise<void> => {
+        if (timeSlotModalData === null) {
+            return;
+        }
+        const { error: updateTimeSlotError } =
+            await updateDbCollectionCentreTimeSlots(timeSlotModalData);
+        const baseAuditLog = getBaseAuditLogForCollectionCentreTimeSlots(
+            "update collection centre time slots",
+            timeSlotModalData
+        );
+
+        if (updateTimeSlotError) {
+            setTimeSlotModalErrorMessage(
+                `Failed to update the collection centre time slots. Log ID: ${updateTimeSlotError.logId}`
+            );
+            await sendAuditLog({
+                ...baseAuditLog,
+                wasSuccess: false,
+                logId: updateTimeSlotError.logId,
+            });
+        }
+
+        await sendAuditLog({ ...baseAuditLog, wasSuccess: true });
+        props.onClose();
+    };
+
+    const checkIfSlotExists = (
+        existingTimeSlotData: FormattedTimeSlotsWithPrimaryKey,
+        newTimeSlot: FormattedTimeSlot
+    ): boolean => {
+        return existingTimeSlotData.timeSlots.some((slot) => slot.time === newTimeSlot.time);
+    };
+
+    const addNewTimeSlotToTimeSlotModalData = (
+        existingTimeSlotData: FormattedTimeSlotsWithPrimaryKey,
+        newTimeSlot: FormattedTimeSlot
+    ): void => {
+        const newTimeSlotArray = [...existingTimeSlotData.timeSlots, newTimeSlot];
+        newTimeSlotArray.sort((slot1, slot2) => slot1.time.localeCompare(slot2.time));
+
+        const updatedTimeSlotModalData: FormattedTimeSlotsWithPrimaryKey = {
+            ...existingTimeSlotData,
+            timeSlots: newTimeSlotArray,
+        };
+
+        setTimeSlotModalData(updatedTimeSlotModalData);
+    };
+
+    const handleAddNewSlotClick = async (): Promise<void> => {
+        setTimeSlotEditIsShown(true);
+        setCollectionTimeSlotValue(dayjs(collectionTimeSlotValue));
+    };
+
+    const handleAddSlotClick = async (): Promise<void> => {
+        setAddCollectionTimeSlotError(null);
+        if (timeSlotModalData === null || collectionTimeSlotValue === undefined) {
+            return;
+        }
+        const newTimeSlot: FormattedTimeSlot = {
+            time: formatDayjsToHoursAndMinutes(collectionTimeSlotValue),
+            isActive: true,
+        };
+
+        if (checkIfSlotExists(timeSlotModalData, newTimeSlot)) {
+            setAddCollectionTimeSlotError(
+                "This time slot already exists. Please select a different time."
+            );
+            return;
+        }
+
+        addNewTimeSlotToTimeSlotModalData(timeSlotModalData, newTimeSlot);
+
+        setTimeSlotEditIsShown(false);
+    };
+
+    const toggleTimeSlotInModalData = (timeLabel: string): void => {
+        if (!timeSlotModalData) {
+            return;
+        }
+
+        const timeSlotIndex = timeSlotModalData.timeSlots.findIndex(
+            (slot) => slot.time === timeLabel
+        );
+        const timeSlot = timeSlotModalData.timeSlots[timeSlotIndex];
+        if (!timeSlot) {
+            return;
+        }
+
+        timeSlot.isActive = !timeSlot.isActive;
+
+        const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
+            ...timeSlotModalData,
+            timeSlots: timeSlotModalData.timeSlots,
+        };
+
+        setTimeSlotModalData(updatedTimeSlotData);
+    };
+
+    const deleteTimeSlotFromModalData = (timeLabel: string): void => {
+        if (!timeSlotModalData) {
+            return;
+        }
+
+        const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
+            ...timeSlotModalData,
+            timeSlots: timeSlotModalData.timeSlots.filter(
+                (timeSlot) => timeSlot.time !== timeLabel
+            ),
+        };
+
+        setTimeSlotModalData(updatedTimeSlotData);
+    };
+
+    return (
+        <Modal
+            header={
+                <>
+                    <Icon icon={faShoePrints} color={theme.primary.largeForeground[2]} /> Edit
+                    Collection Centre Time Slots
+                </>
+            }
+            isOpen={props.isOpen}
+            onClose={() => {
+                props.onClose();
+            }}
+            headerId="expandedCollectionCentreTimeSlotsModal"
+            footer={
+                <SpaceBetween>
+                    {!timeSlotEditIsShown && (
+                        <Button onClick={handleAddNewSlotClick} variant="contained">
+                            Add a new slot
+                        </Button>
+                    )}
+                    {timeSlotEditIsShown && (
+                        <>
+                            <Centerer>
+                                <DesktopTimePicker
+                                    label="New Collection Slot"
+                                    views={["hours", "minutes"]}
+                                    format="HH:mm"
+                                    value={dayjs(collectionTimeSlotValue)}
+                                    onChange={(value) =>
+                                        value !== null && setCollectionTimeSlotValue(value)
+                                    }
+                                />
+                                <Button onClick={handleAddSlotClick} variant="contained">
+                                    Add slot
+                                </Button>
+                            </Centerer>
+                            {addCollectionTimeSlotError && (
+                                <ErrorTextModalFooter>
+                                    {addCollectionTimeSlotError}
+                                </ErrorTextModalFooter>
+                            )}
+                        </>
+                    )}
+                    <Button onClick={handleModalSaveClick} variant="contained">
+                        Save
+                    </Button>
+                </SpaceBetween>
+            }
+        >
+            <OutsideDiv>
+                <ContentDiv>
+                    <Centerer>
+                        <Heading>{props.selectedCollectionCentreInfo?.name}</Heading>
+                    </Centerer>
+                    <Centerer>
+                        <ModalTimeSlotsContainer>
+                            <FormGroup>
+                                {timeSlotModalData &&
+                                    timeSlotModalData.timeSlots.map((timeSlot) => {
+                                        return (
+                                            <ModalTimeSlotRow key={timeSlot.time}>
+                                                <SpaceBetween>
+                                                    <CheckboxInput
+                                                        label={timeSlot.time}
+                                                        checked={timeSlot.isActive}
+                                                        onChange={() =>
+                                                            toggleTimeSlotInModalData(timeSlot.time)
+                                                        }
+                                                    />
+                                                    <StyledIconButton
+                                                        onClick={() =>
+                                                            deleteTimeSlotFromModalData(
+                                                                timeSlot.time
+                                                            )
+                                                        }
+                                                        aria-label="delete"
+                                                    >
+                                                        <StyledIcon
+                                                            icon={faTrashAlt}
+                                                            onHoverText={`Delete timeslot ${timeSlot.time}`}
+                                                        />
+                                                    </StyledIconButton>
+                                                </SpaceBetween>
+                                            </ModalTimeSlotRow>
+                                        );
+                                    })}
+                            </FormGroup>
+                        </ModalTimeSlotsContainer>
+                    </Centerer>
+                </ContentDiv>
+                <ButtonsDiv>
+                    {timeSlotModalErrorMessage && (
+                        <ErrorSecondaryText>{timeSlotModalErrorMessage}</ErrorSecondaryText>
+                    )}
+                </ButtonsDiv>
+            </OutsideDiv>
+        </Modal>
+    );
+};
+
+export default CollectionCentreTimeSlotsModal;

--- a/src/app/admin/collectionCentresTable/CollectionCentreTimeSlotsModal.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentreTimeSlotsModal.tsx
@@ -10,6 +10,7 @@ import {
     ButtonsDiv,
     Centerer,
     ContentDiv,
+    InputContainer,
     OutsideDiv,
     SpaceBetween,
 } from "@/components/Modal/ModalFormStyles";
@@ -41,7 +42,17 @@ const ModalTimeSlotsContainer = styled.div`
 `;
 
 const ModalTimeSlotRow = styled.div`
-    width: 15rem;
+    width: 20rem;
+`;
+
+const ColumnContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const RowContainer = styled.div`
+    display: flex;
+    flex-direction: row;
 `;
 
 function getBaseAuditLogForCollectionCentreTimeSlots(
@@ -221,8 +232,8 @@ const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
         <Modal
             header={
                 <>
-                    <Icon icon={faShoePrints} color={theme.primary.largeForeground[2]} /> Edit
-                    Collection Centre Time Slots
+                    <Icon icon={faShoePrints} color={theme.primary.largeForeground[2]} />
+                    Edit Collection Time Slots
                 </>
             }
             isOpen={props.isOpen}
@@ -230,37 +241,55 @@ const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
                 props.onClose();
             }}
             headerId="expandedCollectionCentreTimeSlotsModal"
+            testId="CollectionCentreTimeSlotsModal"
+            maxWidth="xs"
             footer={
                 <SpaceBetween>
                     {!timeSlotEditIsShown && (
-                        <Button onClick={handleAddNewSlotClick} variant="contained">
-                            Add a new slot
+                        <Button
+                            onClick={handleAddNewSlotClick}
+                            variant="contained"
+                            data-testid="DefineNewSlot"
+                        >
+                            Define a new slot
                         </Button>
                     )}
                     {timeSlotEditIsShown && (
-                        <>
-                            <Centerer>
-                                <DesktopTimePicker
-                                    label="New Collection Slot"
-                                    views={["hours", "minutes"]}
-                                    format="HH:mm"
-                                    value={dayjs(collectionTimeSlotValue)}
-                                    onChange={(value) =>
-                                        value !== null && setCollectionTimeSlotValue(value)
-                                    }
-                                />
-                                <Button onClick={handleAddSlotClick} variant="contained">
+                        <ColumnContainer>
+                            <RowContainer>
+                                <InputContainer>
+                                    <DesktopTimePicker
+                                        label="New Collection Slot"
+                                        views={["hours", "minutes"]}
+                                        format="HH:mm"
+                                        value={dayjs(collectionTimeSlotValue)}
+                                        onChange={(value) =>
+                                            value !== null && setCollectionTimeSlotValue(value)
+                                        }
+                                    />
+                                </InputContainer>
+                                <Button
+                                    onClick={handleAddSlotClick}
+                                    variant="contained"
+                                    data-testid="AddSlot"
+                                >
                                     Add slot
                                 </Button>
-                            </Centerer>
+                            </RowContainer>
                             {addCollectionTimeSlotError && (
-                                <ErrorTextModalFooter>
-                                    {addCollectionTimeSlotError}
-                                </ErrorTextModalFooter>
+                                <div>
+                                    <ErrorTextModalFooter>
+                                        {addCollectionTimeSlotError}
+                                    </ErrorTextModalFooter>
+                                </div>
                             )}
-                        </>
+                        </ColumnContainer>
                     )}
-                    <Button onClick={handleModalSaveClick} variant="contained">
+                    <Button
+                        onClick={handleModalSaveClick}
+                        variant="contained"
+                        data-testid="SaveSlotsCloseModal"
+                    >
                         Save
                     </Button>
                 </SpaceBetween>
@@ -272,7 +301,7 @@ const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
                         <Heading>{props.selectedCollectionCentreInfo?.name}</Heading>
                     </Centerer>
                     <Centerer>
-                        <ModalTimeSlotsContainer>
+                        <ModalTimeSlotsContainer aria-label="List of defined time slots">
                             <FormGroup>
                                 {timeSlotModalData &&
                                     timeSlotModalData.timeSlots.map((timeSlot) => {
@@ -285,6 +314,7 @@ const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
                                                         onChange={() =>
                                                             toggleTimeSlotInModalData(timeSlot.time)
                                                         }
+                                                        ariaLabel="Time slot"
                                                     />
                                                     <StyledIconButton
                                                         onClick={() =>
@@ -292,7 +322,7 @@ const CollectionCentreTimeSlotsModal: React.FC<Props> = (props) => {
                                                                 timeSlot.time
                                                             )
                                                         }
-                                                        aria-label="delete"
+                                                        aria-label="Delete"
                                                     >
                                                         <StyledIcon
                                                             icon={faTrashAlt}

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -268,6 +268,7 @@ const CollectionCentresTable: React.FC = () => {
                         size="small"
                         onClick={handleEditCollectionCentreTimeSlot}
                         disabled={params.row.isNew || params.row.isDelivery}
+                        aria-label={`Edit collection slots for ${params.row.name}`}
                     >
                         Edit Collection Slots
                     </Button>

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import { Schema } from "@/databaseUtils";
 import { logErrorReturnLogId } from "@/logger/logger";
 import supabase from "@/supabaseClient";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
-import { ErrorSecondaryText, ErrorTextModalFooter } from "@/app/errorStylingandMessages";
 import {
     GridActionsCellItem,
     GridColDef,
@@ -21,64 +19,19 @@ import SaveIcon from "@mui/icons-material/Save";
 import CancelIcon from "@mui/icons-material/Close";
 import EditIcon from "@mui/icons-material/Edit";
 import StyledDataGrid from "@/app/admin/common/StyledDataGrid";
-import { FormGroup, LinearProgress } from "@mui/material";
+import { LinearProgress } from "@mui/material";
 import {
+    CollectionCentresTableRow,
     fetchCollectionCentresForTable,
     InsertCollectionCentreResult,
     insertNewCollectionCentre,
     UpdateCollectionCentreResult,
     updateDbCollectionCentre,
-    updateDbCollectionCentreTimeSlots,
 } from "@/app/admin/collectionCentresTable/CollectionCentreActions";
 import { EditToolbar } from "@/app/admin/collectionCentresTable/CollectionCentresTableToolbar";
 import Button from "@mui/material/Button";
-import Icon from "@/components/Icons/Icon";
-import { faShoePrints, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
-import {
-    ButtonsDiv,
-    Centerer,
-    ContentDiv,
-    OutsideDiv,
-    SpaceBetween,
-} from "@/components/Modal/ModalFormStyles";
-import Modal from "@/components/Modal/Modal";
-import styled, { useTheme } from "styled-components";
-import { formatDayjsToHoursAndMinutes, formatTimeStringToHoursAndMinutes } from "@/common/format";
-import { DesktopTimePicker } from "@mui/x-date-pickers";
-import dayjs, { Dayjs } from "dayjs";
 import FloatingToast from "@/components/FloatingToast";
-import CheckboxInput from "@/components/DataInput/CheckboxInput";
-import { StyledIcon, StyledIconButton } from "@/components/Icons/IconButton";
-import { Heading } from "@/app/parcels/ActionBar/ActionModals/GeneralActionModal";
-
-export interface CollectionCentresTableRow {
-    acronym: Schema["collection_centres"]["acronym"];
-    name: Schema["collection_centres"]["name"];
-    id: Schema["collection_centres"]["primary_key"];
-    isDelivery: Schema["collection_centres"]["is_delivery"];
-    isShown: Schema["collection_centres"]["is_shown"];
-    timeSlots: Schema["collection_centres"]["time_slots"];
-    isNew: boolean;
-}
-
-export interface FormattedTimeSlot {
-    time: string;
-    isActive: boolean;
-}
-
-export interface FormattedTimeSlotsWithPrimaryKey {
-    primaryKey: Schema["collection_centres"]["primary_key"];
-    timeSlots: FormattedTimeSlot[];
-}
-
-const ModalTimeSlotsContainer = styled.div`
-    max-height: 40vh;
-    overflow-y: auto;
-`;
-
-const ModalTimeSlotRow = styled.div`
-    width: 15rem;
-`;
+import CollectionCentreTimeSlotsModal from "./CollectionCentreTimeSlotsModal";
 
 function getBaseAuditLogForCollectionCentreAction(
     action: string,
@@ -98,46 +51,6 @@ function getBaseAuditLogForCollectionCentreAction(
     };
 }
 
-function getBaseAuditLogForCollectionCentreTimeSlots(
-    action: string,
-    timeSlotsWithPrimaryKey: FormattedTimeSlotsWithPrimaryKey
-): Pick<AuditLog, "action" | "content" | "collectionCentreId"> {
-    const timeSlots = Object.fromEntries(
-        timeSlotsWithPrimaryKey.timeSlots.map((timeSlot) => [timeSlot.time, timeSlot.isActive])
-    );
-    return {
-        action,
-        content: {
-            timeSlots,
-        },
-        collectionCentreId: timeSlotsWithPrimaryKey.primaryKey,
-    };
-}
-
-const formatCollectionCentreTimeSlotDbData = (
-    row: CollectionCentresTableRow
-): FormattedTimeSlotsWithPrimaryKey => {
-    let formattedTimeSlots: FormattedTimeSlot[];
-
-    if (row.timeSlots === null) {
-        formattedTimeSlots = [];
-    } else {
-        formattedTimeSlots = row.timeSlots.map((timeSlot) => {
-            return {
-                time: formatTimeStringToHoursAndMinutes(
-                    timeSlot.time !== null ? timeSlot.time : ""
-                ),
-                isActive: timeSlot.is_active !== null ? timeSlot.is_active : false,
-            };
-        });
-    }
-
-    return {
-        primaryKey: row.id,
-        timeSlots: formattedTimeSlots,
-    };
-};
-
 const CollectionCentresTable: React.FC = () => {
     const [rows, setRows] = useState<CollectionCentresTableRow[]>([]);
     const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
@@ -145,16 +58,8 @@ const CollectionCentresTable: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [existingRowData, setExistingRowData] = useState<CollectionCentresTableRow | null>(null);
     const [timeSlotModalIsOpen, setTimeSlotModalIsOpen] = useState<boolean>(false);
-    const [timeSlotModalErrorMessage, setTimeSlotModalErrorMessage] = useState<string | null>(null);
-    const [timeSlotModalCentreName, setTimeSlotModalCentreName] = useState<string | null>(null);
-    const [timeSlotModalData, setTimeSlotModalData] =
-        useState<FormattedTimeSlotsWithPrimaryKey | null>(null);
-    const [editableIsShown, setEditableIsShown] = useState<boolean>(false);
-    const [collectionTimeSlotValue, setCollectionTimeSlotValue] = useState<Dayjs>();
-    const [addCollectionTimeSlotError, setAddCollectionTimeSlotError] = useState<string | null>(
-        null
-    );
-    const theme = useTheme();
+    const [selectedRowForTimeSlotEdit, setSelectedRowForTimeSlotEdit] =
+        useState<CollectionCentresTableRow | null>(null);
 
     const getCollectionCentresForTable = useCallback(async () => {
         setErrorMessage(null);
@@ -191,119 +96,6 @@ const CollectionCentresTable: React.FC = () => {
             void supabase.removeChannel(subscriptionChannel);
         };
     }, [getCollectionCentresForTable]);
-
-    const handleModalSaveClick = async (): Promise<void> => {
-        if (timeSlotModalData === null) {
-            return;
-        }
-        const { error: updateTimeSlotError } =
-            await updateDbCollectionCentreTimeSlots(timeSlotModalData);
-        const baseAuditLog = getBaseAuditLogForCollectionCentreTimeSlots(
-            "update collection centre time slots",
-            timeSlotModalData
-        );
-
-        if (updateTimeSlotError) {
-            setTimeSlotModalErrorMessage(
-                `Failed to update the collection centre time slots. Log ID: ${updateTimeSlotError.logId}`
-            );
-            await sendAuditLog({
-                ...baseAuditLog,
-                wasSuccess: false,
-                logId: updateTimeSlotError.logId,
-            });
-        }
-
-        await sendAuditLog({ ...baseAuditLog, wasSuccess: true });
-        setTimeSlotModalIsOpen(false);
-    };
-
-    const handleAddSlotClick = async (): Promise<void> => {
-        setEditableIsShown(true);
-        setCollectionTimeSlotValue(dayjs(collectionTimeSlotValue));
-    };
-
-    const checkIfSlotExists = (
-        existingTimeSlotData: FormattedTimeSlotsWithPrimaryKey,
-        newTimeSlot: FormattedTimeSlot
-    ): boolean => {
-        return existingTimeSlotData.timeSlots.some((slot) => slot.time === newTimeSlot.time);
-    };
-
-    const addNewTimeSlotToTimeSlotModalData = (
-        existingTimeSlotData: FormattedTimeSlotsWithPrimaryKey,
-        newTimeSlot: FormattedTimeSlot
-    ): void => {
-        const newTimeSlotArray = [...existingTimeSlotData.timeSlots, newTimeSlot];
-        newTimeSlotArray.sort((slot1, slot2) => slot1.time.localeCompare(slot2.time));
-
-        const updatedTimeSlotModalData: FormattedTimeSlotsWithPrimaryKey = {
-            ...existingTimeSlotData,
-            timeSlots: newTimeSlotArray,
-        };
-
-        setTimeSlotModalData(updatedTimeSlotModalData);
-    };
-
-    const handleSaveSlotClick = async (): Promise<void> => {
-        setAddCollectionTimeSlotError(null);
-        if (timeSlotModalData === null || collectionTimeSlotValue === undefined) {
-            return;
-        }
-        const newTimeSlot: FormattedTimeSlot = {
-            time: formatDayjsToHoursAndMinutes(collectionTimeSlotValue),
-            isActive: true,
-        };
-
-        if (checkIfSlotExists(timeSlotModalData, newTimeSlot)) {
-            setAddCollectionTimeSlotError(
-                "This time slot already exists. Please select a different time."
-            );
-            return;
-        }
-
-        addNewTimeSlotToTimeSlotModalData(timeSlotModalData, newTimeSlot);
-
-        setEditableIsShown(false);
-    };
-
-    const toggleTimeSlotInModalData = (timeLabel: string): void => {
-        if (!timeSlotModalData) {
-            return;
-        }
-
-        const timeSlotIndex = timeSlotModalData.timeSlots.findIndex(
-            (slot) => slot.time === timeLabel
-        );
-        const timeSlot = timeSlotModalData.timeSlots[timeSlotIndex];
-        if (!timeSlot) {
-            return;
-        }
-
-        timeSlot.isActive = !timeSlot.isActive;
-
-        const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
-            ...timeSlotModalData,
-            timeSlots: timeSlotModalData.timeSlots,
-        };
-
-        setTimeSlotModalData(updatedTimeSlotData);
-    };
-
-    const deleteTimeSlotFromModalData = (timeLabel: string): void => {
-        if (!timeSlotModalData) {
-            return;
-        }
-
-        const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
-            ...timeSlotModalData,
-            timeSlots: timeSlotModalData.timeSlots.filter(
-                (timeSlot) => timeSlot.time !== timeLabel
-            ),
-        };
-
-        setTimeSlotModalData(updatedTimeSlotData);
-    };
 
     const handleSaveClick = (id: GridRowId) => () => {
         setRowModesModel((currentValue) => ({
@@ -466,10 +258,7 @@ const CollectionCentresTable: React.FC = () => {
             renderHeader: (params) => <Header {...params} />,
             renderCell: (params) => {
                 const handleEditCollectionCentreTimeSlot = (): void => {
-                    const row = params.row as CollectionCentresTableRow;
-                    const formattedTimeSlotData = formatCollectionCentreTimeSlotDbData(row);
-                    setTimeSlotModalData(formattedTimeSlotData);
-                    setTimeSlotModalCentreName(row.name);
+                    setSelectedRowForTimeSlotEdit(params.row as CollectionCentresTableRow);
                     setTimeSlotModalIsOpen(true);
                 };
 
@@ -567,104 +356,13 @@ const CollectionCentresTable: React.FC = () => {
                 />
             )}
             {timeSlotModalIsOpen && (
-                <Modal
-                    header={
-                        <>
-                            <Icon icon={faShoePrints} color={theme.primary.largeForeground[2]} />{" "}
-                            Edit Collection Centre Time Slots
-                        </>
-                    }
+                <CollectionCentreTimeSlotsModal
+                    selectedCollectionCentreInfo={selectedRowForTimeSlotEdit}
                     isOpen={timeSlotModalIsOpen}
                     onClose={() => {
                         setTimeSlotModalIsOpen(false);
                     }}
-                    headerId="expandedCollectionCentreTimeSlotsModal"
-                    footer={
-                        <SpaceBetween>
-                            {!editableIsShown && (
-                                <Button onClick={handleAddSlotClick} variant="contained">
-                                    Add a new slot
-                                </Button>
-                            )}
-                            {editableIsShown && (
-                                <>
-                                    <Centerer>
-                                        <DesktopTimePicker
-                                            label="New Collection Slot"
-                                            views={["hours", "minutes"]}
-                                            format="HH:mm"
-                                            value={dayjs(collectionTimeSlotValue)}
-                                            onChange={(value) =>
-                                                value !== null && setCollectionTimeSlotValue(value)
-                                            }
-                                        />
-                                        <Button onClick={handleSaveSlotClick} variant="contained">
-                                            Save slot
-                                        </Button>
-                                    </Centerer>
-                                    {addCollectionTimeSlotError && (
-                                        <ErrorTextModalFooter>
-                                            {addCollectionTimeSlotError}
-                                        </ErrorTextModalFooter>
-                                    )}
-                                </>
-                            )}
-                            <Button onClick={handleModalSaveClick} variant="contained">
-                                Save
-                            </Button>
-                        </SpaceBetween>
-                    }
-                >
-                    <OutsideDiv>
-                        <ContentDiv>
-                            <Centerer>
-                                <Heading>{timeSlotModalCentreName}</Heading>
-                            </Centerer>
-                            <Centerer>
-                                <ModalTimeSlotsContainer>
-                                    <FormGroup>
-                                        {timeSlotModalData &&
-                                            timeSlotModalData.timeSlots.map((timeSlot) => {
-                                                return (
-                                                    <ModalTimeSlotRow key={timeSlot.time}>
-                                                        <SpaceBetween>
-                                                            <CheckboxInput
-                                                                label={timeSlot.time}
-                                                                checked={timeSlot.isActive}
-                                                                onChange={() =>
-                                                                    toggleTimeSlotInModalData(
-                                                                        timeSlot.time
-                                                                    )
-                                                                }
-                                                            />
-                                                            <StyledIconButton
-                                                                onClick={() =>
-                                                                    deleteTimeSlotFromModalData(
-                                                                        timeSlot.time
-                                                                    )
-                                                                }
-                                                                aria-label="delete"
-                                                            >
-                                                                <StyledIcon
-                                                                    icon={faTrashAlt}
-                                                                    onHoverText={`Delete timeslot ${timeSlot.time}`}
-                                                                />
-                                                            </StyledIconButton>
-                                                        </SpaceBetween>
-                                                    </ModalTimeSlotRow>
-                                                );
-                                            })}
-                                    </FormGroup>
-                                </ModalTimeSlotsContainer>
-                            </Centerer>
-                        </ContentDiv>
-                        <ButtonsDiv>
-                            {timeSlotModalErrorMessage && (
-                                <ErrorSecondaryText>{timeSlotModalErrorMessage}</ErrorSecondaryText>
-                            )}
-                        </ButtonsDiv>
-                    </OutsideDiv>
-                </Modal>
+                ></CollectionCentreTimeSlotsModal>
             )}
         </>
     );

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -21,7 +21,7 @@ import SaveIcon from "@mui/icons-material/Save";
 import CancelIcon from "@mui/icons-material/Close";
 import EditIcon from "@mui/icons-material/Edit";
 import StyledDataGrid from "@/app/admin/common/StyledDataGrid";
-import { Checkbox, FormControlLabel, FormGroup, LinearProgress } from "@mui/material";
+import { FormGroup, LinearProgress } from "@mui/material";
 import {
     fetchCollectionCentresForTable,
     InsertCollectionCentreResult,
@@ -33,7 +33,7 @@ import {
 import { EditToolbar } from "@/app/admin/collectionCentresTable/CollectionCentresTableToolbar";
 import Button from "@mui/material/Button";
 import Icon from "@/components/Icons/Icon";
-import { faShoePrints } from "@fortawesome/free-solid-svg-icons";
+import { faShoePrints, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import {
     ButtonsDiv,
     Centerer,
@@ -42,11 +42,14 @@ import {
     SpaceBetween,
 } from "@/components/Modal/ModalFormStyles";
 import Modal from "@/components/Modal/Modal";
-import { useTheme } from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { formatDayjsToHoursAndMinutes, formatTimeStringToHoursAndMinutes } from "@/common/format";
 import { DesktopTimePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 import FloatingToast from "@/components/FloatingToast";
+import CheckboxInput from "@/components/DataInput/CheckboxInput";
+import { StyledIcon, StyledIconButton } from "@/components/Icons/IconButton";
+import { Heading } from "@/app/parcels/ActionBar/ActionModals/GeneralActionModal";
 
 export interface CollectionCentresTableRow {
     acronym: Schema["collection_centres"]["acronym"];
@@ -67,6 +70,15 @@ export interface FormattedTimeSlotsWithPrimaryKey {
     primaryKey: Schema["collection_centres"]["primary_key"];
     timeSlots: FormattedTimeSlot[];
 }
+
+const ModalTimeSlotsContainer = styled.div`
+    max-height: 40vh;
+    overflow-y: auto;
+`;
+
+const ModalTimeSlotRow = styled.div`
+    width: 15rem;
+`;
 
 function getBaseAuditLogForCollectionCentreAction(
     action: string,
@@ -134,6 +146,7 @@ const CollectionCentresTable: React.FC = () => {
     const [existingRowData, setExistingRowData] = useState<CollectionCentresTableRow | null>(null);
     const [timeSlotModalIsOpen, setTimeSlotModalIsOpen] = useState<boolean>(false);
     const [timeSlotModalErrorMessage, setTimeSlotModalErrorMessage] = useState<string | null>(null);
+    const [timeSlotModalCentreName, setTimeSlotModalCentreName] = useState<string | null>(null);
     const [timeSlotModalData, setTimeSlotModalData] =
         useState<FormattedTimeSlotsWithPrimaryKey | null>(null);
     const [editableIsShown, setEditableIsShown] = useState<boolean>(false);
@@ -254,14 +267,13 @@ const CollectionCentresTable: React.FC = () => {
         setEditableIsShown(false);
     };
 
-    const handleTimeSlotCheckBoxChange = (event: React.SyntheticEvent<Element, Event>): void => {
+    const toggleTimeSlotInModalData = (timeLabel: string): void => {
         if (!timeSlotModalData) {
             return;
         }
 
-        const updatedTime = event.currentTarget.parentElement?.parentElement?.innerText;
         const timeSlotIndex = timeSlotModalData.timeSlots.findIndex(
-            (slot) => slot.time === updatedTime
+            (slot) => slot.time === timeLabel
         );
         const timeSlot = timeSlotModalData.timeSlots[timeSlotIndex];
         if (!timeSlot) {
@@ -273,6 +285,21 @@ const CollectionCentresTable: React.FC = () => {
         const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
             ...timeSlotModalData,
             timeSlots: timeSlotModalData.timeSlots,
+        };
+
+        setTimeSlotModalData(updatedTimeSlotData);
+    };
+
+    const deleteTimeSlotFromModalData = (timeLabel: string): void => {
+        if (!timeSlotModalData) {
+            return;
+        }
+
+        const updatedTimeSlotData: FormattedTimeSlotsWithPrimaryKey = {
+            ...timeSlotModalData,
+            timeSlots: timeSlotModalData.timeSlots.filter(
+                (timeSlot) => timeSlot.time !== timeLabel
+            ),
         };
 
         setTimeSlotModalData(updatedTimeSlotData);
@@ -439,8 +466,10 @@ const CollectionCentresTable: React.FC = () => {
             renderHeader: (params) => <Header {...params} />,
             renderCell: (params) => {
                 const handleEditCollectionCentreTimeSlot = (): void => {
-                    const formattedTimeSlotData = formatCollectionCentreTimeSlotDbData(params.row);
+                    const row = params.row as CollectionCentresTableRow;
+                    const formattedTimeSlotData = formatCollectionCentreTimeSlotDbData(row);
                     setTimeSlotModalData(formattedTimeSlotData);
+                    setTimeSlotModalCentreName(row.name);
                     setTimeSlotModalIsOpen(true);
                 };
 
@@ -449,7 +478,7 @@ const CollectionCentresTable: React.FC = () => {
                         variant="outlined"
                         size="small"
                         onClick={handleEditCollectionCentreTimeSlot}
-                        disabled={params.row.isNew}
+                        disabled={params.row.isNew || params.row.isDelivery}
                     >
                         Edit Collection Slots
                     </Button>
@@ -588,19 +617,46 @@ const CollectionCentresTable: React.FC = () => {
                 >
                     <OutsideDiv>
                         <ContentDiv>
-                            <FormGroup>
-                                {timeSlotModalData &&
-                                    timeSlotModalData.timeSlots.map((timeSlot) => {
-                                        return (
-                                            <FormControlLabel
-                                                control={<Checkbox checked={timeSlot.isActive} />}
-                                                label={timeSlot.time}
-                                                onChange={handleTimeSlotCheckBoxChange}
-                                                key={timeSlot.time}
-                                            />
-                                        );
-                                    })}
-                            </FormGroup>
+                            <Centerer>
+                                <Heading>{timeSlotModalCentreName}</Heading>
+                            </Centerer>
+                            <Centerer>
+                                <ModalTimeSlotsContainer>
+                                    <FormGroup>
+                                        {timeSlotModalData &&
+                                            timeSlotModalData.timeSlots.map((timeSlot) => {
+                                                return (
+                                                    <ModalTimeSlotRow key={timeSlot.time}>
+                                                        <SpaceBetween>
+                                                            <CheckboxInput
+                                                                label={timeSlot.time}
+                                                                checked={timeSlot.isActive}
+                                                                onChange={() =>
+                                                                    toggleTimeSlotInModalData(
+                                                                        timeSlot.time
+                                                                    )
+                                                                }
+                                                            />
+                                                            <StyledIconButton
+                                                                onClick={() =>
+                                                                    deleteTimeSlotFromModalData(
+                                                                        timeSlot.time
+                                                                    )
+                                                                }
+                                                                aria-label="delete"
+                                                            >
+                                                                <StyledIcon
+                                                                    icon={faTrashAlt}
+                                                                    onHoverText={`Delete timeslot ${timeSlot.time}`}
+                                                                />
+                                                            </StyledIconButton>
+                                                        </SpaceBetween>
+                                                    </ModalTimeSlotRow>
+                                                );
+                                            })}
+                                    </FormGroup>
+                                </ModalTimeSlotsContainer>
+                            </Centerer>
                         </ContentDiv>
                         <ButtonsDiv>
                             {timeSlotModalErrorMessage && (

--- a/src/app/admin/collectionCentresTable/CollectionCentresTableToolbar.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTableToolbar.tsx
@@ -7,7 +7,7 @@ import {
 import React from "react";
 import Button from "@mui/material/Button";
 import AddIcon from "@mui/icons-material/Add";
-import { CollectionCentresTableRow } from "@/app/admin/collectionCentresTable/CollectionCentresTable";
+import { CollectionCentresTableRow } from "@/app/admin/collectionCentresTable/CollectionCentreActions";
 
 interface EditToolbarProps {
     setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void;

--- a/src/app/batch-create/inputComponents/CollectionInfoEditCellInput.tsx
+++ b/src/app/batch-create/inputComponents/CollectionInfoEditCellInput.tsx
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { BatchActionType, BatchTableDataState, CollectionInfo } from "@/app/batch-create/types";
 import { COLLECTION_INFO_WIDTH } from "@/app/batch-create/columnWidths";
 import { ControlledSelect } from "@/components/DataInput/DropDownSelect";
-import { fetchCollectionCentresForTable } from "@/app/admin/collectionCentresTable/CollectionCentreActions";
-import { CollectionCentresTableRow } from "@/app/admin/collectionCentresTable/CollectionCentresTable";
+import {
+    CollectionCentresTableRow,
+    fetchCollectionCentresForTable,
+} from "@/app/admin/collectionCentresTable/CollectionCentreActions";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { DatePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";

--- a/src/components/DataInput/CheckboxInput.tsx
+++ b/src/components/DataInput/CheckboxInput.tsx
@@ -5,6 +5,7 @@ import { Checkbox, FormControl, FormControlLabel } from "@mui/material";
 
 interface Props {
     label?: string;
+    checked?: boolean;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -13,7 +14,7 @@ const CheckboxInput: React.FC<Props> = (props) => {
         <FormControl>
             <FormControlLabel
                 label={props.label}
-                control={<Checkbox onChange={props.onChange} />}
+                control={<Checkbox checked={props.checked} onChange={props.onChange} />}
             />
         </FormControl>
     );

--- a/src/components/DataInput/CheckboxInput.tsx
+++ b/src/components/DataInput/CheckboxInput.tsx
@@ -5,6 +5,7 @@ import { Checkbox, FormControl, FormControlLabel } from "@mui/material";
 
 interface Props {
     label?: string;
+    ariaLabel?: string;
     checked?: boolean;
     onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
@@ -14,6 +15,7 @@ const CheckboxInput: React.FC<Props> = (props) => {
         <FormControl>
             <FormControlLabel
                 label={props.label}
+                aria-label={props.ariaLabel}
                 control={<Checkbox checked={props.checked} onChange={props.onChange} />}
             />
         </FormControl>

--- a/src/components/Icons/IconButton.tsx
+++ b/src/components/Icons/IconButton.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+import Icon from "@/components/Icons/Icon";
+import { IconButton } from "@mui/material";
+
+export const StyledIconButton = styled(IconButton)`
+    padding: 0.1rem;
+    margin: 0.1rem;
+`;
+
+export const StyledIcon = styled(Icon)`
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+`;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -85,6 +85,7 @@ export interface ModalProps {
     isOpen: boolean;
     onClose: () => void;
     headerId: string;
+    testId?: string;
     className?: string;
     footer?: ReactNode;
     maxWidth?: Breakpoint;
@@ -101,6 +102,7 @@ const Modal: React.FC<ModalProps> = (props) => {
             open={props.isOpen}
             onClose={props.onClose}
             aria-labelledby={props.headerId}
+            data-testid={props.testId}
             className={props.className}
             fullWidth
             maxWidth={props.maxWidth ? props.maxWidth : "md"}

--- a/src/components/Modal/ModalFormStyles.ts
+++ b/src/components/Modal/ModalFormStyles.ts
@@ -25,3 +25,7 @@ export const ContentDiv = styled.div`
 export const ButtonsDiv = styled.div`
     flex: 0 0 10%;
 `;
+
+export const InputContainer = styled.div`
+    max-width: 10rem;
+`;

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Icon from "@/components/Icons/Icon";
 import {
     DistributeClientFilter,
     DistributeServerFilter,
@@ -13,7 +12,8 @@ import {
     faPenToSquare,
     faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { Checkbox, CircularProgress, IconButton, NoSsr } from "@mui/material";
+import { StyledIcon, StyledIconButton } from "../Icons/IconButton";
+import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
 import styled, { useTheme } from "styled-components";
@@ -209,11 +209,6 @@ const CustomCell = <Data,>({
 
     return element;
 };
-
-const StyledIconButton = styled(IconButton)`
-    padding: 0.1rem;
-    margin: 0.1rem;
-`;
 
 const defaultColumnStyleOptions = {
     grow: 1,
@@ -526,12 +521,6 @@ const EditAndReorderArrowDiv = styled.div`
     width: 100%;
     // this transform is necessary to make the buttons visually consistent with the rest of the table without redesigning the layout
     transform: translateX(-1.2rem);
-`;
-
-const StyledIcon = styled(Icon)`
-    cursor: pointer;
-    padding: 0;
-    margin: 0;
 `;
 
 const TableStyling = styled.div<{


### PR DESCRIPTION
## What's changed
The main functional change is:
- the ability to delete timeslots
Other changes:
- the CC modal code has been extracted from the CC table file
- layout and textual changes

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`


