### PR TITLE
#629: Add signposting answer "Don't Know"

### DIFF
--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -32,7 +32,7 @@ const AddClients: () => React.ReactElement = () => {
         extraInformation: "",
         attentionFlag: false,
         signpostingCall: false,
-        signpostingCallReasons: {},
+        signpostingCallReasons: null,
         notes: "",
         lastUpdated: undefined,
     };

--- a/src/app/clients/edit/[id]/autofill.ts
+++ b/src/app/clients/edit/[id]/autofill.ts
@@ -54,7 +54,10 @@ const autofill = (
         extraInformation: clientData.extra_information ?? "",
         attentionFlag: clientData.flagged_for_attention ?? false,
         signpostingCall: clientData.signposting_call_required ?? false,
-        signpostingCallReasons: arrayToBooleanGroup(clientData.signposting_call_reasons ?? []),
+        signpostingCallReasons:
+            clientData.signposting_call_reasons !== null
+                ? arrayToBooleanGroup(clientData.signposting_call_reasons)
+                : null,
         lastUpdated: clientData.last_updated,
         notes: clientData.notes,
     };

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -77,7 +77,7 @@ export interface ClientFields extends Fields {
     extraInformation: string;
     attentionFlag: boolean;
     signpostingCall: boolean;
-    signpostingCallReasons: BooleanGroup;
+    signpostingCallReasons: BooleanGroup | null;
     lastUpdated: string | undefined;
     notes: string | null;
 }

--- a/src/app/clients/form/formSections/SignpostingCallCard.tsx
+++ b/src/app/clients/form/formSections/SignpostingCallCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
     checkboxGroupToArray,
     onChangeCheckboxInGroup,
@@ -9,6 +9,7 @@ import RadioGroupInput from "@/components/DataInput/RadioGroupInput";
 import { ClientCardProps } from "../ClientForm";
 import { FormElementWithSpacing } from "@/components/Form/formStyling";
 import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
+import { Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel } from "@mui/material";
 
 export const signpostingCallOptions: string[] = [
     "Benefits",
@@ -24,6 +25,16 @@ export const signpostingCallLabelsAndKeys: [string, string][] = signpostingCallO
 );
 
 const SignpostingCallCard: React.FC<ClientCardProps> = ({ fieldSetter, fields }) => {
+    const [unknownSignpostingReasons, setUnknownSignpostingReasons] = useState(
+        fields["signpostingCallReasons"] === null
+    );
+
+    const handleCheckCheckboxForUnknown = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        setUnknownSignpostingReasons(event.target.checked);
+
+        fieldSetter({ signpostingCallReasons: null });
+    };
+
     return (
         <GenericFormCard
             title="Signposting Call"
@@ -40,8 +51,26 @@ const SignpostingCallCard: React.FC<ClientCardProps> = ({ fieldSetter, fields })
             ></RadioGroupInput>
 
             <FormElementWithSpacing>
+                <FormControl disabled={fields["signpostingCall"] !== true}>
+                    <FormLabel>What do they need help with?</FormLabel>
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={unknownSignpostingReasons}
+                                    onChange={handleCheckCheckboxForUnknown}
+                                    disabled={fields["signpostingCall"] !== true}
+                                />
+                            }
+                            label="Don't Know"
+                        />
+                    </FormGroup>
+                </FormControl>
+            </FormElementWithSpacing>
+
+            <FormElementWithSpacing>
                 <CheckboxGroupInput
-                    groupLabel="What do they need help with? Tick all that apply. For 'Other', put details in the 'Notes' section."
+                    groupLabel="Tick all that apply. For 'Other', put details in the 'Notes' section."
                     labelsAndKeys={signpostingCallLabelsAndKeys}
                     onChange={onChangeCheckboxInGroup(
                         fieldSetter,
@@ -53,7 +82,7 @@ const SignpostingCallCard: React.FC<ClientCardProps> = ({ fieldSetter, fields })
                             ? checkboxGroupToArray(fields.signpostingCallReasons)
                             : []
                     }
-                    disabled={fields["signpostingCall"] !== true}
+                    disabled={unknownSignpostingReasons || fields["signpostingCall"] !== true}
                 />
             </FormElementWithSpacing>
         </GenericFormCard>

--- a/src/app/parcels/ActionBar/ActionButtons/SignpostingReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/SignpostingReportCsvButton.tsx
@@ -191,7 +191,7 @@ const getSignpostingReportData = async (
                         ? formatNumberAsStringForCsv(rawParcel.client.phone_number)
                         : "",
                     signpostingCallReasons: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.signposting_call_reasons ?? [],
+                        rawParcel.client?.signposting_call_reasons ?? null,
                         signpostingCallOptions
                     ),
                     address: rawParcel.client
@@ -209,11 +209,11 @@ const getSignpostingReportData = async (
                     extraInformation: rawParcel.client?.extra_information ?? "",
                     notes: rawParcel.client?.notes ?? "",
                     cookingFacilities: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.cooking_facilities ?? [],
+                        rawParcel.client?.cooking_facilities ?? null,
                         cookingFacilitiesOptions
                     ),
                     dietaryRequirements: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.dietary_requirements ?? [],
+                        rawParcel.client?.dietary_requirements ?? null,
                         dietaryRequirementOptions
                     ),
                     hygieneProducts: formatHygieneProducts(
@@ -228,11 +228,11 @@ const getSignpostingReportData = async (
                         rawParcel.client?.baby_other_items ?? []
                     ),
                     petFood: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.pet_food ?? [],
+                        rawParcel.client?.pet_food ?? null,
                         petFoodOptions
                     ),
                     otherItems: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.other_items ?? [],
+                        rawParcel.client?.other_items ?? null,
                         otherRequirementOptions
                     ),
                     household: rawParcel.client


### PR DESCRIPTION
## What's changed
Followed the same pattern as used for Dietary Requirements and Cooking Facilities. The database schema already supported null for the reasons.


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
