### PR TITLE
#626 #623 dietary and cooking changes

### DIFF
--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -17,7 +17,7 @@ const AddClients: () => React.ReactElement = () => {
         numberOfChildren: 0,
         children: [],
         listType: null,
-        cookingFacilities: {},
+        cookingFacilities: null,
         dietaryRequirements: null,
         hygieneProductsTampons: null,
         hygieneProductsPads: null,

--- a/src/app/clients/edit/[id]/autofill.ts
+++ b/src/app/clients/edit/[id]/autofill.ts
@@ -33,7 +33,10 @@ const autofill = (
         numberOfChildren: children.length,
         children: children,
         listType: clientData.default_list,
-        cookingFacilities: arrayToBooleanGroup(clientData.cooking_facilities ?? []),
+        cookingFacilities:
+            clientData.cooking_facilities !== null
+                ? arrayToBooleanGroup(clientData.cooking_facilities)
+                : null,
         dietaryRequirements:
             clientData.dietary_requirements !== null
                 ? arrayToBooleanGroup(clientData.dietary_requirements)

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -62,7 +62,7 @@ export interface ClientFields extends Fields {
     children: Person[];
     numberOfChildren: number;
     listType: ListType | null;
-    cookingFacilities: BooleanGroup;
+    cookingFacilities: BooleanGroup | null;
     dietaryRequirements: BooleanGroup | null;
     hygieneProductsTampons: string | null;
     hygieneProductsPads: string | null;

--- a/src/app/clients/form/formSections/CookingFacilitiesCard.tsx
+++ b/src/app/clients/form/formSections/CookingFacilitiesCard.tsx
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
 import { checkboxGroupToArray, onChangeCheckboxInGroup } from "@/components/Form/formFunctions";
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
+import { Checkbox, FormControlLabel } from "@mui/material";
+import { FormElementWithSpacing } from "@/components/Form/formStyling";
 
 export const cookingFacilitiesOptions: string[] = [
     "Microwave",
@@ -19,21 +21,48 @@ export const cookingFacilitiesLabelsAndKeys: [string, string][] = cookingFacilit
 );
 
 const CookingFacilitiesCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
+    const [unknownCookingFacilities, setUnknownCookingFacilities] = useState(
+        fields["cookingFacilities"] === null
+    );
+
+    const handleCheckCheckboxForUnknown = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        setUnknownCookingFacilities(event.target.checked);
+
+        fieldSetter({ cookingFacilities: null });
+    };
+
     return (
         <GenericFormCard
             title="Cooking Facilities"
             required={false}
             text="What cooking facilities does the client have? For 'Other', put details in the 'Extra Information' section."
         >
-            <CheckboxGroupInput
-                labelsAndKeys={cookingFacilitiesLabelsAndKeys}
-                onChange={onChangeCheckboxInGroup(
-                    fieldSetter,
-                    fields.cookingFacilities,
-                    "cookingFacilities"
-                )}
-                checkedKeys={checkboxGroupToArray(fields.cookingFacilities)}
+            <FormControlLabel
+                control={
+                    <Checkbox
+                        checked={unknownCookingFacilities}
+                        onChange={handleCheckCheckboxForUnknown}
+                    />
+                }
+                label="Don't Know"
             />
+            <FormElementWithSpacing>
+                <CheckboxGroupInput
+                    groupLabel="Tick all that apply"
+                    labelsAndKeys={cookingFacilitiesLabelsAndKeys}
+                    onChange={onChangeCheckboxInGroup(
+                        fieldSetter,
+                        fields.cookingFacilities ?? {},
+                        "cookingFacilities"
+                    )}
+                    checkedKeys={
+                        fields.cookingFacilities
+                            ? checkboxGroupToArray(fields.cookingFacilities)
+                            : []
+                    }
+                    disabled={!!unknownCookingFacilities}
+                />
+            </FormElementWithSpacing>
         </GenericFormCard>
     );
 };

--- a/src/app/clients/form/formSections/DietaryRequirementCard.tsx
+++ b/src/app/clients/form/formSections/DietaryRequirementCard.tsx
@@ -13,6 +13,7 @@ export const dietaryRequirementOptions: string[] = [
     "Ginger",
     "Chillies",
     "Spices",
+    "Eggs",
     "Bread",
     "Tea",
     "Coffee",

--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -40,7 +40,10 @@ export const formatClientRecord = (
         address_county: fields.addressCounty,
         address_postcode: fields.addressPostcode,
         default_list: fields.listType as ListType,
-        cooking_facilities: checkboxGroupToArray(fields.cookingFacilities),
+        cooking_facilities:
+            fields.cookingFacilities !== null
+                ? checkboxGroupToArray(fields.cookingFacilities)
+                : null,
         dietary_requirements:
             fields.dietaryRequirements !== null
                 ? checkboxGroupToArray(fields.dietaryRequirements)


### PR DESCRIPTION
## What's changed
Client form changes for 2 tickets: dietary requirements and cooking facilities. No DB change necessary.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
