### PR TITLE
#613: Add Status setting dropmenu to Parcel Modal

### DIFF
--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -20,6 +20,7 @@ const DeletedText = styled.div`
 
 interface Props {
     parcelId: string | null;
+    refreshCallback?: (refreshFunction: () => void) => void;
 }
 
 const sortByTimestampWithMostRecentFirst = (events: EventTableRow[]): EventTableRow[] => {
@@ -37,9 +38,10 @@ function getErrorMessageForExpandedParcelDetailsError(
     }
 }
 
-const ExpandedParcelDetailsView = ({ parcelId }: Props): ReactElement => {
+const ExpandedParcelDetailsView = ({ parcelId, refreshCallback }: Props): ReactElement => {
     const [parcelDetails, setParcelDetails] = useState<ExpandedParcelDetails | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [refreshTrigger, setRefreshTrigger] = useState(0);
 
     const fetchAndSetParcelDetails = useCallback(async (): Promise<void> => {
         if (!parcelId) {
@@ -60,7 +62,17 @@ const ExpandedParcelDetailsView = ({ parcelId }: Props): ReactElement => {
 
     useEffect(() => {
         void fetchAndSetParcelDetails();
-    }, [fetchAndSetParcelDetails]);
+    }, [fetchAndSetParcelDetails, refreshTrigger]);
+
+    const refreshParcelDetails = (): void => {
+        setRefreshTrigger((prev) => prev + 1);
+    };
+
+    useEffect(() => {
+        if (refreshCallback) {
+            refreshCallback(refreshParcelDetails);
+        }
+    }, [refreshCallback]);
 
     return (
         <>

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,16 +1,21 @@
+import supabase from "@/supabaseClient";
+import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Modal from "@/components/Modal/Modal";
 import { Centerer, ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
-import { Suspense } from "react";
+import { Suspense, useRef, useState } from "react";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
 import ExpandedParcelDetailsFallback from "../ExpandedParcelDetailsFallback";
 import LinkButton from "@/components/Buttons/LinkButton";
 import Icon from "@/components/Icons/Icon";
 import { faBoxArchive } from "@fortawesome/free-solid-svg-icons";
 import { useTheme } from "styled-components";
-import { SelectedClientDetails } from "./types";
+import { ParcelsTableRow, SelectedClientDetails } from "./types";
 import { useRouter } from "next/navigation";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
+import { Button } from "@mui/material";
+import { ArrowDropDown } from "@mui/icons-material";
+import Statuses from "../ActionBar/Statuses";
 
 interface ParcelsModalProps {
     modalIsOpen: boolean;
@@ -18,6 +23,7 @@ interface ParcelsModalProps {
     selectedParcelId: string | null;
     selectedClientDetails: SelectedClientDetails | null;
     modalErrorMessage: string | null;
+    setModalErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
 }
 
 const ParcelsModal: React.FC<ParcelsModalProps> = ({
@@ -26,58 +32,102 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     selectedParcelId,
     selectedClientDetails,
     modalErrorMessage,
+    setModalErrorMessage,
 }) => {
+    const [statusAnchorElement, setStatusAnchorElement] = useState<HTMLElement | null>(null);
+    const refreshParcelDetailsRef = useRef<(() => void) | null>(null);
+
     const theme = useTheme();
     const router = useRouter();
+
+    const fetchParcel = async (): Promise<ParcelsTableRow[]> => {
+        return await getParcelsByIds(supabase, [selectedParcelId as string]);
+    };
+
+    const refreshDetails = (): void => {
+        if (refreshParcelDetailsRef.current) {
+            refreshParcelDetailsRef.current();
+        }
+    };
+
+    const postSetStatusCallback = (): void => {
+        refreshDetails();
+    };
+
     return (
-        <Modal
-            header={
-                <>
-                    <Icon icon={faBoxArchive} color={theme.primary.largeForeground[2]} /> Parcel
-                    Details
-                </>
-            }
-            isOpen={modalIsOpen}
-            onClose={() => {
-                setModalIsOpen(false);
-                router.push("/parcels");
-            }}
-            headerId="expandedParcelDetailsModal"
-            footer={
-                <Centerer>
-                    <ConfirmButtons>
-                        <LinkButton link={`/parcels/edit/${selectedParcelId}`}>
-                            Edit Parcel
-                        </LinkButton>
-                        {selectedClientDetails && (
-                            <>
-                                <LinkButton
-                                    link={`/clients?clientId=${selectedClientDetails.clientId}`}
-                                    disabled={!selectedClientDetails.isClientActive}
-                                >
-                                    See Client Details
-                                </LinkButton>
-                                <LinkButton
-                                    link={`/clients/edit/${selectedClientDetails.clientId}`}
-                                    disabled={!selectedClientDetails.isClientActive}
-                                >
-                                    Edit Client Details
-                                </LinkButton>
-                            </>
-                        )}
-                    </ConfirmButtons>
-                </Centerer>
-            }
-        >
-            <OutsideDiv>
-                <ContentDiv>
-                    <Suspense fallback={<ExpandedParcelDetailsFallback />}>
-                        <ExpandedParcelDetails parcelId={selectedParcelId} />
-                    </Suspense>
-                </ContentDiv>
-                {modalErrorMessage && <ErrorSecondaryText>{modalErrorMessage}</ErrorSecondaryText>}
-            </OutsideDiv>
-        </Modal>
+        <>
+            <Statuses
+                fetchSelectedParcels={fetchParcel}
+                postSuccessCallback={postSetStatusCallback}
+                statusAnchorElement={statusAnchorElement}
+                setStatusAnchorElement={setStatusAnchorElement}
+                setModalError={setModalErrorMessage}
+            />
+            <Modal
+                header={
+                    <>
+                        <Icon icon={faBoxArchive} color={theme.primary.largeForeground[2]} /> Parcel
+                        Details
+                    </>
+                }
+                isOpen={modalIsOpen}
+                onClose={() => {
+                    setModalIsOpen(false);
+                    router.push("/parcels");
+                }}
+                headerId="expandedParcelDetailsModal"
+                footer={
+                    <Centerer>
+                        <ConfirmButtons>
+                            <LinkButton link={`/parcels/edit/${selectedParcelId}`}>
+                                Edit Parcel
+                            </LinkButton>
+                            <Button
+                                variant="contained"
+                                onClick={(event) => setStatusAnchorElement(event.currentTarget)}
+                                type="button"
+                                id="status-button"
+                                endIcon={<ArrowDropDown />}
+                            >
+                                Set Status
+                            </Button>
+                            {selectedClientDetails && (
+                                <>
+                                    <LinkButton
+                                        link={`/clients?clientId=${selectedClientDetails.clientId}`}
+                                        disabled={!selectedClientDetails.isClientActive}
+                                    >
+                                        See Client Details
+                                    </LinkButton>
+                                    <LinkButton
+                                        link={`/clients/edit/${selectedClientDetails.clientId}`}
+                                        disabled={!selectedClientDetails.isClientActive}
+                                    >
+                                        Edit Client Details
+                                    </LinkButton>
+                                </>
+                            )}
+                        </ConfirmButtons>
+                    </Centerer>
+                }
+            >
+                <OutsideDiv>
+                    <ContentDiv>
+                        <Suspense fallback={<ExpandedParcelDetailsFallback />}>
+                            <ExpandedParcelDetails
+                                parcelId={selectedParcelId}
+                                refreshCallback={(refresh) => {
+                                    refreshParcelDetailsRef.current = refresh;
+                                }}
+                            />
+                        </Suspense>
+                    </ContentDiv>
+                    {modalErrorMessage && (
+                        <ErrorSecondaryText>{modalErrorMessage}</ErrorSecondaryText>
+                    )}
+                </OutsideDiv>
+            </Modal>
+        </>
     );
 };
 

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -8,7 +8,7 @@ import {
     SelectedClientDetails,
 } from "@/app/parcels/parcelsTable/types";
 import supabase from "@/supabaseClient";
-import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
+import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import buildFilters from "@/app/parcels/parcelsTable/filters";
 import { getSelectedParcelCountMessage } from "@/app/parcels/parcelsTable/format";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
@@ -63,7 +63,7 @@ const ParcelsPage: React.FC = () => {
             return [];
         }
 
-        return await getParcelsByIds(
+        return await getParcelsByIdsWithFiltersAndSorting(
             supabase,
             primaryFilters.concat(additionalFilters),
             sortState,
@@ -120,6 +120,7 @@ const ParcelsPage: React.FC = () => {
                         selectedParcelId={selectedParcelId}
                         selectedClientDetails={selectedClientDetails}
                         modalErrorMessage={modalErrorMessage}
+                        setModalErrorMessage={setModalErrorMessage}
                     />
                 </>
             )}

--- a/src/app/parcels/parcelsTable/fetchParcelTableData.ts
+++ b/src/app/parcels/parcelsTable/fetchParcelTableData.ts
@@ -232,6 +232,18 @@ export const getParcelIds = async (
 
 export const getParcelsByIds = async (
     supabase: Supabase,
+    parcelIds: string[]
+): Promise<ParcelsTableRow[]> => {
+    const query = supabase
+        .from("parcels_plus")
+        .select("*")
+        .in("parcel_id", parcelIds) as DbQuery<DbParcelRow>;
+
+    return runParcelsQueryAndConvertToParcelTableRows(query);
+};
+
+export const getParcelsByIdsWithFiltersAndSorting = async (
+    supabase: Supabase,
     filters: ParcelsFilters,
     sortState: ParcelsSortState,
     parcelIds: string[]
@@ -241,6 +253,12 @@ export const getParcelsByIds = async (
         query.in("parcel_id", parcelIds);
     }
 
+    return runParcelsQueryAndConvertToParcelTableRows(query);
+};
+
+const runParcelsQueryAndConvertToParcelTableRows = async (
+    query: DbQuery<DbParcelRow>
+): Promise<ParcelsTableRow[]> => {
     const { data, error } = (await query) as {
         data: DbParcelRow[];
         error: Error | null;


### PR DESCRIPTION
## What's changed
This is the initial change to solve the use-case in #613 - by adding a Set Status dropmenu to the Parcel Modal.
There are other changes described in [this comment](https://github.com/LambethFoodbank/foodbankapp/issues/613#issuecomment-2764675482) that will probably need to be separate tickets.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

