### PR TITLE
#614 Refactor status logic for Action & Status modals

### DIFF
--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -30,7 +30,7 @@ import { DbClientRow } from "@/databaseUtils";
 import { clientIdParam } from "./constants";
 import { getIsClientActiveErrorMessage, getDeleteClientErrorMessage } from "./format";
 import { getClientParcelsDetails } from "../getClientParcelsData";
-import { saveParcelStatus } from "@/app/parcels/ActionBar/Statuses";
+import { saveParcelStatus } from "@/app/parcels/ActionBar/saveStatus";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
 import FloatingToast from "@/components/FloatingToast";
 

--- a/src/app/clients/clientsTable/format.ts
+++ b/src/app/clients/clientsTable/format.ts
@@ -1,6 +1,6 @@
 import { DeleteClientError } from "../deleteClient";
 import { IsClientActiveError } from "../getExpandedClientDetails";
-import { SaveParcelStatusError } from "@/app/parcels/ActionBar/Statuses";
+import { SaveParcelStatusError } from "@/app/parcels/ActionBar/saveStatus";
 
 export const getIsClientActiveErrorMessage = (error: IsClientActiveError): string => {
     switch (error.type) {

--- a/src/app/parcels/ActionBar/ActionAndStatusBar.test.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusBar.test.tsx
@@ -6,7 +6,6 @@ import ActionAndStatusBar from "@/app/parcels/ActionBar/ActionAndStatusBar";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import StyleManager from "@/app/themes";
 import Localization from "@/app/Localization";
-import { SaveParcelStatusResult } from "@/app/parcels/ActionBar/Statuses";
 
 jest.mock("@/supabaseClient", () => {
     return { default: jest.fn() };
@@ -104,9 +103,8 @@ export const mockData: ParcelsTableRow[] = [
 
 describe("Parcels - Action and Status Bar", () => {
     let parcelIds: string[] = ["123456789", "123456aaaa789"];
-    const onDeleteParcels = async (): Promise<SaveParcelStatusResult> => {
+    const postActivityCallback = (): void => {
         parcelIds = [];
-        return { error: null };
     };
 
     beforeEach(() => {
@@ -118,7 +116,7 @@ describe("Parcels - Action and Status Bar", () => {
                         fetchSelectedParcels={async () =>
                             await mockData.filter((parcel) => parcelIds.includes(parcel.parcelId))
                         }
-                        updateParcelStatuses={onDeleteParcels}
+                        postCheckedParcelActivity={postActivityCallback}
                     />
                 </StyleManager>
             </Localization>

--- a/src/app/parcels/ActionBar/ActionAndStatusBar.tsx
+++ b/src/app/parcels/ActionBar/ActionAndStatusBar.tsx
@@ -5,23 +5,14 @@ import styled from "styled-components";
 import Button from "@mui/material/Button";
 import { ParcelsTableRow } from "../parcelsTable/types";
 import Alert from "@mui/material/Alert";
-import Statuses, { StatusType, SaveParcelStatusResult } from "@/app/parcels/ActionBar/Statuses";
+import Statuses from "@/app/parcels/ActionBar/Statuses";
 import Actions from "@/app/parcels/ActionBar/Actions";
 import { ArrowDropDown } from "@mui/icons-material";
-import { Dayjs } from "dayjs";
 
 export interface ActionAndStatusBarProps {
     fetchSelectedParcels: () => Promise<ParcelsTableRow[]>;
-    updateParcelStatuses: UpdateParcelStatuses;
+    postCheckedParcelActivity: () => void;
 }
-
-export type UpdateParcelStatuses = (
-    parcels: ParcelsTableRow[],
-    newStatus: StatusType,
-    statusEventData?: string,
-    action?: string,
-    date?: Dayjs
-) => Promise<SaveParcelStatusResult>;
 
 const AlertBox = styled.div`
     display: block;
@@ -39,13 +30,14 @@ const ActionAndStatusBar: React.FC<ActionAndStatusBarProps> = (props) => {
         <>
             <Statuses
                 fetchSelectedParcels={props.fetchSelectedParcels}
+                postSuccessCallback={props.postCheckedParcelActivity}
                 statusAnchorElement={statusAnchorElement}
                 setStatusAnchorElement={setStatusAnchorElement}
                 setModalError={setModalError}
             />
             <Actions
                 fetchSelectedParcels={props.fetchSelectedParcels}
-                updateParcelStatuses={props.updateParcelStatuses}
+                postSuccessCallback={props.postCheckedParcelActivity}
                 actionAnchorElement={actionAnchorElement}
                 setActionAnchorElement={setActionAnchorElement}
                 setModalError={setModalError}

--- a/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
@@ -77,65 +77,66 @@ export const packingDateOrSlotUpdate = async (
     }
 
     const { data: parcelData, error: fetchError } = await fetchParcel(parcel.parcelId, supabase);
-    if (updateResponse.error || updateResponse.count === 0) {
-        if (fetchError) {
-            const logId = await logErrorReturnLogId("Error with fetching parcel data", fetchError);
-            await sendAuditLog({
-                action: action,
-                content: {
-                    parcelDetails: {
-                        client_id: parcel.clientId,
-                        packing_date: parcel.packingDate?.toString(),
-                        packing_slot: parcel.packingSlot,
-                        voucher_number: parcel.voucherNumber,
-                        collection_centre: parcel.deliveryCollection.collectionCentreName,
-                        collection_datetime: parcel.collectionDatetime?.toString(),
-                    },
-                },
-                wasSuccess: false,
-                logId,
-            });
-            return { parcelId: parcel.parcelId, error: fetchError };
-        }
 
-        const parcelRecord = {
-            client_id: parcelData.client_id,
-            packing_date: parcelData.packing_date,
-            packing_slot: parcelData.packing_slot?.primary_key,
-            voucher_number: parcelData.voucher_number,
-            collection_centre: parcelData.collection_centre?.primary_key,
-            collection_datetime: parcelData.collection_datetime,
-            last_updated: parcelData.last_updated,
-        };
-
-        const auditLog = {
+    if (fetchError) {
+        const logId = await logErrorReturnLogId("Error with fetching parcel data", fetchError);
+        await sendAuditLog({
             action: action,
-            content: { parcelDetails: parcelRecord, count: updateResponse.count },
-            clientId: parcel.clientId,
-            parcelId: parcel.parcelId,
-        } as const satisfies Partial<AuditLog>;
-
-        if (updateResponse.error) {
-            const logId = await logErrorReturnLogId(
-                "Error with update: parcel data",
-                updateResponse.error
-            );
-            await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-            return {
-                parcelId: null,
-                error: { type: "failedToUpdateParcel", logId } as UpdateParcelError,
-            };
-        }
-
-        if (updateResponse.count === 0) {
-            const logId = await logWarningReturnLogId("Concurrent editing of parcel");
-            await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-            return {
-                parcelId: null,
-                error: { type: "concurrentUpdateConflict", logId } as UpdateParcelError,
-            };
-        }
+            content: {
+                parcelDetails: {
+                    client_id: parcel.clientId,
+                    packing_date: parcel.packingDate?.toString(),
+                    packing_slot: parcel.packingSlot,
+                    voucher_number: parcel.voucherNumber,
+                    collection_centre: parcel.deliveryCollection.collectionCentreName,
+                    collection_datetime: parcel.collectionDatetime?.toString(),
+                },
+            },
+            wasSuccess: false,
+            logId,
+        });
+        return { parcelId: parcel.parcelId, error: fetchError };
     }
+
+    const parcelRecord = {
+        client_id: parcelData.client_id,
+        packing_date: parcelData.packing_date,
+        packing_slot: parcelData.packing_slot?.primary_key,
+        voucher_number: parcelData.voucher_number,
+        collection_centre: parcelData.collection_centre?.primary_key,
+        collection_datetime: parcelData.collection_datetime,
+        last_updated: parcelData.last_updated,
+    };
+
+    const auditLog = {
+        action: action,
+        content: { parcelDetails: parcelRecord, count: updateResponse.count },
+        clientId: parcel.clientId,
+        parcelId: parcel.parcelId,
+    } as const satisfies Partial<AuditLog>;
+
+    if (updateResponse.error) {
+        const logId = await logErrorReturnLogId(
+            "Error with update: parcel data",
+            updateResponse.error
+        );
+        await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
+        return {
+            parcelId: null,
+            error: { type: "failedToUpdateParcel", logId } as UpdateParcelError,
+        };
+    }
+
+    if (updateResponse.count === 0) {
+        const logId = await logWarningReturnLogId("Concurrent editing of parcel");
+        await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
+        return {
+            parcelId: null,
+            error: { type: "concurrentUpdateConflict", logId } as UpdateParcelError,
+        };
+    }
+
+    sendAuditLog({ ...auditLog, wasSuccess: true });
 
     return { parcelId: parcel.parcelId, error: null };
 };

--- a/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
@@ -9,7 +9,6 @@ import { Button } from "@mui/material";
 import SelectedParcelsOverview from "../SelectedParcelsOverview";
 import SingleDateInput, { DateInputProps } from "@/components/DateInputs/SingleDateInput";
 import dayjs, { Dayjs } from "dayjs";
-import { getStatusErrorMessageWithLogId } from "../Statuses";
 import { getDbDate } from "@/common/format";
 import { getUpdateErrorMessage, packingDateOrSlotUpdate } from "./CommonDateAndSlot";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
@@ -93,12 +92,6 @@ const DateChangeModal: React.FC<ActionModalProps> = (props) => {
             })
         );
 
-        const { error: statusUpdateError } = await props.updateParcelStatuses(
-            props.selectedParcels,
-            "Packing Date Changed",
-            `new packing date: ${newPackingDate}`,
-            "change packing date"
-        );
         if (
             !packingDateUpdateErrors.every(
                 (packingDateUpdateError) => packingDateUpdateError.error === null
@@ -109,10 +102,9 @@ const DateChangeModal: React.FC<ActionModalProps> = (props) => {
                     .map((packingDateUpdateError) => getUpdateErrorMessage(packingDateUpdateError))
                     .join("")
             );
-        } else if (statusUpdateError) {
-            setErrorMessage(getStatusErrorMessageWithLogId(statusUpdateError));
         } else {
             setSuccessMessage(`Packing Date Changed to ${newPackingDate}`);
+            props.postSuccessCallback();
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
@@ -68,6 +68,7 @@ const DayOverviewModal: React.FC<ActionModalProps> = (props) => {
             wasSuccess: true,
             content: { parcelIds: props.selectedParcels.map((parcel) => parcel.parcelId) },
         });
+        props.postSuccessCallback();
     };
 
     const onPdfCreationFailed = (pdfError: DayOverviewPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
@@ -13,6 +13,7 @@ import { ParcelsTableRow } from "../../parcelsTable/types";
 import DeleteButton from "@/components/Buttons/DeleteButton";
 import DeleteConfirmationDialog from "@/components/Modal/DeleteConfirmationDialog";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
+import { saveDbParcelStatus } from "../saveStatus";
 
 interface ContentProps {
     onClose: () => void;
@@ -80,11 +81,12 @@ const DeleteParcelModal: React.FC<ActionModalProps> = (props) => {
     const numberOfParcelsToDelete = props.selectedParcels.length;
 
     const onDeleteParcels = async (): Promise<void> => {
-        const { error } = await props.updateParcelStatuses(props.selectedParcels, "Parcel Deleted");
+        const { error } = await saveDbParcelStatus(props.selectedParcels, "Parcel Deleted");
         if (error) {
             setErrorMessage(getStatusErrorMessageWithLogId(error));
         } else {
             setSuccessMessage(`${numberOfParcelsToDelete > 1 ? "Parcels" : "Parcel"} Deleted`);
+            props.postSuccessCallback();
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
@@ -13,7 +13,7 @@ import { ParcelsTableRow } from "../../parcelsTable/types";
 import DeleteButton from "@/components/Buttons/DeleteButton";
 import DeleteConfirmationDialog from "@/components/Modal/DeleteConfirmationDialog";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
-import { saveDbParcelStatus } from "../saveStatus";
+import { saveParcelTableRowsStatus } from "../saveStatus";
 
 interface ContentProps {
     onClose: () => void;
@@ -81,7 +81,7 @@ const DeleteParcelModal: React.FC<ActionModalProps> = (props) => {
     const numberOfParcelsToDelete = props.selectedParcels.length;
 
     const onDeleteParcels = async (): Promise<void> => {
-        const { error } = await saveDbParcelStatus(props.selectedParcels, "Parcel Deleted");
+        const { error } = await saveParcelTableRowsStatus(props.selectedParcels, "Parcel Deleted");
         if (error) {
             setErrorMessage(getStatusErrorMessageWithLogId(error));
         } else {

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -17,6 +17,7 @@ import { sendAuditLog } from "@/server/auditLog";
 import { displayNameForNullDriverName } from "@/common/format";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
+import { saveDbParcelStatus } from "../saveStatus";
 
 interface DriverOverviewInputProps {
     onDateChange: (newDate: Dayjs | null) => void;
@@ -164,7 +165,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
     };
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await props.updateParcelStatuses(
+        const { error } = await saveDbParcelStatus(
             props.selectedParcels,
             "Out for Delivery",
             `with ${driverName ?? displayNameForNullDriverName}`,
@@ -185,6 +186,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
                 driverName: driverName,
             },
         });
+        props.postSuccessCallback();
     };
 
     const onPdfCreationFailed = (pdfError: DriverOverviewError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -17,7 +17,7 @@ import { sendAuditLog } from "@/server/auditLog";
 import { displayNameForNullDriverName } from "@/common/format";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
-import { saveDbParcelStatus } from "../saveStatus";
+import { saveParcelTableRowsStatus } from "../saveStatus";
 
 interface DriverOverviewInputProps {
     onDateChange: (newDate: Dayjs | null) => void;
@@ -165,7 +165,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
     };
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await saveDbParcelStatus(
+        const { error } = await saveParcelTableRowsStatus(
             props.selectedParcels,
             "Out for Delivery",
             `with ${driverName ?? displayNameForNullDriverName}`,

--- a/src/app/parcels/ActionBar/ActionModals/GeneralActionModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GeneralActionModal.tsx
@@ -3,13 +3,12 @@ import { ParcelsTableRow } from "../../parcelsTable/types";
 import Modal from "@/components/Modal/Modal";
 import { ActionName } from "../Actions";
 import React from "react";
-import { UpdateParcelStatuses } from "../ActionAndStatusBar";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
 
 export interface ActionModalProps extends Omit<React.ComponentProps<typeof Modal>, "children"> {
     selectedParcels: ParcelsTableRow[];
-    updateParcelStatuses: UpdateParcelStatuses;
+    postSuccessCallback: () => void;
     actionName: ActionName;
 }
 

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -10,6 +10,7 @@ interface ContentProps {
     setActionCompleted: (completed: boolean) => void;
     mapsLinkForSelectedParcels: string;
     setSuccessMessage: (message: string) => void;
+    postSuccessCallback: () => void;
 }
 
 const GenerateMapModalContent: React.FC<ContentProps> = ({
@@ -18,6 +19,7 @@ const GenerateMapModalContent: React.FC<ContentProps> = ({
     setActionCompleted,
     mapsLinkForSelectedParcels,
     setSuccessMessage,
+    postSuccessCallback,
 }) => {
     const generateMapButtonFocusRef = useRef<HTMLButtonElement>(null);
 
@@ -40,6 +42,7 @@ const GenerateMapModalContent: React.FC<ContentProps> = ({
                 openInNewTab(mapsLinkForSelectedParcels);
                 setSuccessMessage("Map Generated");
                 setActionCompleted(true);
+                postSuccessCallback();
             }}
             ref={generateMapButtonFocusRef}
         >
@@ -86,6 +89,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
                     setActionCompleted={setActionCompleted}
                     mapsLinkForSelectedParcels={mapsLinkForSelectedParcels}
                     setSuccessMessage={setSuccessMessage}
+                    postSuccessCallback={props.postSuccessCallback}
                 />
             )}
         </GeneralActionModal>

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -17,6 +17,7 @@ import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadW
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
+import { saveDbParcelStatus } from "../saveStatus";
 
 interface ShippingLabelsInputProps {
     onLabelQuantityChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -141,7 +142,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
     );
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await props.updateParcelStatuses(
+        const { error } = await saveDbParcelStatus(
             props.selectedParcels,
             "Shipping Labels Downloaded",
             labelQuantity.toString()
@@ -159,6 +160,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
                 labelQuantity: labelQuantity,
             },
         });
+        props.postSuccessCallback();
     };
 
     const onPdfCreationFailed = (pdfError: ShippingLabelError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -17,7 +17,7 @@ import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadW
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
-import { saveDbParcelStatus } from "../saveStatus";
+import { saveParcelTableRowsStatus } from "../saveStatus";
 
 interface ShippingLabelsInputProps {
     onLabelQuantityChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -142,7 +142,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
     );
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await saveDbParcelStatus(
+        const { error } = await saveParcelTableRowsStatus(
             props.selectedParcels,
             "Shipping Labels Downloaded",
             labelQuantity.toString()

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -10,6 +10,7 @@ import { sendAuditLog } from "@/server/auditLog";
 import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadWarning";
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";
 import { ParcelsTableRow } from "../../parcelsTable/types";
+import { saveDbParcelStatus } from "../saveStatus";
 
 interface ContentProps {
     selectedParcels: ParcelsTableRow[];
@@ -93,7 +94,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
     const parcelIds = props.selectedParcels.map((parcel) => parcel.parcelId);
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await props.updateParcelStatuses(
+        const { error } = await saveDbParcelStatus(
             props.selectedParcels,
             "Shopping List Downloaded"
         );
@@ -107,6 +108,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
             wasSuccess: true,
             content: { parcelIds: parcelIds },
         });
+        props.postSuccessCallback();
     };
 
     const onPdfCreationFailed = (pdfError: ShoppingListPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -10,7 +10,7 @@ import { sendAuditLog } from "@/server/auditLog";
 import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadWarning";
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";
 import { ParcelsTableRow } from "../../parcelsTable/types";
-import { saveDbParcelStatus } from "../saveStatus";
+import { saveParcelTableRowsStatus } from "../saveStatus";
 
 interface ContentProps {
     selectedParcels: ParcelsTableRow[];
@@ -94,7 +94,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
     const parcelIds = props.selectedParcels.map((parcel) => parcel.parcelId);
 
     const onPdfCreationCompleted = async (): Promise<void> => {
-        const { error } = await saveDbParcelStatus(
+        const { error } = await saveParcelTableRowsStatus(
             props.selectedParcels,
             "Shopping List Downloaded"
         );

--- a/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
@@ -87,6 +87,7 @@ const SignPostingReportModal: React.FC<ActionModalProps> = (props) => {
                 toDate: dateRange.to.toString(),
             },
         });
+        props.postSuccessCallback();
     };
 
     const onFileCreationFailed = (csvError: FetchSignpostingReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
@@ -7,7 +7,6 @@ import GeneralActionModal, {
 } from "./GeneralActionModal";
 import { Button } from "@mui/material";
 import SelectedParcelsOverview from "../SelectedParcelsOverview";
-import { getStatusErrorMessageWithLogId } from "../Statuses";
 import supabase from "@/supabaseClient";
 import { PackingSlotsLabelsAndValues, fetchPackingSlotsInfo } from "@/common/fetch";
 import { UncontrolledSelect } from "@/components/DataInput/DropDownSelect";
@@ -112,12 +111,6 @@ const SlotChangeModal: React.FC<ActionModalProps> = (props) => {
         const newPackingSlotText: string =
             packingSlots.find((packingSlot) => packingSlot[1] === slot)?.at(0) ?? "";
 
-        const { error: statusUpdateError } = await props.updateParcelStatuses(
-            props.selectedParcels,
-            "Packing Slot Changed",
-            `new packing slot: ${newPackingSlotText}`,
-            "change packing slot"
-        );
         if (
             !packingSlotUpdateErrors.every(
                 (packingSlotUpdateError) => packingSlotUpdateError.error === null
@@ -128,10 +121,9 @@ const SlotChangeModal: React.FC<ActionModalProps> = (props) => {
                     .map((packingSlotUpdateError) => getUpdateErrorMessage(packingSlotUpdateError))
                     .join("")
             );
-        } else if (statusUpdateError) {
-            setErrorMessage(getStatusErrorMessageWithLogId(statusUpdateError));
         } else {
             setSuccessMessage(`Packing Slot Changed to ${newPackingSlotText}`);
+            props.postSuccessCallback();
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/Actions.tsx
+++ b/src/app/parcels/ActionBar/Actions.tsx
@@ -5,7 +5,6 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { ParcelsTableRow } from "../parcelsTable/types";
 import { ActionModalProps } from "./ActionModals/GeneralActionModal";
-import { UpdateParcelStatuses } from "./ActionAndStatusBar";
 import { allRoles, organisationRoles, RoleUpdateContext } from "@/app/roles";
 import { UserRole } from "@/databaseUtils";
 import DayOverviewModal from "./ActionModals/DayOverviewModal";
@@ -107,7 +106,7 @@ const availableActions: ActionTypes[] = [
 
 interface Props {
     fetchSelectedParcels: () => Promise<ParcelsTableRow[]>;
-    updateParcelStatuses: UpdateParcelStatuses;
+    postSuccessCallback: () => void;
     actionAnchorElement: HTMLElement | null;
     setActionAnchorElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
     setModalError: React.Dispatch<React.SetStateAction<string | null>>;
@@ -142,7 +141,7 @@ const getActionModal = (
 
 const Actions: React.FC<Props> = ({
     fetchSelectedParcels,
-    updateParcelStatuses,
+    postSuccessCallback,
     actionAnchorElement,
     setActionAnchorElement,
     setModalError,
@@ -204,7 +203,7 @@ const Actions: React.FC<Props> = ({
                         header: modalToDisplay,
                         headerId: "action-modal-header",
                         actionName: modalToDisplay,
-                        updateParcelStatuses: updateParcelStatuses,
+                        postSuccessCallback: postSuccessCallback,
                     })
                 );
             })}

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -9,7 +9,7 @@ import StatusesModal from "@/app/parcels/ActionBar/StatusesModal";
 import { ParcelStatus } from "@/databaseUtils";
 import { fetchParcelStatuses } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import {
-    saveDbParcelStatus,
+    saveParcelTableRowsStatus,
     SaveParcelStatusError,
     StatusType,
 } from "@/app/parcels/ActionBar/saveStatus";
@@ -83,7 +83,7 @@ const Statuses: React.FC<Props> = ({
             setServerErrorMessage("Chosen status was not found.");
             return;
         }
-        const { error } = await saveDbParcelStatus(
+        const { error } = await saveParcelTableRowsStatus(
             selectedParcels,
             selectedStatus,
             null,

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -1,18 +1,18 @@
 "use client";
 
-import supabase from "@/supabaseClient";
 import React, { useEffect, useState } from "react";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import dayjs, { Dayjs } from "dayjs";
+import { Dayjs } from "dayjs";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import StatusesModal from "@/app/parcels/ActionBar/StatusesModal";
-import { logErrorReturnLogId } from "@/logger/logger";
-import { sendAuditLog } from "@/server/auditLog";
 import { ParcelStatus } from "@/databaseUtils";
 import { fetchParcelStatuses } from "@/app/parcels/parcelsTable/fetchParcelTableData";
-
-export type StatusType = ParcelStatus[][number];
+import {
+    saveDbParcelStatus,
+    SaveParcelStatusError,
+    StatusType,
+} from "@/app/parcels/ActionBar/saveStatus";
 
 const nonMenuStatuses: StatusType[] = [
     "Packing Date Changed", //Generated when packing date is changed
@@ -25,71 +25,9 @@ const nonMenuStatuses: StatusType[] = [
 
 const userFacingLabelForEmptyStatus = "No Status";
 
-type SaveParcelStatusErrorType = "eventInsertionFailed";
-
-export interface SaveParcelStatusError {
-    type: SaveParcelStatusErrorType;
-    logId: string;
-}
-
-export interface DeleteClientError {
-    type: SaveParcelStatusErrorType;
-    logId: string;
-}
-
-export type SaveParcelStatusResult = { error: null | SaveParcelStatusError };
-
-export const saveParcelStatus = async (
-    parcelIds: string[],
-    statusName: StatusType,
-    statusEventData?: string | null,
-    action?: string,
-    date?: Dayjs
-): Promise<SaveParcelStatusResult> => {
-    const timestamp = (date ?? dayjs()).toISOString();
-    const eventsToInsert = parcelIds
-        .map((parcelId: string) => {
-            return {
-                new_parcel_status: statusName,
-                parcel_id: parcelId,
-                event_data: statusEventData,
-                timestamp,
-            };
-        })
-        .flat();
-
-    const auditLogs = eventsToInsert.map((eventToInsert) => ({
-        action: action ?? "change parcel status",
-        content: { eventToInsert },
-        parcelId: eventToInsert.parcel_id,
-    }));
-
-    const { data, error } = await supabase
-        .from("events")
-        .insert(eventsToInsert)
-        .select("event_id:primary_key, parcel_id");
-
-    if (error || !data) {
-        const logId = await logErrorReturnLogId("Error with insert: Status event", error);
-        auditLogs.forEach(
-            (auditLog) => void sendAuditLog({ ...auditLog, wasSuccess: false, logId })
-        );
-        return { error: { type: "eventInsertionFailed", logId: logId } };
-    }
-
-    auditLogs.forEach((auditLog) =>
-        sendAuditLog({
-            ...auditLog,
-            eventId: data.find((event) => auditLog.parcelId === event.parcel_id)?.event_id,
-            wasSuccess: true,
-        })
-    );
-
-    return { error: null };
-};
-
 interface Props {
     fetchSelectedParcels: () => Promise<ParcelsTableRow[]>;
+    postSuccessCallback: () => void;
     statusAnchorElement: HTMLElement | null;
     setStatusAnchorElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>;
     setModalError: React.Dispatch<React.SetStateAction<string | null>>;
@@ -110,6 +48,7 @@ const userFacingStatusString = (selectedStatus: StatusType | null): string =>
 
 const Statuses: React.FC<Props> = ({
     fetchSelectedParcels,
+    postSuccessCallback,
     statusAnchorElement,
     setStatusAnchorElement,
     setModalError,
@@ -144,10 +83,8 @@ const Statuses: React.FC<Props> = ({
             setServerErrorMessage("Chosen status was not found.");
             return;
         }
-        const { error } = await saveParcelStatus(
-            selectedParcels.map((parcel: ParcelsTableRow) => {
-                return parcel.parcelId;
-            }),
+        const { error } = await saveDbParcelStatus(
+            selectedParcels,
             selectedStatus,
             null,
             undefined,
@@ -158,6 +95,7 @@ const Statuses: React.FC<Props> = ({
         }
         if (!error) {
             setStatusModal(false);
+            postSuccessCallback();
         }
     };
 

--- a/src/app/parcels/ActionBar/saveStatus.ts
+++ b/src/app/parcels/ActionBar/saveStatus.ts
@@ -16,11 +16,6 @@ export interface SaveParcelStatusError {
     logId: string;
 }
 
-export interface DeleteClientError {
-    type: SaveParcelStatusErrorType;
-    logId: string;
-}
-
 export type SaveParcelStatusResult = { error: null | SaveParcelStatusError };
 
 export const saveParcelStatus = async (

--- a/src/app/parcels/ActionBar/saveStatus.ts
+++ b/src/app/parcels/ActionBar/saveStatus.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import supabase from "@/supabaseClient";
+import dayjs, { Dayjs } from "dayjs";
+import { logErrorReturnLogId } from "@/logger/logger";
+import { sendAuditLog } from "@/server/auditLog";
+import { ParcelStatus } from "@/databaseUtils";
+import { ParcelsTableRow } from "../parcelsTable/types";
+
+export type StatusType = ParcelStatus[][number];
+
+type SaveParcelStatusErrorType = "eventInsertionFailed";
+
+export interface SaveParcelStatusError {
+    type: SaveParcelStatusErrorType;
+    logId: string;
+}
+
+export interface DeleteClientError {
+    type: SaveParcelStatusErrorType;
+    logId: string;
+}
+
+export type SaveParcelStatusResult = { error: null | SaveParcelStatusError };
+
+export const saveParcelStatus = async (
+    parcelIds: string[],
+    statusName: StatusType,
+    statusEventData?: string | null,
+    action?: string,
+    date?: Dayjs
+): Promise<SaveParcelStatusResult> => {
+    const timestamp = (date ?? dayjs()).toISOString();
+    const eventsToInsert = parcelIds
+        .map((parcelId: string) => {
+            return {
+                new_parcel_status: statusName,
+                parcel_id: parcelId,
+                event_data: statusEventData,
+                timestamp,
+            };
+        })
+        .flat();
+
+    const auditLogs = eventsToInsert.map((eventToInsert) => ({
+        action: action ?? "change parcel status",
+        content: { eventToInsert },
+        parcelId: eventToInsert.parcel_id,
+    }));
+
+    const { data, error } = await supabase
+        .from("events")
+        .insert(eventsToInsert)
+        .select("event_id:primary_key, parcel_id");
+
+    if (error || !data) {
+        const logId = await logErrorReturnLogId("Error with insert: Status event", error);
+        auditLogs.forEach(
+            (auditLog) => void sendAuditLog({ ...auditLog, wasSuccess: false, logId })
+        );
+        return { error: { type: "eventInsertionFailed", logId: logId } };
+    }
+
+    auditLogs.forEach((auditLog) =>
+        sendAuditLog({
+            ...auditLog,
+            eventId: data.find((event) => auditLog.parcelId === event.parcel_id)?.event_id,
+            wasSuccess: true,
+        })
+    );
+
+    return { error: null };
+};
+
+export const saveDbParcelStatus = async (
+    parcelRows: ParcelsTableRow[],
+    statusName: StatusType,
+    statusEventData?: string | null,
+    action?: string,
+    date?: Dayjs
+): Promise<SaveParcelStatusResult> => {
+    return saveParcelStatus(
+        parcelRows.map((parcelRow) => parcelRow.parcelId),
+        statusName,
+        statusEventData,
+        action,
+        date
+    );
+};

--- a/src/app/parcels/ActionBar/saveStatus.ts
+++ b/src/app/parcels/ActionBar/saveStatus.ts
@@ -72,7 +72,7 @@ export const saveParcelStatus = async (
     return { error: null };
 };
 
-export const saveDbParcelStatus = async (
+export const saveParcelTableRowsStatus = async (
     parcelRows: ParcelsTableRow[],
     statusName: StatusType,
     statusEventData?: string | null,

--- a/src/app/parcels/format.ts
+++ b/src/app/parcels/format.ts
@@ -1,4 +1,4 @@
-import { StatusType } from "./ActionBar/Statuses";
+import { StatusType } from "./ActionBar/saveStatus";
 
 export const formatEventName = (newStatus: StatusType, eventData: string | null): string =>
     `${newStatus} ${eventData ? ` (${eventData})` : ""}`;

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -9,14 +9,8 @@ import {
 } from "@/app/parcels/parcelsTable/types";
 import supabase from "@/supabaseClient";
 import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
-import {
-    StatusType,
-    saveParcelStatus,
-    SaveParcelStatusResult,
-} from "@/app/parcels/ActionBar/Statuses";
 import buildFilters from "@/app/parcels/parcelsTable/filters";
 import { getSelectedParcelCountMessage } from "@/app/parcels/parcelsTable/format";
-import { Dayjs } from "dayjs";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
 import PreTableControls from "@/app/parcels/parcelsTable/PreTableControls";
 import ParcelsTable from "@/app/parcels/parcelsTable/ParcelsTable";
@@ -64,24 +58,6 @@ const ParcelsPage: React.FC = () => {
         })();
     }, []);
 
-    const updateParcelStatuses = async (
-        parcels: ParcelsTableRow[],
-        newStatus: StatusType,
-        statusEventData?: string,
-        action?: string,
-        date?: Dayjs
-    ): Promise<SaveParcelStatusResult> => {
-        const { error } = await saveParcelStatus(
-            parcels.map((parcel) => parcel.parcelId),
-            newStatus,
-            statusEventData,
-            action,
-            date
-        );
-        setCheckedParcelIds([]);
-        return { error: error };
-    };
-
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
         if (checkedParcelIds.length === 0) {
             return [];
@@ -95,6 +71,10 @@ const ParcelsPage: React.FC = () => {
         );
     };
 
+    const postCheckedParcelActivity = (): void => {
+        setCheckedParcelIds([]);
+    };
+
     return (
         <>
             <PreTableControls
@@ -102,7 +82,7 @@ const ParcelsPage: React.FC = () => {
                 setIsPackingManagerView={setIsPackingManagerView}
                 selectedParcelMessage={selectedParcelMessage}
                 getCheckedParcelsData={getCheckedParcelsData}
-                updateParcelStatuses={updateParcelStatuses}
+                postCheckedParcelActivity={postCheckedParcelActivity}
             />
             {areFiltersLoadingForFirstTime ? (
                 <Centerer>

--- a/src/app/parcels/parcelsTable/PreTableControls.tsx
+++ b/src/app/parcels/parcelsTable/PreTableControls.tsx
@@ -2,21 +2,13 @@ import { ActionsContainer, PreTableControlsContainer } from "@/components/Form/f
 import { Button } from "@mui/material";
 import ActionAndStatusBar from "../ActionBar/ActionAndStatusBar";
 import { ParcelsTableRow } from "./types";
-import { Dayjs } from "dayjs";
-import { SaveParcelStatusResult, StatusType } from "../ActionBar/Statuses";
 
 interface PreTableControlsProps {
     isPackingManagerView: boolean;
     setIsPackingManagerView: (isPackingManagerView: boolean) => void;
     selectedParcelMessage: string | null;
     getCheckedParcelsData: () => Promise<ParcelsTableRow[]>;
-    updateParcelStatuses: (
-        parcels: ParcelsTableRow[],
-        newStatus: StatusType,
-        statusEventData?: string,
-        action?: string,
-        date?: Dayjs
-    ) => Promise<SaveParcelStatusResult>;
+    postCheckedParcelActivity: () => void;
 }
 
 const PreTableControls: React.FC<PreTableControlsProps> = (props) => {
@@ -38,7 +30,7 @@ const PreTableControls: React.FC<PreTableControlsProps> = (props) => {
             <ActionsContainer>
                 <ActionAndStatusBar
                     fetchSelectedParcels={props.getCheckedParcelsData}
-                    updateParcelStatuses={props.updateParcelStatuses}
+                    postCheckedParcelActivity={props.postCheckedParcelActivity}
                 />
             </ActionsContainer>
         </PreTableControlsContainer>

--- a/src/app/parcels/parcelsTable/fetchParcelTableData.ts
+++ b/src/app/parcels/parcelsTable/fetchParcelTableData.ts
@@ -17,7 +17,7 @@ import {
 } from "./types";
 import { checkForCongestionCharge, CongestionChargeReturnType } from "@/common/congestionCharges";
 import convertParcelDbtoParcelRow from "./convertParcelDBtoParcelRow";
-import { StatusType } from "@/app/parcels/ActionBar/Statuses";
+import { StatusType } from "@/app/parcels/ActionBar/saveStatus";
 import { defaultParcelsSort, defaultParcelsSortConfig } from "./sortableColumns";
 import { DbQuery } from "@/components/Tables/Filters";
 


### PR DESCRIPTION
## What's changed
The requirement for the ticket is just to deselect all parcels after status is set. This ended up with a fairly substantial refactoring of the status handling code for Actions and Statuses, but that refactoring revealed some inconsistencies & bugs, so it was worth it.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

