### PR TITLE
#597 Remove icons from Driver Overview, to avoid error rendering SVG on page breaks

### DIFF
--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -117,25 +117,26 @@ const getActionModal = (
     actionName: ActionName,
     actionModalProps: ActionModalProps
 ): React.ReactElement => {
+    const elementKey = `${actionName}_modal`;
     switch (actionName) {
         case "Change Packing Date":
-            return <DateChangeModal {...actionModalProps} />;
+            return <DateChangeModal key={elementKey} {...actionModalProps} />;
         case "Change Packing Slot":
-            return <SlotChangeModal {...actionModalProps} />;
+            return <SlotChangeModal key={elementKey} {...actionModalProps} />;
         case "Download Shipping Labels":
-            return <ShippingLabelModal {...actionModalProps} />;
+            return <ShippingLabelModal key={elementKey} {...actionModalProps} />;
         case "Download Shopping Lists":
-            return <ShoppingListModal {...actionModalProps} />;
+            return <ShoppingListModal key={elementKey} {...actionModalProps} />;
         case "Download Driver Overview":
-            return <DriverOverviewModal {...actionModalProps} />;
+            return <DriverOverviewModal key={elementKey} {...actionModalProps} />;
         case "Generate Map":
-            return <GenerateMapModal {...actionModalProps} />;
+            return <GenerateMapModal key={elementKey} {...actionModalProps} />;
         case "Download Day Overview":
-            return <DayOverviewModal {...actionModalProps} />;
+            return <DayOverviewModal key={elementKey} {...actionModalProps} />;
         case "Delete Parcel":
-            return <DeleteParcelModal {...actionModalProps} />;
+            return <DeleteParcelModal key={elementKey} {...actionModalProps} />;
         case "Download Signposting Report":
-            return <SignPostingReportModal {...actionModalProps} />;
+            return <SignPostingReportModal key={elementKey} {...actionModalProps} />;
     }
 };
 

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -248,10 +248,10 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
                             <Text style={styles.h1text}>
                                 {data.driverName ?? displayNameForNullDriverName}
                             </Text>
-                        </View>{" "}
+                        </View>
                         <View style={styles.infoColumn}>
                             <Text style={styles.h1text}>{formatDate(data.date)}</Text>
-                        </View>{" "}
+                        </View>
                     </View>
                     {/* eslint-disable-next-line -- needed to remove the need for alt text on the logo */}
                     <Image src="/logo.png" style={styles.logoStyling}></Image>

--- a/src/pdf/DriverOverview/DriverOverviewPdf.tsx
+++ b/src/pdf/DriverOverview/DriverOverviewPdf.tsx
@@ -3,8 +3,6 @@
 import React from "react";
 import { Text, Document, Page, View, StyleSheet, Image } from "@react-pdf/renderer";
 import { displayNameForNullDriverName, formatDate } from "@/common/format";
-import { faTruck, faShoePrints, IconDefinition } from "@fortawesome/free-solid-svg-icons";
-import FontAwesomeIconPdfComponent from "@/pdf/FontAwesomeIconPdfComponent";
 import {
     DriverOverviewRowData,
     DriverOverviewTablesData,
@@ -24,12 +22,13 @@ interface DriverOverviewCardProps {
 const styles = StyleSheet.create({
     container: {
         padding: 25,
+        paddingBottom: 40,
         alignItems: "center",
         fontFamily: "Helvetica",
     },
     fixedFooter: {
         position: "absolute",
-        bottom: "5px",
+        bottom: "20px",
         fontSize: "10px",
         textAlign: "center",
     },
@@ -199,18 +198,17 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
 
     const createTable = (
         tableName: string | null,
-        icon: IconDefinition,
         rows: DriverOverviewRowData[]
     ): React.JSX.Element => {
         return (
             <View style={styles.tableContainer}>
                 <View fixed>
+                    {/* react-pdf has a bug rendering SVGs that are on a page break, so the delivery/collection icon has been removed
+                     * https://github.com/diegomura/react-pdf/issues/1853#issuecomment-2573870127 (although that issue is closed, the bug still occurs)
+                     */}
                     {tableName && (
                         <View style={[styles.tableTitle, styles.flexRow]}>
                             <Text>{tableName} </Text>
-                            <FontAwesomeIconPdfComponent
-                                faIcon={icon}
-                            ></FontAwesomeIconPdfComponent>
                         </View>
                     )}
                     <View style={[styles.flexColumn, { width: "100%" }]}>
@@ -226,13 +224,11 @@ const DriverOverviewCard: React.FC<DriverOverviewCardProps> = ({ data }) => {
         return <View style={styles.tableContainer}>{sectionTables}</View>;
     };
 
-    const deliveriesSection = createSection([
-        createTable("Deliveries", faTruck, data.tableData.deliveries),
-    ]);
+    const deliveriesSection = createSection([createTable("Deliveries", data.tableData.deliveries)]);
 
     const collectionsSection = createSection(
         data.tableData.collections.map((ccData) =>
-            createTable(ccData.collectionCentreName, faShoePrints, ccData.rowData)
+            createTable(ccData.collectionCentreName, ccData.rowData)
         )
     );
 


### PR DESCRIPTION
## What's changed
react-pdf fails to render an SVG over a page break (error: "Unsupported number: Infinity"), so I've removed the icons from the table headers. Also increased the spacing at the bottom of the pages and the footer placement.



