### PR TITLE
#641 Encode filter params in URL 

### DIFF
--- a/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
+++ b/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
@@ -38,6 +38,24 @@ describe("Parcels page url params", () => {
         cy.url().should("not.include", "fullName=");
     });
 
+    it("Filters are set when URL params are changed directly", () => {
+        const fromDateYmd = "2024-05-14";
+        const fromDateDmy = "14/05/2024";
+        const toDateYmd = "2024-06-02";
+        const toDateDmy = "02/06/2024";
+        const newFullName = "er";
+
+        cy.visit(
+            `/parcels?fullName=${newFullName}&packingDate[]=${fromDateYmd}&packingDate[]=${toDateYmd}`
+        );
+
+        cy.get("[data-testid='text-filter-fullName']")
+            .find("input")
+            .should("have.value", newFullName);
+        cy.get("[data-testid='date-range-input-from']").should("have.value", fromDateDmy);
+        cy.get("[data-testid='date-range-input-to']").should("have.value", toDateDmy);
+    });
+
     it("URL params are updated when going into packing manager view", () => {
         // Wait until table has loaded data
         cy.get("[role='table']").should("be.visible");
@@ -51,6 +69,19 @@ describe("Parcels page url params", () => {
         cy.get("[data-testid='packing-manager-view-button']").click();
         cy.get("[data-testid='all-parcels-button']").click();
         cy.url().should("not.include", "view=");
+    });
+
+    it("Packing manager view enabled when URL param is set", () => {
+        cy.visit("/parcels?view=Packing%20Manager");
+
+        // Wait until table has loaded data
+        cy.get("[role='table']").should("be.visible");
+        cy.get("[aria-label='table-progress-bar']").should("not.exist");
+
+        cy.get("[data-testid='packing-manager-view-button']").should(
+            "have.class",
+            "MuiButton-contained"
+        );
     });
 
     // Skipping this test because the seed data doesn't have parcels dated today,

--- a/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
+++ b/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
@@ -1,0 +1,64 @@
+describe("Parcels page url params", () => {
+    beforeEach(() => {
+        cy.login();
+        cy.visit("/parcels");
+    });
+
+    const formatTodaysDateAsYYYYMMDD = () => {
+        const today = new Date();
+        return today.toISOString().split("T")[0];
+    };
+
+    it("Initial URL params are set to be the current date", () => {
+        const formattedDate = formatTodaysDateAsYYYYMMDD();
+        const expectedUrl = `/parcels?packingDate[]=${formattedDate}&packingDate[]=${formattedDate}`;
+        cy.url().should("include", expectedUrl);
+    });
+
+    it("URL params are updated when filters are applied", () => {
+        const formattedDate = formatTodaysDateAsYYYYMMDD();
+
+        cy.get("[data-testid='text-filter-fullName']").type("th");
+
+        const expectedUrl = `/parcels?fullName=th&packingDate[]=${formattedDate}&packingDate[]=${formattedDate}`;
+        cy.url().should("include", expectedUrl);
+    });
+
+    it("Empty URL params are removed when filters are cleared", () => {
+        const formattedDate = formatTodaysDateAsYYYYMMDD();
+        cy.get("[data-testid='text-filter-fullName']").find("input").type("th");
+        cy.url().should("include", `fullName=th`);
+
+        cy.get("[data-testid='text-filter-fullName']").find("input").clear();
+
+        cy.url().should(
+            "include",
+            `/parcels?packingDate[]=${formattedDate}&packingDate[]=${formattedDate}`
+        );
+        cy.url().should("not.include", "fullName=");
+    });
+
+    it("URL params are updated when going into packing manager view", () => {
+        // Wait until table has loaded data
+        cy.get("[role='table']").should("be.visible");
+        cy.get("[aria-label='table-progress-bar']").should("not.exist");
+
+        cy.get("[data-testid='packing-manager-view-button']").click();
+        cy.url().should("include", "view=Packing%20Manager");
+    });
+
+    it("URL params are updated when going back to all parcels view", () => {
+        cy.get("[data-testid='packing-manager-view-button']").click();
+        cy.get("[data-testid='all-parcels-button']").click();
+        cy.url().should("not.include", "view=");
+    });
+
+    it("URL params are updated when a parcel is opened", () => {
+        cy.get("[id='cell-fullName-0']").click();
+
+        cy.get("[id='expandedParcelDetailsModal']").should("be.visible");
+
+        // This should have the parcel ID
+        cy.url().should("include", "parcelId=");
+    });
+});

--- a/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
+++ b/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
@@ -4,7 +4,7 @@ describe("Parcels page url params", () => {
         cy.visit("/parcels");
     });
 
-    const formatTodaysDateAsYYYYMMDD = () => {
+    const formatTodaysDateAsYYYYMMDD = (): string => {
         const today = new Date();
         return today.toISOString().split("T")[0];
     };
@@ -27,7 +27,7 @@ describe("Parcels page url params", () => {
     it("Empty URL params are removed when filters are cleared", () => {
         const formattedDate = formatTodaysDateAsYYYYMMDD();
         cy.get("[data-testid='text-filter-fullName']").find("input").type("th");
-        cy.url().should("include", `fullName=th`);
+        cy.url().should("include", "fullName=th");
 
         cy.get("[data-testid='text-filter-fullName']").find("input").clear();
 

--- a/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
+++ b/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
@@ -53,7 +53,9 @@ describe("Parcels page url params", () => {
         cy.url().should("not.include", "view=");
     });
 
-    it("URL params are updated when a parcel is opened", () => {
+    // Skipping this test because the seed data doesn't have parcels dated today,
+    // so the table will not have any data to display.
+    it.skip("URL params are updated when a parcel is opened", () => {
         cy.get("[id='cell-fullName-0']").click();
 
         cy.get("[id='expandedParcelDetailsModal']").should("be.visible");

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "next": "^14.2.25",
         "nyc": "^15.1.0",
         "pdf-parse": "^1.1.1",
+        "query-string": "^9.1.1",
         "react": "^18.3.1",
         "react-data-table-component": "^7.5.4",
         "react-dom": "^18.3.1",
@@ -9516,6 +9517,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-uri-component": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -11100,6 +11110,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/filter-obj": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-cache-dir": {
@@ -18534,6 +18556,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/query-string": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.1.1.tgz",
+      "integrity": "sha512-MWkCOVIcJP9QSKU52Ngow6bsAWAPlPK2MludXvcrS2bGZSl+T1qX9MZvRIkqUIkGLJquMJHWfsT6eRqUpp4aWg==",
+      "license": "MIT",
+      "dependencies": {
+        "decode-uri-component": "^0.4.1",
+        "filter-obj": "^5.1.0",
+        "split-on-first": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "dev": true,
@@ -19566,6 +19605,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/split-on-first": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "next": "^14.2.25",
     "nyc": "^15.1.0",
     "pdf-parse": "^1.1.1",
+    "query-string": "^9.1.1",
     "react": "^18.3.1",
     "react-data-table-component": "^7.5.4",
     "react-dom": "^18.3.1",

--- a/src/app/admin/usersTable/filters.ts
+++ b/src/app/admin/usersTable/filters.ts
@@ -1,7 +1,6 @@
 import { serverSideChecklistFilter } from "@/components/Tables/ChecklistFilter";
 import { UserRow, UsersFilter, UsersFilterMethod, UsersFilters } from "./types";
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
-import { usersTableHeaderKeysAndLabels } from "./headers";
 import { allRoles } from "@/app/roles";
 import { Schema } from "@/databaseUtils";
 
@@ -45,19 +44,16 @@ export const usersFilters: UsersFilters = [
     buildServerSideTextFilter({
         key: "firstName",
         label: "First Name",
-        headers: usersTableHeaderKeysAndLabels,
         method: firstNameSearch,
     }),
     buildServerSideTextFilter({
         key: "lastName",
         label: "Last Name",
-        headers: usersTableHeaderKeysAndLabels,
         method: lastNameSearch,
     }),
     buildServerSideTextFilter({
         key: "email",
         label: "Email",
-        headers: usersTableHeaderKeysAndLabels,
         method: emailSearch,
     }),
     buildUserRoleFilter(),

--- a/src/app/clients/clientsTable/filters.ts
+++ b/src/app/clients/clientsTable/filters.ts
@@ -1,5 +1,4 @@
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
-import clientsHeaders from "./headers";
 import { ClientsFilter, ClientsFilterMethod } from "./types";
 import {
     familySearch,
@@ -30,25 +29,21 @@ const clientsFilters: ClientsFilter[] = [
     buildServerSideTextFilter({
         key: "fullName",
         label: "Name",
-        headers: clientsHeaders,
         method: clientsFullNameSearch,
     }),
     buildServerSideTextFilter({
         key: "familyCategory",
         label: "Family Size",
-        headers: clientsHeaders,
         method: clientsFamilySearch,
     }),
     buildServerSideTextFilter({
         key: "addressPostcode",
         label: "Postcode",
-        headers: clientsHeaders,
         method: clientsPostcodeSearch,
     }),
     buildServerSideTextFilter({
         key: "phoneNumber",
         label: "Phone",
-        headers: clientsHeaders,
         method: clientsPhoneSearch,
     }),
 ];

--- a/src/app/lists/ListDataview.tsx
+++ b/src/app/lists/ListDataview.tsx
@@ -266,7 +266,7 @@ const ListsDataView: React.FC<ListDataViewProps> = ({
         setListData(
             listOfIngredients.filter((row) => {
                 return primaryFilters.every((filter) => {
-                    return filter.method(row, filter.state, filter.key);
+                    return filter.method(row, filter.state, filter.rowKey);
                 });
             })
         );

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -17,7 +17,7 @@ import ListsDataView, {
 } from "@/app/lists/ListDataview";
 import { ErrorSecondaryText } from "../errorStylingandMessages";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
-import { buttonGroupFilter, filterRowbyButton } from "@/components/Tables/ButtonFilter";
+import { clientSideButtonGroupFilter, filterRowbyButton } from "@/components/Tables/ButtonFilter";
 import { buildClientSideTextFilter, filterRowByText } from "@/components/Tables/TextFilter";
 
 interface FetchedListsData {
@@ -87,13 +87,13 @@ const filters: ListFilter[] = [
     buildClientSideTextFilter({
         key: "itemName",
         label: "Item",
-        headers: listsHeaderKeysAndLabels,
         method: filterRowByText,
     }),
-    buttonGroupFilter({
+    clientSideButtonGroupFilter({
         key: "listType",
+        rowKey: "listType",
         filterLabel: "",
-        filterOptions: LIST_TYPES_ARRAY,
+        itemLabelsAndKeys: LIST_TYPES_ARRAY.map((type) => [type, type]),
         initialActiveFilter: "regular",
         method: filterRowbyButton,
         shouldPersistOnClear: true,

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -86,6 +86,7 @@ const formatListData = (listsData: Schema["lists"][]): ListRow[] => {
 const filters: ListFilter[] = [
     buildClientSideTextFilter({
         key: "itemName",
+        rowKey: "itemName",
         label: "Item",
         method: filterRowByText,
     }),

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -67,7 +67,7 @@ const ExpandedParcelDetailsView = ({
         setParcelDetails(expandedParcelDetails);
         setParcelClientId(expandedParcelDetails.expandedParcelData.clientId);
         setIsClientActive(expandedParcelDetails.expandedParcelData.isActive);
-    }, [parcelId]);
+    }, [parcelId, setIsClientActive, setParcelClientId]);
 
     useEffect(() => {
         void fetchAndSetParcelDetails();

--- a/src/app/parcels/ExpandedParcelDetails.tsx
+++ b/src/app/parcels/ExpandedParcelDetails.tsx
@@ -20,6 +20,8 @@ const DeletedText = styled.div`
 
 interface Props {
     parcelId: string | null;
+    setParcelClientId: (clientId: string | null) => void;
+    setIsClientActive: (isActive: boolean | null) => void;
     refreshCallback?: (refreshFunction: () => void) => void;
 }
 
@@ -38,7 +40,12 @@ function getErrorMessageForExpandedParcelDetailsError(
     }
 }
 
-const ExpandedParcelDetailsView = ({ parcelId, refreshCallback }: Props): ReactElement => {
+const ExpandedParcelDetailsView = ({
+    parcelId,
+    setParcelClientId,
+    setIsClientActive,
+    refreshCallback,
+}: Props): ReactElement => {
     const [parcelDetails, setParcelDetails] = useState<ExpandedParcelDetails | null>(null);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [refreshTrigger, setRefreshTrigger] = useState(0);
@@ -58,6 +65,8 @@ const ExpandedParcelDetailsView = ({ parcelId, refreshCallback }: Props): ReactE
         }
 
         setParcelDetails(expandedParcelDetails);
+        setParcelClientId(expandedParcelDetails.expandedParcelData.clientId);
+        setIsClientActive(expandedParcelDetails.expandedParcelData.isActive);
     }, [parcelId]);
 
     useEffect(() => {

--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -141,6 +141,7 @@ const getExpandedParcelDetails = async (
             parcelDetails: {
                 expandedParcelData: {
                     isActive: true,
+                    clientId: client.primary_key,
                     voucherNumber: rawParcelDetails.voucher_number ?? "",
                     fullName: client.full_name ?? "",
                     listType: rawParcelDetails.list_type,
@@ -196,6 +197,7 @@ const getExpandedParcelDetails = async (
         parcelDetails: {
             expandedParcelData: {
                 isActive: false,
+                clientId: client.primary_key,
                 voucherNumber: rawParcelDetails.voucher_number ?? "",
                 listType: rawParcelDetails.list_type,
                 packingDateAndSlot: formatPackingDateAndSlot(
@@ -226,10 +228,12 @@ interface ParcelDataIndependentOfClient extends Data {
 
 interface ParcelDataForInactiveClient extends ParcelDataIndependentOfClient {
     isActive: false;
+    clientId: string;
 }
 
 interface ParcelDataForActiveClient extends ParcelDataIndependentOfClient {
     isActive: true;
+    clientId: string;
     fullName: string;
     address: string;
     deliveryInstructions: string;
@@ -296,6 +300,10 @@ export const getExpandedParcelDataForDataViewer = (
     });
     parcelDetailsForDataViewer["isActive"] = {
         value: parcelDetails["isActive"],
+        hide: true,
+    };
+    parcelDetailsForDataViewer["clientId"] = {
+        value: parcelDetails["clientId"],
         hide: true,
     };
     parcelDetailsForDataViewer["listType"] = {

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,7 +1,7 @@
 import supabase from "@/supabaseClient";
 import { Suspense, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { ParcelsTableRow, SelectedClientDetails } from "@/app/parcels/parcelsTable/types";
+import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
 import ExpandedParcelDetailsFallback from "../ExpandedParcelDetailsFallback";
 import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
@@ -37,9 +37,6 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     const [statusAnchorElement, setStatusAnchorElement] = useState<HTMLElement | null>(null);
     const refreshParcelDetailsRef = useRef<(() => void) | null>(null);
 
-    const [selectedClientDetails, setSelectedClientDetails] =
-        useState<SelectedClientDetails | null>(null); // QQ remove this
-
     const [parcelClientId, setParcelClientId] = useState<string | null>(null);
     const [isClientActive, setIsClientActive] = useState<boolean | null>(null);
     const [modalErrorMessage, setModalErrorMessage] = useState<string | null>(null);
@@ -51,8 +48,6 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     };
 
     const refreshDetails = (): void => {
-        console.log("QQ refreshing parcel details");
-
         if (refreshParcelDetailsRef.current) {
             refreshParcelDetailsRef.current();
         }

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,53 +1,70 @@
 import supabase from "@/supabaseClient";
-import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
-import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
-import Modal from "@/components/Modal/Modal";
-import { Centerer, ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
 import { Suspense, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { ParcelsTableRow, SelectedClientDetails } from "@/app/parcels/parcelsTable/types";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
 import ExpandedParcelDetailsFallback from "../ExpandedParcelDetailsFallback";
+import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
+import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
+import Statuses from "../ActionBar/Statuses";
+import { mergeParamsIntoURL } from "@/common/urlQueryParams";
+import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
+import Modal from "@/components/Modal/Modal";
+import { Centerer, ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
 import LinkButton from "@/components/Buttons/LinkButton";
 import Icon from "@/components/Icons/Icon";
 import { faBoxArchive } from "@fortawesome/free-solid-svg-icons";
 import { useTheme } from "styled-components";
-import { ParcelsTableRow, SelectedClientDetails } from "./types";
-import { useRouter } from "next/navigation";
 import { ConfirmButtons } from "@/components/Buttons/GeneralButtonParts";
 import { Button } from "@mui/material";
 import { ArrowDropDown } from "@mui/icons-material";
-import Statuses from "../ActionBar/Statuses";
 
 interface ParcelsModalProps {
     modalIsOpen: boolean;
     setModalIsOpen: (modalIsOpen: boolean) => void;
     selectedParcelId: string | null;
-    selectedClientDetails: SelectedClientDetails | null;
-    modalErrorMessage: string | null;
-    setModalErrorMessage: React.Dispatch<React.SetStateAction<string | null>>;
+    setSelectedParcelId: (selectedParcelId: string | null) => void;
 }
 
 const ParcelsModal: React.FC<ParcelsModalProps> = ({
     modalIsOpen,
     setModalIsOpen,
     selectedParcelId,
-    selectedClientDetails,
-    modalErrorMessage,
-    setModalErrorMessage,
+    setSelectedParcelId,
 }) => {
+    const searchParams = useSearchParams();
+
     const [statusAnchorElement, setStatusAnchorElement] = useState<HTMLElement | null>(null);
     const refreshParcelDetailsRef = useRef<(() => void) | null>(null);
 
+    const [selectedClientDetails, setSelectedClientDetails] =
+        useState<SelectedClientDetails | null>(null); // QQ remove this
+
+    const [parcelClientId, setParcelClientId] = useState<string | null>(null);
+    const [isClientActive, setIsClientActive] = useState<boolean | null>(null);
+    const [modalErrorMessage, setModalErrorMessage] = useState<string | null>(null);
+
     const theme = useTheme();
-    const router = useRouter();
 
     const fetchParcel = async (): Promise<ParcelsTableRow[]> => {
         return await getParcelsByIds(supabase, [selectedParcelId as string]);
     };
 
     const refreshDetails = (): void => {
+        console.log("QQ refreshing parcel details");
+
         if (refreshParcelDetailsRef.current) {
             refreshParcelDetailsRef.current();
         }
+    };
+
+    const closeParcelModalAndUpdateURL = (): void => {
+        setModalIsOpen(false);
+        setSelectedParcelId(null);
+
+        const paramsRecord: Record<string, string | null> = {};
+        paramsRecord[parcelIdParam] = null;
+        mergeParamsIntoURL(searchParams, paramsRecord);
     };
 
     const postSetStatusCallback = (): void => {
@@ -72,8 +89,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                 }
                 isOpen={modalIsOpen}
                 onClose={() => {
-                    setModalIsOpen(false);
-                    router.push("/parcels"); // QQ this needs to set the shared URL params wrapped object, not overwrite
+                    closeParcelModalAndUpdateURL();
                 }}
                 headerId="expandedParcelDetailsModal"
                 footer={
@@ -91,17 +107,17 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                             >
                                 Set Status
                             </Button>
-                            {selectedClientDetails && (
+                            {parcelClientId && (
                                 <>
                                     <LinkButton
-                                        link={`/clients?clientId=${selectedClientDetails.clientId}`}
-                                        disabled={!selectedClientDetails.isClientActive}
+                                        link={`/clients?clientId=${parcelClientId}`}
+                                        disabled={!isClientActive}
                                     >
                                         See Client Details
                                     </LinkButton>
                                     <LinkButton
-                                        link={`/clients/edit/${selectedClientDetails.clientId}`}
-                                        disabled={!selectedClientDetails.isClientActive}
+                                        link={`/clients/edit/${parcelClientId}`}
+                                        disabled={!isClientActive}
                                     >
                                         Edit Client Details
                                     </LinkButton>
@@ -116,6 +132,8 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                         <Suspense fallback={<ExpandedParcelDetailsFallback />}>
                             <ExpandedParcelDetails
                                 parcelId={selectedParcelId}
+                                setParcelClientId={setParcelClientId}
+                                setIsClientActive={setIsClientActive}
                                 refreshCallback={(refresh) => {
                                     refreshParcelDetailsRef.current = refresh;
                                 }}

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -73,7 +73,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                 isOpen={modalIsOpen}
                 onClose={() => {
                     setModalIsOpen(false);
-                    router.push("/parcels");
+                    router.push("/parcels"); // QQ this needs to set the shared URL params wrapped object, not overwrite
                 }}
                 headerId="expandedParcelDetailsModal"
                 footer={

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,14 +1,11 @@
 import supabase from "@/supabaseClient";
 import { Suspense, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
 import ExpandedParcelDetailsFallback from "../ExpandedParcelDetailsFallback";
 import { getParcelsByIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Statuses from "../ActionBar/Statuses";
-import { mergeParamsIntoURL } from "@/common/urlQueryParams";
-import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
 import Modal from "@/components/Modal/Modal";
 import { Centerer, ContentDiv, OutsideDiv } from "@/components/Modal/ModalFormStyles";
 import LinkButton from "@/components/Buttons/LinkButton";
@@ -21,19 +18,15 @@ import { ArrowDropDown } from "@mui/icons-material";
 
 interface ParcelsModalProps {
     modalIsOpen: boolean;
-    setModalIsOpen: (modalIsOpen: boolean) => void;
     selectedParcelId: string | null;
-    setSelectedParcelId: (selectedParcelId: string | null) => void;
+    closeParcelModal: () => void;
 }
 
 const ParcelsModal: React.FC<ParcelsModalProps> = ({
     modalIsOpen,
-    setModalIsOpen,
     selectedParcelId,
-    setSelectedParcelId,
+    closeParcelModal,
 }) => {
-    const searchParams = useSearchParams();
-
     const [statusAnchorElement, setStatusAnchorElement] = useState<HTMLElement | null>(null);
     const refreshParcelDetailsRef = useRef<(() => void) | null>(null);
 
@@ -51,15 +44,6 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
         if (refreshParcelDetailsRef.current) {
             refreshParcelDetailsRef.current();
         }
-    };
-
-    const closeParcelModalAndUpdateURL = (): void => {
-        setModalIsOpen(false);
-        setSelectedParcelId(null);
-
-        const paramsRecord: Record<string, string | null> = {};
-        paramsRecord[parcelIdParam] = null;
-        mergeParamsIntoURL(searchParams, paramsRecord);
     };
 
     const postSetStatusCallback = (): void => {
@@ -84,7 +68,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                 }
                 isOpen={modalIsOpen}
                 onClose={() => {
-                    closeParcelModalAndUpdateURL();
+                    closeParcelModal();
                 }}
                 headerId="expandedParcelDetailsModal"
                 footer={

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -108,28 +108,27 @@ const ParcelsPage: React.FC = () => {
         );
     }, [primaryFilters, today, yesterday]);
 
-    const currentlyAppliedFilters = () => {
+    const currentlyAppliedFilters = useMemo(() => {
+        console.log("WW: rebuilding currentlyAppliedFilters");
+
         return isPackingManagerView
             ? [...packingManagerViewPrimaryFilters, ...additionalFilters]
             : [...primaryFilters, ...additionalFilters];
-    };
+    }, [isPackingManagerView, packingManagerViewPrimaryFilters, primaryFilters, additionalFilters]);
 
     useEffect(() => {
         if (!urlParamsHaveBeenProcessed) {
             return;
         }
 
-        const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters());
+        console.log("QQ: about to buildQueryParamsFromFilters");
+        // QQ Why is this happening twice, both times showing the old searchParams filter value,
+        // and why does the table refreshed twice, the first time based on the old filter value?
+
+        const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters);
         paramsRecord[pageViewTypeParam] = isPackingManagerView ? pageViewTypePackingManager : null;
         mergeParamsIntoURL(searchParams, paramsRecord);
-    }, [
-        isPackingManagerView,
-        primaryFilters,
-        packingManagerViewPrimaryFilters,
-        additionalFilters,
-        searchParams,
-        urlParamsHaveBeenProcessed,
-    ]);
+    }, [isPackingManagerView, currentlyAppliedFilters, searchParams, urlParamsHaveBeenProcessed]);
 
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
         if (checkedParcelIds.length === 0) {
@@ -217,7 +216,7 @@ const ParcelsPage: React.FC = () => {
                         openParcelModal={openParcelModalAndUpdateURL}
                         sortState={sortState}
                         setSortState={setSortState}
-                        appliedFilters={currentlyAppliedFilters()}
+                        appliedFilters={currentlyAppliedFilters}
                         areFiltersLoadingForFirstTime={areFiltersLoadingForFirstTime}
                         setErrorMessage={setErrorMessage}
                         isPackingManagerView={isPackingManagerView}

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import queryString from "query-string";
 import {
     ParcelsTableRow,
     ParcelsSortState,
@@ -9,7 +11,10 @@ import {
 } from "@/app/parcels/parcelsTable/types";
 import supabase from "@/supabaseClient";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
-import buildFilters from "@/app/parcels/parcelsTable/filters";
+import buildFilters, {
+    buildQueryParamsFromFilters,
+    updateFiltersFromQueryParams,
+} from "@/app/parcels/parcelsTable/filters";
 import { getSelectedParcelCountMessage } from "@/app/parcels/parcelsTable/format";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
 import PreTableControls from "@/app/parcels/parcelsTable/PreTableControls";
@@ -28,6 +33,9 @@ import { PreTableControlsContainer } from "@/components/controlsStyling";
 type ParcelTableFilterState = string | DateRangeState | string[];
 
 const ParcelsPage: React.FC = () => {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+
     const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
     const [selectedClientDetails, setSelectedClientDetails] =
         useState<SelectedClientDetails | null>(null);
@@ -62,12 +70,68 @@ const ParcelsPage: React.FC = () => {
     useEffect(() => {
         (async () => {
             setAreFiltersLoadingForFirstTime(true);
-            const filtersObject = await buildFilters();
+            let filtersObject = await buildFilters();
+
+            const params = queryString.parse(searchParams.toString());
+            filtersObject = updateFiltersFromQueryParams(
+                params,
+                filtersObject.primaryFilters,
+                filtersObject.additionalFilters
+            );
+
             setPrimaryFilters(filtersObject.primaryFilters);
             setAdditionalFilters(filtersObject.additionalFilters);
             setAreFiltersLoadingForFirstTime(false);
+
+            console.log("QQ Filters loaded:");
         })();
     }, []);
+
+    // QQ utility function
+    const areRecordsEqual = (obj1: Record<string, any>, obj2: Record<string, any>): boolean => {
+        const keys1 = Object.keys(obj1);
+        const keys2 = Object.keys(obj2);
+
+        if (keys1.length !== keys2.length) {
+            return false;
+        }
+
+        return keys1.every((key) => obj1[key] === obj2[key]);
+    };
+
+    // QQ utility function
+    const mergeParamsIntoURL = (
+        searchParams: URLSearchParams,
+        paramsToUpdate: Record<string, any>
+    ) => {
+        const paramsInURL = queryString.parse(searchParams.toString());
+        let mergedParams = {
+            ...paramsInURL,
+            ...paramsToUpdate,
+        };
+        mergedParams = Object.fromEntries(
+            Object.entries(mergedParams).filter(([key, value]) => value)
+        );
+
+        if (!areRecordsEqual(paramsInURL, mergedParams)) {
+            console.log("QQ updating URL");
+
+            // App Router doesn't support shallow routing, so router.push would reload the page
+            const queryStringified = queryString.stringify(mergedParams);
+            window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);
+        }
+    };
+
+    useEffect(() => {
+        if (areFiltersLoadingForFirstTime) {
+            return;
+        }
+
+        const filterParams = buildQueryParamsFromFilters(primaryFilters, additionalFilters);
+        mergeParamsIntoURL(searchParams, filterParams);
+    }, [primaryFilters, additionalFilters]);
+
+    // QQ TODO: make filter URL params work with Packing Manager view
 
     const packingManagerViewPrimaryFilters = useMemo(
         () =>

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -67,16 +67,10 @@ const ParcelsPage: React.FC = () => {
     const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
 
     useEffect(() => {
-        console.log("QQ: Page load: ", window.location.search);
-    }, []);
-
-    useEffect(() => {
         (async () => {
             if (urlParamsHaveBeenProcessed) {
                 return;
             }
-
-            console.log("VV: Processing URL params");
 
             setAreFiltersLoadingForFirstTime(true);
 
@@ -114,8 +108,6 @@ const ParcelsPage: React.FC = () => {
     }, [primaryFilters, today, yesterday]);
 
     const currentlyAppliedFilters = useMemo(() => {
-        console.log("WW: rebuilding currentlyAppliedFilters");
-
         return isPackingManagerView
             ? [...packingManagerViewPrimaryFilters, ...additionalFilters]
             : [...primaryFilters, ...additionalFilters];
@@ -125,8 +117,6 @@ const ParcelsPage: React.FC = () => {
         if (!urlParamsHaveBeenProcessed) {
             return;
         }
-
-        console.log("QQ: about to buildQueryParamsFromFilters");
 
         const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters);
         mergeParamsIntoURL(searchParams, paramsRecord);

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -2,7 +2,11 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import supabase from "@/supabaseClient";
-import { ParcelsTableRow, ParcelsSortState, ParcelsFilter } from "@/app/parcels/parcelsTable/types";
+import {
+    ParcelsTableRow,
+    ParcelsSortState,
+    ParcelsFilters,
+} from "@/app/parcels/parcelsTable/types";
 import { useSearchParams } from "next/navigation";
 import { mergeParamsIntoURL, parseQueryParams } from "@/common/urlQueryParams";
 import {
@@ -12,6 +16,7 @@ import {
 } from "@/app/parcels/parcelsTable/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import buildFilters, {
+    buildPackingManagerPrimaryFilters,
     buildQueryParamsFromFilters,
     updateFiltersFromQueryParams,
 } from "@/app/parcels/parcelsTable/filters";
@@ -26,7 +31,6 @@ import FloatingToast from "@/components/FloatingToast";
 import TableFiltersBar from "@/components/Tables/TableFiltersBar";
 import { DistributeServerFilter } from "@/components/Tables/Filters";
 import { DbParcelRow } from "@/databaseUtils";
-import { shouldFilterBeDisabled } from "./packingManagerHelpers";
 import dayjs from "dayjs";
 import { PreTableControlsContainer } from "@/components/controlsStyling";
 
@@ -43,12 +47,12 @@ const ParcelsPage: React.FC = () => {
 
     const [sortState, setSortState] = useState<ParcelsSortState>({ sortEnabled: false });
 
-    const [primaryFilters, setPrimaryFilters] = useState<
-        (ParcelsFilter<string> | ParcelsFilter<DateRangeState> | ParcelsFilter<string[]>)[]
-    >([]);
-    const [additionalFilters, setAdditionalFilters] = useState<
-        (ParcelsFilter<string> | ParcelsFilter<DateRangeState> | ParcelsFilter<string[]>)[]
-    >([]);
+    const [primaryFilters, setPrimaryFilters] = useState<ParcelsFilters>([]);
+    const [additionalFilters, setAdditionalFilters] = useState<ParcelsFilters>([]);
+
+    const [isPackingManagerView, setIsPackingManagerView] = useState<boolean>(false);
+    const [packingManagerViewPrimaryFilters, setPackingManagerViewPrimaryFilters] =
+        useState<ParcelsFilters>([]);
 
     const [areFiltersLoadingForFirstTime, setAreFiltersLoadingForFirstTime] =
         useState<boolean>(true);
@@ -57,8 +61,6 @@ const ParcelsPage: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const selectedParcelMessage = getSelectedParcelCountMessage(checkedParcelIds.length);
-
-    const [isPackingManagerView, setIsPackingManagerView] = useState<boolean>(false);
 
     const today = useMemo(() => dayjs().startOf("day"), []);
     const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
@@ -100,47 +102,34 @@ const ParcelsPage: React.FC = () => {
         })();
     }, [urlParamsHaveBeenProcessed, searchParams, primaryFilters, additionalFilters]);
 
-    const packingManagerViewPrimaryFilters = useMemo(
-        () =>
-            primaryFilters.map((filter) => {
-                if (filter.key === "packingDate") {
-                    return {
-                        ...filter,
-                        state: { from: yesterday, to: today },
-                        isDisabled: true,
-                        isHiddenInUrl: true,
-                    } as ParcelsFilter<DateRangeState>;
-                }
-                if (shouldFilterBeDisabled(filter)) {
-                    return { ...filter, isDisabled: true, isHiddenInUrl: true };
-                }
-                return filter;
-            }),
-        [primaryFilters, today, yesterday]
-    );
+    useEffect(() => {
+        setPackingManagerViewPrimaryFilters(
+            buildPackingManagerPrimaryFilters(primaryFilters, today, yesterday)
+        );
+    }, [primaryFilters, today, yesterday]);
 
-    const allFilters = useMemo(() => {
-        console.log("UU: recalculate allFilters");
-
-        const tmp = isPackingManagerView
+    const currentlyAppliedFilters = () => {
+        return isPackingManagerView
             ? [...packingManagerViewPrimaryFilters, ...additionalFilters]
             : [...primaryFilters, ...additionalFilters];
-
-        console.dir(tmp);
-        return tmp;
-    }, [isPackingManagerView, packingManagerViewPrimaryFilters, additionalFilters, primaryFilters]);
+    };
 
     useEffect(() => {
         if (!urlParamsHaveBeenProcessed) {
             return;
         }
 
-        console.log("UU: rebuilding query params from filters");
-
-        const paramsRecord = buildQueryParamsFromFilters(allFilters);
+        const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters());
         paramsRecord[pageViewTypeParam] = isPackingManagerView ? pageViewTypePackingManager : null;
         mergeParamsIntoURL(searchParams, paramsRecord);
-    }, [allFilters, isPackingManagerView, searchParams, urlParamsHaveBeenProcessed]);
+    }, [
+        isPackingManagerView,
+        primaryFilters,
+        packingManagerViewPrimaryFilters,
+        additionalFilters,
+        searchParams,
+        urlParamsHaveBeenProcessed,
+    ]);
 
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
         if (checkedParcelIds.length === 0) {
@@ -199,7 +188,11 @@ const ParcelsPage: React.FC = () => {
                     filters={
                         isPackingManagerView ? packingManagerViewPrimaryFilters : primaryFilters
                     }
-                    setFilters={setPrimaryFilters}
+                    setFilters={
+                        isPackingManagerView
+                            ? setPackingManagerViewPrimaryFilters
+                            : setPrimaryFilters
+                    }
                     additionalFilters={additionalFilters}
                     setAdditionalFilters={setAdditionalFilters}
                 />
@@ -224,7 +217,7 @@ const ParcelsPage: React.FC = () => {
                         openParcelModal={openParcelModalAndUpdateURL}
                         sortState={sortState}
                         setSortState={setSortState}
-                        appliedFilters={allFilters}
+                        appliedFilters={currentlyAppliedFilters()}
                         areFiltersLoadingForFirstTime={areFiltersLoadingForFirstTime}
                         setErrorMessage={setErrorMessage}
                         isPackingManagerView={isPackingManagerView}

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -5,7 +5,11 @@ import supabase from "@/supabaseClient";
 import { ParcelsTableRow, ParcelsSortState, ParcelsFilter } from "@/app/parcels/parcelsTable/types";
 import { useSearchParams } from "next/navigation";
 import { mergeParamsIntoURL, parseQueryParams } from "@/common/urlQueryParams";
-import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
+import {
+    pageViewTypePackingManager,
+    pageViewTypeParam,
+    parcelIdParam,
+} from "@/app/parcels/parcelsTable/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import buildFilters, {
     buildQueryParamsFromFilters,
@@ -48,6 +52,7 @@ const ParcelsPage: React.FC = () => {
 
     const [areFiltersLoadingForFirstTime, setAreFiltersLoadingForFirstTime] =
         useState<boolean>(true);
+    const [urlParamsHaveBeenProcessed, setUrlParamsHaveBeenProcessed] = useState<boolean>(false);
 
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -59,28 +64,41 @@ const ParcelsPage: React.FC = () => {
     const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
 
     useEffect(() => {
+        console.log("QQ: Page load");
+    }, []);
+
+    useEffect(() => {
         (async () => {
-            if (primaryFilters.length === 0 && additionalFilters.length === 0) {
-                setAreFiltersLoadingForFirstTime(true);
-                let filtersObject = await buildFilters();
-
-                const params = parseQueryParams(searchParams);
-                filtersObject = updateFiltersFromQueryParams(
-                    params,
-                    filtersObject.primaryFilters,
-                    filtersObject.additionalFilters
-                );
-
-                setPrimaryFilters(filtersObject.primaryFilters);
-                setAdditionalFilters(filtersObject.additionalFilters);
-                setAreFiltersLoadingForFirstTime(false);
-
-                if (params[parcelIdParam]) {
-                    openParcelModal(params[parcelIdParam] as string);
-                }
+            if (urlParamsHaveBeenProcessed) {
+                return;
             }
+
+            setAreFiltersLoadingForFirstTime(true);
+
+            const urlParams = parseQueryParams(searchParams);
+            if (urlParams[pageViewTypeParam] === pageViewTypePackingManager) {
+                setIsPackingManagerView(true);
+            }
+
+            let filtersObject = await buildFilters();
+
+            filtersObject = updateFiltersFromQueryParams(
+                urlParams,
+                filtersObject.primaryFilters,
+                filtersObject.additionalFilters
+            );
+
+            setPrimaryFilters(filtersObject.primaryFilters);
+            setAdditionalFilters(filtersObject.additionalFilters);
+            setAreFiltersLoadingForFirstTime(false);
+
+            if (urlParams[parcelIdParam]) {
+                openParcelModal(urlParams[parcelIdParam] as string);
+            }
+
+            setUrlParamsHaveBeenProcessed(true);
         })();
-    }, [searchParams, primaryFilters, additionalFilters]);
+    }, [urlParamsHaveBeenProcessed, searchParams, primaryFilters, additionalFilters]);
 
     const packingManagerViewPrimaryFilters = useMemo(
         () =>
@@ -90,10 +108,11 @@ const ParcelsPage: React.FC = () => {
                         ...filter,
                         state: { from: yesterday, to: today },
                         isDisabled: true,
+                        isHiddenInUrl: true,
                     } as ParcelsFilter<DateRangeState>;
                 }
                 if (shouldFilterBeDisabled(filter)) {
-                    return { ...filter, isDisabled: true };
+                    return { ...filter, isDisabled: true, isHiddenInUrl: true };
                 }
                 return filter;
             }),
@@ -107,13 +126,14 @@ const ParcelsPage: React.FC = () => {
     }, [isPackingManagerView, packingManagerViewPrimaryFilters, additionalFilters, primaryFilters]);
 
     useEffect(() => {
-        if (areFiltersLoadingForFirstTime) {
+        if (!urlParamsHaveBeenProcessed) {
             return;
         }
 
-        const filterParams = buildQueryParamsFromFilters(allFilters);
-        mergeParamsIntoURL(searchParams, filterParams);
-    }, [allFilters, areFiltersLoadingForFirstTime, searchParams]);
+        const paramsRecord = buildQueryParamsFromFilters(allFilters);
+        paramsRecord[pageViewTypeParam] = isPackingManagerView ? pageViewTypePackingManager : null;
+        mergeParamsIntoURL(searchParams, paramsRecord);
+    }, [allFilters, isPackingManagerView, searchParams, urlParamsHaveBeenProcessed]);
 
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
         if (checkedParcelIds.length === 0) {
@@ -142,6 +162,15 @@ const ParcelsPage: React.FC = () => {
 
         const paramsRecord: Record<string, string> = {};
         paramsRecord[parcelIdParam] = parcelId;
+        mergeParamsIntoURL(searchParams, paramsRecord);
+    };
+
+    const closeParcelModalAndUpdateURL = (): void => {
+        setModalIsOpen(false);
+        setSelectedParcelId(null);
+
+        const paramsRecord: Record<string, string | null> = {};
+        paramsRecord[parcelIdParam] = null;
         mergeParamsIntoURL(searchParams, paramsRecord);
     };
 
@@ -195,9 +224,8 @@ const ParcelsPage: React.FC = () => {
                     />
                     <ParcelsModal
                         modalIsOpen={modalIsOpen}
-                        setModalIsOpen={setModalIsOpen}
                         selectedParcelId={selectedParcelId}
-                        setSelectedParcelId={setSelectedParcelId}
+                        closeParcelModal={closeParcelModalAndUpdateURL}
                     />
                 </>
             )}

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -15,7 +15,8 @@ import {
     parcelIdParam,
 } from "@/app/parcels/parcelsTable/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
-import buildFilters, {
+import {
+    buildParcelFilters,
     buildPackingManagerPrimaryFilters,
     buildQueryParamsFromFilters,
     updateFiltersFromQueryParams,
@@ -66,7 +67,7 @@ const ParcelsPage: React.FC = () => {
     const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
 
     useEffect(() => {
-        console.log("QQ: Page load");
+        console.log("QQ: Page load: ", window.location.search);
     }, []);
 
     useEffect(() => {
@@ -75,14 +76,13 @@ const ParcelsPage: React.FC = () => {
                 return;
             }
 
+            console.log("VV: Processing URL params");
+
             setAreFiltersLoadingForFirstTime(true);
 
             const urlParams = parseQueryParams(searchParams.toString());
-            if (urlParams[pageViewTypeParam] === pageViewTypePackingManager) {
-                setIsPackingManagerView(true);
-            }
 
-            let filtersObject = await buildFilters();
+            let filtersObject = await buildParcelFilters(today);
 
             filtersObject = updateFiltersFromQueryParams(
                 urlParams,
@@ -94,13 +94,18 @@ const ParcelsPage: React.FC = () => {
             setAdditionalFilters(filtersObject.additionalFilters);
             setAreFiltersLoadingForFirstTime(false);
 
+            setIsPackingManagerView(
+                filtersObject.primaryFilters.find((filter) => filter.key === pageViewTypeParam)
+                    ?.state === pageViewTypePackingManager
+            );
+
             if (urlParams[parcelIdParam]) {
                 openParcelModal(urlParams[parcelIdParam] as string);
             }
 
             setUrlParamsHaveBeenProcessed(true);
         })();
-    }, [urlParamsHaveBeenProcessed, searchParams, primaryFilters, additionalFilters]);
+    }, [urlParamsHaveBeenProcessed, searchParams, primaryFilters, additionalFilters, today]);
 
     useEffect(() => {
         setPackingManagerViewPrimaryFilters(
@@ -122,11 +127,8 @@ const ParcelsPage: React.FC = () => {
         }
 
         console.log("QQ: about to buildQueryParamsFromFilters");
-        // QQ Why is this happening twice, both times showing the old searchParams filter value,
-        // and why does the table refreshed twice, the first time based on the old filter value?
 
         const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters);
-        paramsRecord[pageViewTypeParam] = isPackingManagerView ? pageViewTypePackingManager : null;
         mergeParamsIntoURL(searchParams, paramsRecord);
     }, [isPackingManagerView, currentlyAppliedFilters, searchParams, urlParamsHaveBeenProcessed]);
 
@@ -145,6 +147,15 @@ const ParcelsPage: React.FC = () => {
 
     const postCheckedParcelActivity = (): void => {
         setCheckedParcelIds([]);
+    };
+
+    const setIsPackingManagerViewInternal = (isPackingManager: boolean): void => {
+        const viewFilter = primaryFilters.find((filter) => filter.key === pageViewTypeParam);
+        if (viewFilter) {
+            viewFilter.state = isPackingManager ? pageViewTypePackingManager : "";
+        }
+
+        setIsPackingManagerView(isPackingManager);
     };
 
     const openParcelModal = (parcelId: string): void => {
@@ -174,7 +185,7 @@ const ParcelsPage: React.FC = () => {
             <PreTableControlsContainer>
                 <PreTableControls
                     isPackingManagerView={isPackingManagerView}
-                    setIsPackingManagerView={setIsPackingManagerView}
+                    setIsPackingManagerView={setIsPackingManagerViewInternal}
                     selectedParcelMessage={selectedParcelMessage}
                     getCheckedParcelsData={getCheckedParcelsData}
                     postCheckedParcelActivity={postCheckedParcelActivity}
@@ -184,10 +195,10 @@ const ParcelsPage: React.FC = () => {
                     DistributeServerFilter<ParcelsTableRow, ParcelTableFilterState, DbParcelRow>,
                     ParcelTableFilterState
                 >
-                    filters={
+                    primaryFilters={
                         isPackingManagerView ? packingManagerViewPrimaryFilters : primaryFilters
                     }
-                    setFilters={
+                    setPrimaryFilters={
                         isPackingManagerView
                             ? setPackingManagerViewPrimaryFilters
                             : setPrimaryFilters

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -1,15 +1,11 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import queryString from "query-string";
-import {
-    ParcelsTableRow,
-    ParcelsSortState,
-    ParcelsFilter,
-    SelectedClientDetails,
-} from "@/app/parcels/parcelsTable/types";
 import supabase from "@/supabaseClient";
+import { ParcelsTableRow, ParcelsSortState, ParcelsFilter } from "@/app/parcels/parcelsTable/types";
+import { useSearchParams } from "next/navigation";
+import { mergeParamsIntoURL, parseQueryParams } from "@/common/urlQueryParams";
+import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import buildFilters, {
     buildQueryParamsFromFilters,
@@ -33,12 +29,9 @@ import { PreTableControlsContainer } from "@/components/controlsStyling";
 type ParcelTableFilterState = string | DateRangeState | string[];
 
 const ParcelsPage: React.FC = () => {
-    const router = useRouter();
     const searchParams = useSearchParams();
 
     const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
-    const [selectedClientDetails, setSelectedClientDetails] =
-        useState<SelectedClientDetails | null>(null);
 
     const [checkedParcelIds, setCheckedParcelIds] = useState<string[]>([]);
 
@@ -58,8 +51,6 @@ const ParcelsPage: React.FC = () => {
 
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-    const [modalErrorMessage, setModalErrorMessage] = useState<string | null>(null);
-
     const selectedParcelMessage = getSelectedParcelCountMessage(checkedParcelIds.length);
 
     const [isPackingManagerView, setIsPackingManagerView] = useState<boolean>(false);
@@ -69,69 +60,27 @@ const ParcelsPage: React.FC = () => {
 
     useEffect(() => {
         (async () => {
-            setAreFiltersLoadingForFirstTime(true);
-            let filtersObject = await buildFilters();
+            if (primaryFilters.length === 0 && additionalFilters.length === 0) {
+                setAreFiltersLoadingForFirstTime(true);
+                let filtersObject = await buildFilters();
 
-            const params = queryString.parse(searchParams.toString());
-            filtersObject = updateFiltersFromQueryParams(
-                params,
-                filtersObject.primaryFilters,
-                filtersObject.additionalFilters
-            );
+                const params = parseQueryParams(searchParams);
+                filtersObject = updateFiltersFromQueryParams(
+                    params,
+                    filtersObject.primaryFilters,
+                    filtersObject.additionalFilters
+                );
 
-            setPrimaryFilters(filtersObject.primaryFilters);
-            setAdditionalFilters(filtersObject.additionalFilters);
-            setAreFiltersLoadingForFirstTime(false);
+                setPrimaryFilters(filtersObject.primaryFilters);
+                setAdditionalFilters(filtersObject.additionalFilters);
+                setAreFiltersLoadingForFirstTime(false);
 
-            console.log("QQ Filters loaded:");
+                if (params[parcelIdParam]) {
+                    openParcelModal(params[parcelIdParam] as string);
+                }
+            }
         })();
-    }, []);
-
-    // QQ utility function
-    const areRecordsEqual = (obj1: Record<string, any>, obj2: Record<string, any>): boolean => {
-        const keys1 = Object.keys(obj1);
-        const keys2 = Object.keys(obj2);
-
-        if (keys1.length !== keys2.length) {
-            return false;
-        }
-
-        return keys1.every((key) => obj1[key] === obj2[key]);
-    };
-
-    // QQ utility function
-    const mergeParamsIntoURL = (
-        searchParams: URLSearchParams,
-        paramsToUpdate: Record<string, any>
-    ) => {
-        const paramsInURL = queryString.parse(searchParams.toString());
-        let mergedParams = {
-            ...paramsInURL,
-            ...paramsToUpdate,
-        };
-        mergedParams = Object.fromEntries(
-            Object.entries(mergedParams).filter(([key, value]) => value)
-        );
-
-        if (!areRecordsEqual(paramsInURL, mergedParams)) {
-            console.log("QQ updating URL");
-
-            // App Router doesn't support shallow routing, so router.push would reload the page
-            const queryStringified = queryString.stringify(mergedParams);
-            window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);
-        }
-    };
-
-    useEffect(() => {
-        if (areFiltersLoadingForFirstTime) {
-            return;
-        }
-
-        const filterParams = buildQueryParamsFromFilters(primaryFilters, additionalFilters);
-        mergeParamsIntoURL(searchParams, filterParams);
-    }, [primaryFilters, additionalFilters]);
-
-    // QQ TODO: make filter URL params work with Packing Manager view
+    }, [searchParams]);
 
     const packingManagerViewPrimaryFilters = useMemo(
         () =>
@@ -157,6 +106,15 @@ const ParcelsPage: React.FC = () => {
             : [...primaryFilters, ...additionalFilters];
     }, [isPackingManagerView, packingManagerViewPrimaryFilters, additionalFilters, primaryFilters]);
 
+    useEffect(() => {
+        if (areFiltersLoadingForFirstTime) {
+            return;
+        }
+
+        const filterParams = buildQueryParamsFromFilters(allFilters);
+        mergeParamsIntoURL(searchParams, filterParams);
+    }, [allFilters, areFiltersLoadingForFirstTime, searchParams]);
+
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
         if (checkedParcelIds.length === 0) {
             return [];
@@ -172,6 +130,19 @@ const ParcelsPage: React.FC = () => {
 
     const postCheckedParcelActivity = (): void => {
         setCheckedParcelIds([]);
+    };
+
+    const openParcelModal = (parcelId: string): void => {
+        setSelectedParcelId(parcelId);
+        setModalIsOpen(true);
+    };
+
+    const openParcelModalAndUpdateURL = (parcelId: string): void => {
+        openParcelModal(parcelId);
+
+        const paramsRecord: Record<string, string> = {};
+        paramsRecord[parcelIdParam] = parcelId;
+        mergeParamsIntoURL(searchParams, paramsRecord);
     };
 
     return (
@@ -212,26 +183,21 @@ const ParcelsPage: React.FC = () => {
                         ></FloatingToast>
                     )}
                     <ParcelsTable
-                        setSelectedParcelId={setSelectedParcelId}
-                        setSelectedClientDetails={setSelectedClientDetails}
                         checkedParcelIds={checkedParcelIds}
                         setCheckedParcelIds={setCheckedParcelIds}
-                        setModalIsOpen={setModalIsOpen}
+                        openParcelModal={openParcelModalAndUpdateURL}
                         sortState={sortState}
                         setSortState={setSortState}
                         appliedFilters={allFilters}
                         areFiltersLoadingForFirstTime={areFiltersLoadingForFirstTime}
                         setErrorMessage={setErrorMessage}
-                        setModalErrorMessage={setModalErrorMessage}
                         isPackingManagerView={isPackingManagerView}
                     />
                     <ParcelsModal
                         modalIsOpen={modalIsOpen}
                         setModalIsOpen={setModalIsOpen}
                         selectedParcelId={selectedParcelId}
-                        selectedClientDetails={selectedClientDetails}
-                        modalErrorMessage={modalErrorMessage}
-                        setModalErrorMessage={setModalErrorMessage}
+                        setSelectedParcelId={setSelectedParcelId}
                     />
                 </>
             )}

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -119,7 +119,7 @@ const ParcelsPage: React.FC = () => {
         }
 
         const paramsRecord = buildQueryParamsFromFilters(currentlyAppliedFilters);
-        mergeParamsIntoURL(searchParams, paramsRecord);
+        mergeParamsIntoURL(paramsRecord);
     }, [isPackingManagerView, currentlyAppliedFilters, searchParams, urlParamsHaveBeenProcessed]);
 
     const getCheckedParcelsData = async (): Promise<ParcelsTableRow[]> => {
@@ -158,7 +158,7 @@ const ParcelsPage: React.FC = () => {
 
         const paramsRecord: Record<string, string> = {};
         paramsRecord[parcelIdParam] = parcelId;
-        mergeParamsIntoURL(searchParams, paramsRecord);
+        mergeParamsIntoURL(paramsRecord);
     };
 
     const closeParcelModalAndUpdateURL = (): void => {
@@ -167,7 +167,7 @@ const ParcelsPage: React.FC = () => {
 
         const paramsRecord: Record<string, string | null> = {};
         paramsRecord[parcelIdParam] = null;
-        mergeParamsIntoURL(searchParams, paramsRecord);
+        mergeParamsIntoURL(paramsRecord);
     };
 
     return (

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -120,15 +120,22 @@ const ParcelsPage: React.FC = () => {
     );
 
     const allFilters = useMemo(() => {
-        return isPackingManagerView
+        console.log("UU: recalculate allFilters");
+
+        const tmp = isPackingManagerView
             ? [...packingManagerViewPrimaryFilters, ...additionalFilters]
             : [...primaryFilters, ...additionalFilters];
+
+        console.dir(tmp);
+        return tmp;
     }, [isPackingManagerView, packingManagerViewPrimaryFilters, additionalFilters, primaryFilters]);
 
     useEffect(() => {
         if (!urlParamsHaveBeenProcessed) {
             return;
         }
+
+        console.log("UU: rebuilding query params from filters");
 
         const paramsRecord = buildQueryParamsFromFilters(allFilters);
         paramsRecord[pageViewTypeParam] = isPackingManagerView ? pageViewTypePackingManager : null;

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -80,7 +80,7 @@ const ParcelsPage: React.FC = () => {
                 }
             }
         })();
-    }, [searchParams]);
+    }, [searchParams, primaryFilters, additionalFilters]);
 
     const packingManagerViewPrimaryFilters = useMemo(
         () =>

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -77,7 +77,7 @@ const ParcelsPage: React.FC = () => {
 
             setAreFiltersLoadingForFirstTime(true);
 
-            const urlParams = parseQueryParams(searchParams);
+            const urlParams = parseQueryParams(searchParams.toString());
             if (urlParams[pageViewTypeParam] === pageViewTypePackingManager) {
                 setIsPackingManagerView(true);
             }

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -90,6 +90,9 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             setErrorMessage(null);
             setIsLoading(true);
 
+            console.log("TT: Fetching parcels data");
+            console.dir(appliedFilters);
+
             const { data, error } = await getParcelsDataAndCount(
                 supabase,
                 appliedFilters,
@@ -146,6 +149,8 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             clearTimeout(fetchParcelsTimer.current);
             fetchParcelsTimer.current = null;
         }
+
+        console.log("TT: loadCountAndDataWithTimer");
 
         setIsLoading(true);
         fetchParcelsTimer.current = setTimeout(() => {

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -84,12 +84,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         if (parcelsTableFetchAbortController.current) {
             setErrorMessage(null);
 
-            console.log("TT: Fetching parcels data");
-            console.dir(appliedFilters);
-
-            console.log("TT: Fetching parcels data");
-            console.dir(appliedFilters);
-
             const { data, error } = await getParcelsDataAndCount(
                 supabase,
                 appliedFilters,
@@ -138,8 +132,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             clearTimeout(fetchParcelsTimer.current);
             fetchParcelsTimer.current = null;
         }
-
-        console.log("TT: loadCountAndDataWithTimer");
 
         setIsLoading(true);
         fetchParcelsTimer.current = setTimeout(() => {

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -1,17 +1,11 @@
 import { BreakPointConfig, Row, ServerPaginatedTable } from "@/components/Tables/Table";
 import TableSurface from "@/components/Tables/TableSurface";
-import {
-    ParcelsFilter,
-    ParcelsSortState,
-    ParcelsTableRow,
-    SelectedClientDetails,
-} from "@/app/parcels/parcelsTable/types";
+import { ParcelsFilter, ParcelsSortState, ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import { DbParcelRow } from "@/databaseUtils";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
 import {
     defaultNumberOfParcelsPerPage,
     numberOfParcelsPerPageOptions,
-    parcelIdParam,
 } from "@/app/parcels/parcelsTable/constants";
 import {
     parcelTableDefaultShownHeaders,
@@ -19,7 +13,6 @@ import {
     parcelTableToggleableHeaders,
 } from "@/app/parcels/parcelsTable/headers";
 import {
-    getClientIdAndIsActiveErrorMessage,
     getParcelDataErrorMessage,
     parcelTableColumnDisplayFunctions,
 } from "@/app/parcels/parcelsTable/format";
@@ -30,9 +23,7 @@ import parcelsSortableColumns, {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dayjs from "dayjs";
 import { shouldBeInPackingManagerView } from "@/app/parcels/parcelsTable/packingManagerHelpers";
-import { useRouter, useSearchParams } from "next/navigation";
 import {
-    getClientIdAndIsActive,
     getParcelIds,
     getParcelsDataAndCount,
 } from "@/app/parcels/parcelsTable/fetchParcelTableData";
@@ -41,11 +32,9 @@ import { searchForBreakPoints } from "@/app/parcels/parcelsTable/conditionalStyl
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
 
 interface ParcelsTableProps {
-    setSelectedParcelId: (parcelId: string | null) => void;
-    setSelectedClientDetails: (clientDetails: SelectedClientDetails | null) => void;
     checkedParcelIds: string[];
     setCheckedParcelIds: (ids: string[]) => void;
-    setModalIsOpen: (isOpen: boolean) => void;
+    openParcelModal: (parcelId: string) => void;
     sortState: ParcelsSortState;
     setSortState: (sortState: ParcelsSortState) => void;
     appliedFilters: (
@@ -55,22 +44,18 @@ interface ParcelsTableProps {
     )[];
     areFiltersLoadingForFirstTime: boolean;
     setErrorMessage: (errorMessage: string | null) => void;
-    setModalErrorMessage: (errorMessage: string | null) => void;
     isPackingManagerView: boolean;
 }
 
 const ParcelsTable: React.FC<ParcelsTableProps> = ({
-    setSelectedParcelId,
-    setSelectedClientDetails,
     checkedParcelIds,
     setCheckedParcelIds,
-    setModalIsOpen,
+    openParcelModal,
     sortState,
     setSortState,
     appliedFilters,
     areFiltersLoadingForFirstTime,
     setErrorMessage,
-    setModalErrorMessage,
     isPackingManagerView,
 }) => {
     const [isLoading, setIsLoading] = useState(true);
@@ -84,9 +69,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     const [isAllCheckBoxSelected, setAllCheckBoxSelected] = useState(false);
     const fetchParcelsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const searchParams = useSearchParams();
-    const parcelId = searchParams.get(parcelIdParam);
-
     const [parcelCountPerPage, setParcelCountPerPage] = useState(defaultNumberOfParcelsPerPage);
     const [currentPage, setCurrentPage] = useState(1);
     const startPoint = (currentPage - 1) * parcelCountPerPage;
@@ -94,35 +76,8 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
 
     const parcelsTableFetchAbortController = useRef<AbortController | null>(null);
 
-    const router = useRouter();
-
     const today = useMemo(() => dayjs().startOf("day"), []);
     const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
-
-    const fetchAndSetClientDetailsForSelectedParcel = useCallback(async (): Promise<void> => {
-        if (parcelId === null) {
-            return;
-        }
-
-        const { data, error } = await getClientIdAndIsActive(parcelId);
-        if (error) {
-            setModalErrorMessage(getClientIdAndIsActiveErrorMessage(error));
-        } else {
-            setSelectedClientDetails(data);
-        }
-    }, [parcelId, setSelectedClientDetails, setModalErrorMessage]);
-
-    useEffect(() => {
-        if (parcelId) {
-            setSelectedParcelId(parcelId);
-            setModalIsOpen(true);
-        }
-    }, [parcelId, setSelectedParcelId, setModalIsOpen]);
-
-    useEffect(() => {
-        setSelectedClientDetails(null);
-        void fetchAndSetClientDetailsForSelectedParcel();
-    }, [fetchAndSetClientDetailsForSelectedParcel, setSelectedClientDetails]);
 
     const fetchAndDisplayParcelsData = useCallback(async (): Promise<void> => {
         if (parcelsTableFetchAbortController.current) {
@@ -268,8 +223,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     }, [filteredParcelCount, checkedParcelIds, isAllCheckBoxSelected]);
 
     const onParcelTableRowClick = (row: Row<ParcelsTableRow>): void => {
-        setSelectedParcelId(row.data.parcelId);
-        router.push(`/parcels?${parcelIdParam}=${row.data.parcelId}`);
+        openParcelModal(row.data.parcelId);
     };
 
     return (

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -20,9 +20,7 @@ import { parcelTableColumnStyleOptions } from "@/app/parcels/parcelsTable/styles
 import parcelsSortableColumns, {
     defaultParcelsSortConfig,
 } from "@/app/parcels/parcelsTable/sortableColumns";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import dayjs from "dayjs";
-import { shouldBeInPackingManagerView } from "@/app/parcels/parcelsTable/packingManagerHelpers";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
     getParcelIds,
     getParcelsDataAndCount,
@@ -76,9 +74,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
 
     const parcelsTableFetchAbortController = useRef<AbortController | null>(null);
 
-    const today = useMemo(() => dayjs().startOf("day"), []);
-    const yesterday = useMemo(() => today.subtract(1, "day"), [today]);
-
     const fetchAndDisplayParcelsData = useCallback(async (): Promise<void> => {
         if (parcelsTableFetchAbortController.current) {
             parcelsTableFetchAbortController.current.abort("stale request");
@@ -88,7 +83,9 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
 
         if (parcelsTableFetchAbortController.current) {
             setErrorMessage(null);
-            setIsLoading(true);
+
+            console.log("TT: Fetching parcels data");
+            console.dir(appliedFilters);
 
             console.log("TT: Fetching parcels data");
             console.dir(appliedFilters);
@@ -135,14 +132,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             void fetchAndDisplayParcelsData();
         }
     }, [areFiltersLoadingForFirstTime, fetchAndDisplayParcelsData]);
-
-    const packingManagerViewDataPortion = useMemo(
-        () =>
-            parcelsDataPortion.filter((parcel) =>
-                shouldBeInPackingManagerView(parcel, today, yesterday)
-            ),
-        [parcelsDataPortion, today, yesterday]
-    );
 
     const loadCountAndDataWithTimer = (): void => {
         if (fetchParcelsTimer.current) {
@@ -234,15 +223,11 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     return (
         <TableSurface>
             <ServerPaginatedTable<ParcelsTableRow, DbParcelRow, string | DateRangeState | string[]>
-                dataPortion={
-                    isPackingManagerView ? packingManagerViewDataPortion : parcelsDataPortion
-                }
+                dataPortion={parcelsDataPortion}
                 isLoading={isLoading}
                 paginationConfig={{
                     enablePagination: true,
-                    filteredCount: isPackingManagerView
-                        ? packingManagerViewDataPortion.length
-                        : filteredParcelCount,
+                    filteredCount: filteredParcelCount,
                     onPageChange: setCurrentPage,
                     onPerPageChange: setParcelCountPerPage,
                     defaultRowsPerPage: defaultNumberOfParcelsPerPage,

--- a/src/app/parcels/parcelsTable/PreTableControls.tsx
+++ b/src/app/parcels/parcelsTable/PreTableControls.tsx
@@ -17,12 +17,14 @@ const PreTableControls: React.FC<PreTableControlsProps> = (props) => {
             <Button
                 variant={props.isPackingManagerView ? "outlined" : "contained"}
                 onClick={() => props.setIsPackingManagerView(false)}
+                data-testid="all-parcels-button"
             >
                 All parcels
             </Button>
             <Button
                 variant={props.isPackingManagerView ? "contained" : "outlined"}
                 onClick={() => props.setIsPackingManagerView(true)}
+                data-testid="packing-manager-view-button"
             >
                 Packing manager view
             </Button>

--- a/src/app/parcels/parcelsTable/constants.ts
+++ b/src/app/parcels/parcelsTable/constants.ts
@@ -1,5 +1,8 @@
 export const parcelIdParam = "parcelId";
 
+export const pageViewTypeParam = "view";
+export const pageViewTypePackingManager = "Packing Manager";
+
 export const defaultNumberOfParcelsPerPage = 100;
 
 export const numberOfParcelsPerPageOptions = [10, 25, 50, 100];

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -17,7 +17,7 @@ import {
     packingSlotOptionsSet,
 } from "./types";
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
-import dayjs from "dayjs";
+import dayjs, { Dayjs } from "dayjs";
 import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 import { parcelTableHeaderKeysAndLabels } from "./headers";
 import { DbParcelRow } from "@/databaseUtils";
@@ -28,6 +28,7 @@ import {
     phoneSearch,
     postcodeSearch,
 } from "@/common/databaseFilters";
+import { shouldFilterBeDisabled } from "./packingManagerHelpers";
 
 const parcelsFullNameSearch: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",
@@ -294,12 +295,42 @@ export const updateFiltersFromQueryParams = (
     return { primaryFilters, additionalFilters };
 };
 
-export const buildQueryParamsFromFilters = (allFilters: ParcelsFilters): UrlQueryParamsRecord => {
+export const buildPackingManagerPrimaryFilters = (
+    primaryFilters: ParcelsFilters,
+    today: Dayjs,
+    yesterday: Dayjs
+): ParcelsFilters => {
+    return primaryFilters.map((filter) => {
+        if (shouldFilterBeDisabled(filter)) {
+            if (filter.key === "packingDate") {
+                return {
+                    ...filter,
+                    state: { from: yesterday, to: today },
+                    isDisabled: true,
+                    isHiddenInUrl: true,
+                } as ParcelsFilter<DateRangeState>;
+            } else if (["packingSlot", "lastStatus"].includes(filter.key)) {
+                return {
+                    ...filter,
+                    state: [] as string[],
+                    isDisabled: true,
+                    isHiddenInUrl: true,
+                } as ParcelsFilter<string[]>;
+            } else {
+                return { ...filter, isDisabled: true, isHiddenInUrl: true };
+            }
+        }
+
+        return { ...filter };
+    });
+};
+
+export const buildQueryParamsFromFilters = (
+    appliedFilters: ParcelsFilters
+): UrlQueryParamsRecord => {
     let params: UrlQueryParamsRecord = {};
 
-    console.dir(allFilters);
-
-    allFilters.forEach((filter: ParcelsFiltersAllStates) => {
+    appliedFilters.forEach((filter: ParcelsFiltersAllStates) => {
         params = { ...params, ...filter.generateUrlParam() };
     });
 

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -227,14 +227,6 @@ const buildSpecialViewFilter = (today: Dayjs): ParcelsFilter<string> => {
         shouldPersistOnClear: true,
         isHidden: true,
     });
-
-    // QQ
-    // return buildServerSideTextFilter({
-    //     key: pageViewTypeParam,
-    //     label: "View",
-    //     method: specialViewSearchMethod,
-    //     isHidden: true,
-    // });
 };
 
 export const buildParcelFilters = async (

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -17,6 +17,8 @@ import {
 } from "./types";
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import { ParsedQuery } from "query-string";
 import { parcelTableHeaderKeysAndLabels } from "./headers";
 import { DbParcelRow } from "@/databaseUtils";
 import {
@@ -241,6 +243,210 @@ const buildFilters = async (): Promise<{
         }),
     ];
     return { primaryFilters: primaryFilters, additionalFilters: additionalFilters };
+};
+
+// QQ utility function
+const readArrayParamFromQuery = (params: ParsedQuery, paramName: string): string[] | null => {
+    const paramValue = params[paramName];
+
+    if (paramValue) {
+        if (typeof paramValue === "string") {
+            return [paramValue];
+        } else if (Array.isArray(paramValue)) {
+            return paramValue.filter((method): method is string => method !== null);
+        }
+    }
+    return null;
+};
+
+export const updateFiltersFromQueryParams = (
+    params: ParsedQuery,
+    primaryFilters: ParcelsFilters,
+    additionalFilters: ParcelsFilters
+): {
+    primaryFilters: ParcelsFilters;
+    additionalFilters: ParcelsFilters;
+} => {
+    dayjs.extend(customParseFormat);
+
+    if (params.packingDateFrom && params.packingDateTo) {
+        const from = dayjs(params.packingDateFrom as string, "YYYY-MM-DD");
+        const to = dayjs(params.packingDateTo as string, "YYYY-MM-DD");
+
+        if (from.isValid() && to.isValid()) {
+            primaryFilters = primaryFilters.map((filter) => {
+                if (filter.key === "packingDate") {
+                    return {
+                        ...filter,
+                        state: { from: from, to: to },
+                    } as ParcelsFilter<DateRangeState>;
+                }
+                return filter;
+            });
+        }
+    }
+
+    if (params.name) {
+        primaryFilters = primaryFilters.map((filter) => {
+            if (filter.key === "fullName") {
+                return {
+                    ...filter,
+                    state: params.name,
+                } as ParcelsFilter<string>;
+            }
+            return filter;
+        });
+    }
+
+    if (params.postcode) {
+        primaryFilters = primaryFilters.map((filter) => {
+            if (filter.key === "addressPostcode") {
+                return {
+                    ...filter,
+                    state: params.postcode,
+                } as ParcelsFilter<string>;
+            }
+            return filter;
+        });
+    }
+
+    const methodParamValues = readArrayParamFromQuery(params, "method");
+    if (methodParamValues) {
+        primaryFilters = primaryFilters.map((filter) => {
+            if (filter.key === "deliveryCollection") {
+                return {
+                    ...filter,
+                    state: methodParamValues,
+                } as ParcelsFilter<string[]>;
+            }
+            return filter;
+        });
+    }
+
+    const packingSlotParamValues = readArrayParamFromQuery(params, "packingSlot");
+    if (packingSlotParamValues) {
+        primaryFilters = primaryFilters.map((filter) => {
+            if (filter.key === "packingSlot") {
+                return {
+                    ...filter,
+                    state: packingSlotParamValues,
+                } as ParcelsFilter<string[]>;
+            }
+            return filter;
+        });
+    }
+
+    const lastStatusParamValues = readArrayParamFromQuery(params, "lastStatus");
+    if (lastStatusParamValues) {
+        primaryFilters = primaryFilters.map((filter) => {
+            if (filter.key === "lastStatus") {
+                return {
+                    ...filter,
+                    state: lastStatusParamValues,
+                } as ParcelsFilter<string[]>;
+            }
+            return filter;
+        });
+    }
+
+    if (params.familySize) {
+        additionalFilters = additionalFilters.map((filter) => {
+            if (filter.key === "familyCategory") {
+                return {
+                    ...filter,
+                    state: params.familySize,
+                } as ParcelsFilter<string>;
+            }
+            return filter;
+        });
+    }
+
+    if (params.phone) {
+        additionalFilters = additionalFilters.map((filter) => {
+            if (filter.key === "phoneNumber") {
+                return {
+                    ...filter,
+                    state: params.phone,
+                } as ParcelsFilter<string>;
+            }
+            return filter;
+        });
+    }
+
+    if (params.voucher) {
+        additionalFilters = additionalFilters.map((filter) => {
+            if (filter.key === "voucherNumber") {
+                return {
+                    ...filter,
+                    state: params.voucher,
+                } as ParcelsFilter<string>;
+            }
+            return filter;
+        });
+    }
+
+    return { primaryFilters, additionalFilters };
+};
+
+export const buildQueryParamsFromFilters = (
+    primaryFilters: ParcelsFilters,
+    additionalFilters: ParcelsFilters
+): Record<string, string | string[]> => {
+    const params: Record<string, string | string[]> = {};
+
+    const packingDateFilter = primaryFilters.find((filter) => filter.key === "packingDate");
+    if (packingDateFilter) {
+        const { from, to } = packingDateFilter.state as DateRangeState;
+        params.packingDateFrom = from.format("YYYY-MM-DD");
+        params.packingDateTo = to.format("YYYY-MM-DD");
+    }
+
+    const fullNameFilter = primaryFilters.find((filter) => filter.key === "fullName");
+    if (fullNameFilter) {
+        params.name = fullNameFilter.state as string;
+    }
+
+    const postcodeFilter = primaryFilters.find((filter) => filter.key === "addressPostcode");
+    if (postcodeFilter) {
+        params.postcode = postcodeFilter.state as string;
+    }
+
+    const deliveryCollectionFilter = primaryFilters.find(
+        (filter) => filter.key === "deliveryCollection"
+    );
+    if (deliveryCollectionFilter) {
+        const deliveryCollectionState = deliveryCollectionFilter.state as string[];
+        params.method = deliveryCollectionState;
+    }
+
+    const packingSlotFilter = primaryFilters.find((filter) => filter.key === "packingSlot");
+    if (packingSlotFilter) {
+        const packingSlotState = packingSlotFilter.state as string[];
+        params.packingSlot = packingSlotState;
+    }
+
+    const lastStatusFilter = primaryFilters.find((filter) => filter.key === "lastStatus");
+    if (lastStatusFilter) {
+        const lastStatusState = lastStatusFilter.state as string[];
+        params.lastStatus = lastStatusState;
+    }
+
+    const familySizeFilter = additionalFilters.find((filter) => filter.key === "familyCategory");
+    if (familySizeFilter) {
+        params.familySize = familySizeFilter.state as string;
+    }
+
+    const phoneNumberFilter = additionalFilters.find((filter) => filter.key === "phoneNumber");
+    if (phoneNumberFilter) {
+        params.phone = phoneNumberFilter.state as string;
+    }
+
+    const voucherFilter = additionalFilters.find((filter) => filter.key === "voucherNumber");
+    if (voucherFilter) {
+        params.voucher = voucherFilter.state as string;
+    }
+
+    return params;
 };
 
 export default buildFilters;

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -12,13 +12,13 @@ import {
     ParcelsFilter,
     ParcelsFilterMethod,
     ParcelsFilters,
+    ParcelsFiltersAllStates,
     ParcelsTableRow,
     packingSlotOptionsSet,
 } from "./types";
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
 import dayjs from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import { ParsedQuery } from "query-string";
+import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 import { parcelTableHeaderKeysAndLabels } from "./headers";
 import { DbParcelRow } from "@/databaseUtils";
 import {
@@ -28,7 +28,6 @@ import {
     phoneSearch,
     postcodeSearch,
 } from "@/common/databaseFilters";
-import { readArrayParamFromQuery } from "@/common/urlQueryParams";
 
 const parcelsFullNameSearch: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",
@@ -247,190 +246,60 @@ const buildFilters = async (): Promise<{
 };
 
 export const updateFiltersFromQueryParams = (
-    params: ParsedQuery,
+    urlParams: UrlQueryParamsRecord,
     primaryFilters: ParcelsFilters,
     additionalFilters: ParcelsFilters
 ): {
     primaryFilters: ParcelsFilters;
     additionalFilters: ParcelsFilters;
 } => {
-    dayjs.extend(customParseFormat);
-
-    if (params.packingDateFrom && params.packingDateTo) {
-        const from = dayjs(params.packingDateFrom as string, "YYYY-MM-DD");
-        const to = dayjs(params.packingDateTo as string, "YYYY-MM-DD");
-
-        if (from.isValid() && to.isValid()) {
-            primaryFilters = primaryFilters.map((filter) => {
-                if (filter.key === "packingDate") {
-                    return {
-                        ...filter,
-                        state: { from: from, to: to },
-                    } as ParcelsFilter<DateRangeState>;
-                }
-                return filter;
-            });
+    primaryFilters = primaryFilters.map((filter) => {
+        const paramValForFilter = filter.readStateFromUrlQueryParams(urlParams);
+        if (paramValForFilter !== null) {
+            if (filter.key === "packingDate") {
+                return {
+                    ...filter,
+                    state: paramValForFilter,
+                } as ParcelsFilter<DateRangeState>;
+            } else if (["fullName", "addressPostcode"].includes(filter.key)) {
+                return {
+                    ...filter,
+                    state: paramValForFilter,
+                } as ParcelsFilter<string>;
+            } else if (["deliveryCollection", "packingSlot", "lastStatus"].includes(filter.key)) {
+                return {
+                    ...filter,
+                    state: paramValForFilter,
+                } as ParcelsFilter<string[]>;
+            }
         }
-    }
 
-    if (params.name) {
-        primaryFilters = primaryFilters.map((filter) => {
-            if (filter.key === "fullName") {
+        return filter;
+    });
+
+    additionalFilters = additionalFilters.map((filter) => {
+        const paramValForFilter = filter.readStateFromUrlQueryParams(urlParams);
+        if (paramValForFilter !== null) {
+            if (["familyCategory", "phoneNumber", "voucherNumber"].includes(filter.key)) {
                 return {
                     ...filter,
-                    state: params.name,
+                    state: paramValForFilter,
                 } as ParcelsFilter<string>;
             }
-            return filter;
-        });
-    }
+        }
 
-    if (params.postcode) {
-        primaryFilters = primaryFilters.map((filter) => {
-            if (filter.key === "addressPostcode") {
-                return {
-                    ...filter,
-                    state: params.postcode,
-                } as ParcelsFilter<string>;
-            }
-            return filter;
-        });
-    }
-
-    const methodParamValues = readArrayParamFromQuery(params, "method");
-    if (methodParamValues) {
-        primaryFilters = primaryFilters.map((filter) => {
-            if (filter.key === "deliveryCollection") {
-                return {
-                    ...filter,
-                    state: methodParamValues,
-                } as ParcelsFilter<string[]>;
-            }
-            return filter;
-        });
-    }
-
-    const packingSlotParamValues = readArrayParamFromQuery(params, "packingSlot");
-    if (packingSlotParamValues) {
-        primaryFilters = primaryFilters.map((filter) => {
-            if (filter.key === "packingSlot") {
-                return {
-                    ...filter,
-                    state: packingSlotParamValues,
-                } as ParcelsFilter<string[]>;
-            }
-            return filter;
-        });
-    }
-
-    const lastStatusParamValues = readArrayParamFromQuery(params, "lastStatus");
-    if (lastStatusParamValues) {
-        primaryFilters = primaryFilters.map((filter) => {
-            if (filter.key === "lastStatus") {
-                return {
-                    ...filter,
-                    state: lastStatusParamValues,
-                } as ParcelsFilter<string[]>;
-            }
-            return filter;
-        });
-    }
-
-    if (params.familySize) {
-        additionalFilters = additionalFilters.map((filter) => {
-            if (filter.key === "familyCategory") {
-                return {
-                    ...filter,
-                    state: params.familySize,
-                } as ParcelsFilter<string>;
-            }
-            return filter;
-        });
-    }
-
-    if (params.phone) {
-        additionalFilters = additionalFilters.map((filter) => {
-            if (filter.key === "phoneNumber") {
-                return {
-                    ...filter,
-                    state: params.phone,
-                } as ParcelsFilter<string>;
-            }
-            return filter;
-        });
-    }
-
-    if (params.voucher) {
-        additionalFilters = additionalFilters.map((filter) => {
-            if (filter.key === "voucherNumber") {
-                return {
-                    ...filter,
-                    state: params.voucher,
-                } as ParcelsFilter<string>;
-            }
-            return filter;
-        });
-    }
+        return filter;
+    });
 
     return { primaryFilters, additionalFilters };
 };
 
-export const buildQueryParamsFromFilters = (
-    allFilters: ParcelsFilters
-): Record<string, string | string[]> => {
-    const params: Record<string, string | string[]> = {};
+export const buildQueryParamsFromFilters = (allFilters: ParcelsFilters): UrlQueryParamsRecord => {
+    let params: UrlQueryParamsRecord = {};
 
-    const packingDateFilter = allFilters.find((filter) => filter.key === "packingDate");
-    if (packingDateFilter) {
-        const { from, to } = packingDateFilter.state as DateRangeState;
-        params.packingDateFrom = from.format("YYYY-MM-DD");
-        params.packingDateTo = to.format("YYYY-MM-DD");
-    }
-
-    const fullNameFilter = allFilters.find((filter) => filter.key === "fullName");
-    if (fullNameFilter) {
-        params.name = fullNameFilter.state as string;
-    }
-
-    const postcodeFilter = allFilters.find((filter) => filter.key === "addressPostcode");
-    if (postcodeFilter) {
-        params.postcode = postcodeFilter.state as string;
-    }
-
-    const deliveryCollectionFilter = allFilters.find(
-        (filter) => filter.key === "deliveryCollection"
-    );
-    if (deliveryCollectionFilter) {
-        const deliveryCollectionState = deliveryCollectionFilter.state as string[];
-        params.method = deliveryCollectionState;
-    }
-
-    const packingSlotFilter = allFilters.find((filter) => filter.key === "packingSlot");
-    if (packingSlotFilter) {
-        const packingSlotState = packingSlotFilter.state as string[];
-        params.packingSlot = packingSlotState;
-    }
-
-    const lastStatusFilter = allFilters.find((filter) => filter.key === "lastStatus");
-    if (lastStatusFilter) {
-        const lastStatusState = lastStatusFilter.state as string[];
-        params.lastStatus = lastStatusState;
-    }
-
-    const familySizeFilter = allFilters.find((filter) => filter.key === "familyCategory");
-    if (familySizeFilter) {
-        params.familySize = familySizeFilter.state as string;
-    }
-
-    const phoneNumberFilter = allFilters.find((filter) => filter.key === "phoneNumber");
-    if (phoneNumberFilter) {
-        params.phone = phoneNumberFilter.state as string;
-    }
-
-    const voucherFilter = allFilters.find((filter) => filter.key === "voucherNumber");
-    if (voucherFilter) {
-        params.voucher = voucherFilter.state as string;
-    }
+    allFilters.forEach((filter: ParcelsFiltersAllStates) => {
+        params = { ...params, ...filter.generateUrlParam() };
+    });
 
     return params;
 };

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -297,6 +297,8 @@ export const updateFiltersFromQueryParams = (
 export const buildQueryParamsFromFilters = (allFilters: ParcelsFilters): UrlQueryParamsRecord => {
     let params: UrlQueryParamsRecord = {};
 
+    console.dir(allFilters);
+
     allFilters.forEach((filter: ParcelsFiltersAllStates) => {
         params = { ...params, ...filter.generateUrlParam() };
     });

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -28,6 +28,7 @@ import {
     phoneSearch,
     postcodeSearch,
 } from "@/common/databaseFilters";
+import { readArrayParamFromQuery } from "@/common/urlQueryParams";
 
 const parcelsFullNameSearch: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",
@@ -245,20 +246,6 @@ const buildFilters = async (): Promise<{
     return { primaryFilters: primaryFilters, additionalFilters: additionalFilters };
 };
 
-// QQ utility function
-const readArrayParamFromQuery = (params: ParsedQuery, paramName: string): string[] | null => {
-    const paramValue = params[paramName];
-
-    if (paramValue) {
-        if (typeof paramValue === "string") {
-            return [paramValue];
-        } else if (Array.isArray(paramValue)) {
-            return paramValue.filter((method): method is string => method !== null);
-        }
-    }
-    return null;
-};
-
 export const updateFiltersFromQueryParams = (
     params: ParsedQuery,
     primaryFilters: ParcelsFilters,
@@ -389,29 +376,28 @@ export const updateFiltersFromQueryParams = (
 };
 
 export const buildQueryParamsFromFilters = (
-    primaryFilters: ParcelsFilters,
-    additionalFilters: ParcelsFilters
+    allFilters: ParcelsFilters
 ): Record<string, string | string[]> => {
     const params: Record<string, string | string[]> = {};
 
-    const packingDateFilter = primaryFilters.find((filter) => filter.key === "packingDate");
+    const packingDateFilter = allFilters.find((filter) => filter.key === "packingDate");
     if (packingDateFilter) {
         const { from, to } = packingDateFilter.state as DateRangeState;
         params.packingDateFrom = from.format("YYYY-MM-DD");
         params.packingDateTo = to.format("YYYY-MM-DD");
     }
 
-    const fullNameFilter = primaryFilters.find((filter) => filter.key === "fullName");
+    const fullNameFilter = allFilters.find((filter) => filter.key === "fullName");
     if (fullNameFilter) {
         params.name = fullNameFilter.state as string;
     }
 
-    const postcodeFilter = primaryFilters.find((filter) => filter.key === "addressPostcode");
+    const postcodeFilter = allFilters.find((filter) => filter.key === "addressPostcode");
     if (postcodeFilter) {
         params.postcode = postcodeFilter.state as string;
     }
 
-    const deliveryCollectionFilter = primaryFilters.find(
+    const deliveryCollectionFilter = allFilters.find(
         (filter) => filter.key === "deliveryCollection"
     );
     if (deliveryCollectionFilter) {
@@ -419,29 +405,29 @@ export const buildQueryParamsFromFilters = (
         params.method = deliveryCollectionState;
     }
 
-    const packingSlotFilter = primaryFilters.find((filter) => filter.key === "packingSlot");
+    const packingSlotFilter = allFilters.find((filter) => filter.key === "packingSlot");
     if (packingSlotFilter) {
         const packingSlotState = packingSlotFilter.state as string[];
         params.packingSlot = packingSlotState;
     }
 
-    const lastStatusFilter = primaryFilters.find((filter) => filter.key === "lastStatus");
+    const lastStatusFilter = allFilters.find((filter) => filter.key === "lastStatus");
     if (lastStatusFilter) {
         const lastStatusState = lastStatusFilter.state as string[];
         params.lastStatus = lastStatusState;
     }
 
-    const familySizeFilter = additionalFilters.find((filter) => filter.key === "familyCategory");
+    const familySizeFilter = allFilters.find((filter) => filter.key === "familyCategory");
     if (familySizeFilter) {
         params.familySize = familySizeFilter.state as string;
     }
 
-    const phoneNumberFilter = additionalFilters.find((filter) => filter.key === "phoneNumber");
+    const phoneNumberFilter = allFilters.find((filter) => filter.key === "phoneNumber");
     if (phoneNumberFilter) {
         params.phone = phoneNumberFilter.state as string;
     }
 
-    const voucherFilter = additionalFilters.find((filter) => filter.key === "voucherNumber");
+    const voucherFilter = allFilters.find((filter) => filter.key === "voucherNumber");
     if (voucherFilter) {
         params.voucher = voucherFilter.state as string;
     }

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -17,9 +17,9 @@ import {
     packingSlotOptionsSet,
 } from "./types";
 import { buildServerSideTextFilter } from "@/components/Tables/TextFilter";
-import dayjs, { Dayjs } from "dayjs";
+import { serverSideButtonGroupFilter } from "@/components/Tables/ButtonFilter";
+import { Dayjs } from "dayjs";
 import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
-import { parcelTableHeaderKeysAndLabels } from "./headers";
 import { DbParcelRow } from "@/databaseUtils";
 import {
     dbFilterWithSubstringQueries,
@@ -28,29 +28,33 @@ import {
     phoneSearch,
     postcodeSearch,
 } from "@/common/databaseFilters";
-import { shouldFilterBeDisabled } from "./packingManagerHelpers";
+import {
+    packingManagerParcelStatuses,
+    shouldFilterBeDisabledInPackingManagerView,
+} from "./packingManagerHelpers";
+import { pageViewTypePackingManager, pageViewTypeParam } from "./constants";
 
-const parcelsFullNameSearch: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
+const parcelsFullNameSearchMethod: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",
     "client_is_active"
 );
 
-const parcelsPostcodeSearch: ParcelsFilterMethod<string> = postcodeSearch<DbParcelRow>(
+const parcelsPostcodeSearchMethod: ParcelsFilterMethod<string> = postcodeSearch<DbParcelRow>(
     "client_address_postcode",
     "client_is_active"
 );
 
-const parcelsFamilySearch: ParcelsFilterMethod<string> = familySearch(
+const parcelsFamilySearchMethod: ParcelsFilterMethod<string> = familySearch(
     "family_count",
     "client_is_active"
 );
 
-const parcelsPhoneSearch: ParcelsFilterMethod<string> = phoneSearch<DbParcelRow>(
+const parcelsPhoneSearchMethod: ParcelsFilterMethod<string> = phoneSearch<DbParcelRow>(
     "client_phone_number",
     "client_is_active"
 );
 
-const voucherSearch: ParcelsFilterMethod<string> = dbFilterWithSubstringQueries<DbParcelRow>(
+const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQueries<DbParcelRow>(
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
@@ -195,11 +199,50 @@ const buildPackingSlotFilter = async (): Promise<ParcelsFilter<string[]>> => {
     });
 };
 
-const buildFilters = async (): Promise<{
+const buildSpecialViewFilter = (today: Dayjs): ParcelsFilter<string> => {
+    const yesterday = today.subtract(1, "day");
+
+    const specialViewSearchMethod: ParcelsFilterMethod<string> = (query, state) => {
+        if (state === pageViewTypePackingManager) {
+            return query
+                .or(
+                    `and(packing_date.eq.${getDbDate(yesterday)}, packing_slot_name.eq."PM"), ` +
+                        `and(packing_date.eq.${getDbDate(today)}, packing_slot_name.eq."AM")`
+                )
+                .in("last_status_event_name", packingManagerParcelStatuses);
+        }
+
+        return query;
+    };
+
+    return serverSideButtonGroupFilter({
+        key: pageViewTypeParam,
+        filterLabel: "",
+        itemLabelsAndKeys: [
+            ["All parcels", ""],
+            ["Packing manager view", pageViewTypePackingManager],
+        ],
+        initialActiveFilter: "",
+        method: specialViewSearchMethod,
+        shouldPersistOnClear: true,
+        isHidden: true,
+    });
+
+    // QQ
+    // return buildServerSideTextFilter({
+    //     key: pageViewTypeParam,
+    //     label: "View",
+    //     method: specialViewSearchMethod,
+    //     isHidden: true,
+    // });
+};
+
+export const buildParcelFilters = async (
+    today: Dayjs
+): Promise<{
     primaryFilters: ParcelsFilters;
     additionalFilters: ParcelsFilters;
 }> => {
-    const today = dayjs();
     const dateFilter = buildDateFilter({
         from: today,
         to: today,
@@ -209,41 +252,75 @@ const buildFilters = async (): Promise<{
         buildServerSideTextFilter({
             key: "fullName",
             label: "Name",
-            headers: parcelTableHeaderKeysAndLabels,
-            method: parcelsFullNameSearch,
+            method: parcelsFullNameSearchMethod,
         }),
         buildServerSideTextFilter({
             key: "addressPostcode",
             label: "Postcode",
-            headers: parcelTableHeaderKeysAndLabels,
-            method: parcelsPostcodeSearch,
+            method: parcelsPostcodeSearchMethod,
         }),
         await buildDeliveryCollectionFilter(),
         await buildPackingSlotFilter(),
         await buildLastStatusFilter(),
+        buildSpecialViewFilter(today),
     ];
 
     const additionalFilters: ParcelsFilters = [
         buildServerSideTextFilter({
             key: "familyCategory",
             label: "Family Size",
-            headers: parcelTableHeaderKeysAndLabels,
-            method: parcelsFamilySearch,
+            method: parcelsFamilySearchMethod,
         }),
         buildServerSideTextFilter({
             key: "phoneNumber",
             label: "Phone",
-            headers: parcelTableHeaderKeysAndLabels,
-            method: parcelsPhoneSearch,
+            method: parcelsPhoneSearchMethod,
         }),
         buildServerSideTextFilter({
             key: "voucherNumber",
             label: "Voucher",
-            headers: parcelTableHeaderKeysAndLabels,
-            method: voucherSearch,
+            method: voucherSearchMethod,
         }),
     ];
     return { primaryFilters: primaryFilters, additionalFilters: additionalFilters };
+};
+
+export const buildPackingManagerPrimaryFilters = (
+    primaryFilters: ParcelsFilters,
+    today: Dayjs,
+    yesterday: Dayjs
+): ParcelsFilters => {
+    return primaryFilters.map((filter) => {
+        if (shouldFilterBeDisabledInPackingManagerView(filter)) {
+            if (filter.key === "packingDate") {
+                return {
+                    ...filter,
+                    state: { from: yesterday, to: today },
+                    isDisabled: true,
+                    isHiddenInUrl: true,
+                } as ParcelsFilter<DateRangeState>;
+            } else if (["packingSlot", "lastStatus"].includes(filter.key)) {
+                return {
+                    ...filter,
+                    state: [] as string[],
+                    isDisabled: true,
+                    isHiddenInUrl: true,
+                } as ParcelsFilter<string[]>;
+            } else if (filter.key === pageViewTypeParam) {
+                return {
+                    ...filter,
+                    state: pageViewTypePackingManager,
+                    isDisabled: true,
+                    isHidden: true,
+                    isHiddenInUrl: false,
+                } as ParcelsFilter<string>;
+            } else {
+                return { ...filter, isDisabled: true, isHiddenInUrl: true };
+            }
+        }
+
+        return { ...filter };
+    });
 };
 
 export const updateFiltersFromQueryParams = (
@@ -262,7 +339,7 @@ export const updateFiltersFromQueryParams = (
                     ...filter,
                     state: paramValForFilter,
                 } as ParcelsFilter<DateRangeState>;
-            } else if (["fullName", "addressPostcode"].includes(filter.key)) {
+            } else if (["fullName", "addressPostcode", pageViewTypeParam].includes(filter.key)) {
                 return {
                     ...filter,
                     state: paramValForFilter,
@@ -295,36 +372,6 @@ export const updateFiltersFromQueryParams = (
     return { primaryFilters, additionalFilters };
 };
 
-export const buildPackingManagerPrimaryFilters = (
-    primaryFilters: ParcelsFilters,
-    today: Dayjs,
-    yesterday: Dayjs
-): ParcelsFilters => {
-    return primaryFilters.map((filter) => {
-        if (shouldFilterBeDisabled(filter)) {
-            if (filter.key === "packingDate") {
-                return {
-                    ...filter,
-                    state: { from: yesterday, to: today },
-                    isDisabled: true,
-                    isHiddenInUrl: true,
-                } as ParcelsFilter<DateRangeState>;
-            } else if (["packingSlot", "lastStatus"].includes(filter.key)) {
-                return {
-                    ...filter,
-                    state: [] as string[],
-                    isDisabled: true,
-                    isHiddenInUrl: true,
-                } as ParcelsFilter<string[]>;
-            } else {
-                return { ...filter, isDisabled: true, isHiddenInUrl: true };
-            }
-        }
-
-        return { ...filter };
-    });
-};
-
 export const buildQueryParamsFromFilters = (
     appliedFilters: ParcelsFilters
 ): UrlQueryParamsRecord => {
@@ -336,5 +383,3 @@ export const buildQueryParamsFromFilters = (
 
     return params;
 };
-
-export default buildFilters;

--- a/src/app/parcels/parcelsTable/packingManagerHelpers.ts
+++ b/src/app/parcels/parcelsTable/packingManagerHelpers.ts
@@ -1,38 +1,21 @@
-import { areDaysIdentical } from "@/components/Tables/DateFilter";
-import { ParcelsFilter, ParcelsTableRow } from "./types";
-import dayjs from "dayjs";
+import { ParcelsFilter } from "./types";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
+import { pageViewTypeParam } from "./constants";
 
-export const shouldBeInPackingManagerView = (
-    parcel: ParcelsTableRow,
-    today: dayjs.Dayjs,
-    yesterday: dayjs.Dayjs
-): boolean => {
-    if (areDaysIdentical(dayjs(parcel.packingDate), today) && parcel.packingSlot !== "AM") {
-        return false;
-    }
-    if (areDaysIdentical(dayjs(parcel.packingDate), yesterday) && parcel.packingSlot !== "PM") {
-        return false;
-    }
-    if (parcel.lastStatus) {
-        if (
-            parcel.lastStatus.name.includes("Shipping Labels Downloaded") ||
-            parcel.lastStatus.name.includes("Shopping List Downloaded") ||
-            parcel.lastStatus.name.includes("Called and Confirmed")
-        ) {
-            return true;
-        }
-    }
-    return false;
-};
+export const packingManagerParcelStatuses = [
+    "Shipping Labels Downloaded",
+    "Shopping List Downloaded",
+    "Called and Confirmed",
+];
 
-export const shouldFilterBeDisabled = (
+export const shouldFilterBeDisabledInPackingManagerView = (
     filter: ParcelsFilter<string> | ParcelsFilter<DateRangeState> | ParcelsFilter<string[]>
 ): boolean => {
     if (
         filter.key === "packingDate" ||
         filter.key === "packingSlot" ||
-        filter.key === "lastStatus"
+        filter.key === "lastStatus" ||
+        filter.key === pageViewTypeParam
     ) {
         return true;
     }

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -1,6 +1,5 @@
 "use client";
 
-import { ReadonlyURLSearchParams } from "next/navigation";
 import queryString, { ParsedQuery } from "query-string";
 
 export type UrlQueryParamsRecord = ParsedQuery;
@@ -47,10 +46,7 @@ const areRecordsEqual = (obj1: UrlQueryParamsRecord, obj2: UrlQueryParamsRecord)
     );
 };
 
-export const mergeParamsIntoURL = (
-    searchParams: ReadonlyURLSearchParams,
-    paramsToUpdate: UrlQueryParamsRecord
-): void => {
+export const mergeParamsIntoURL = (paramsToUpdate: UrlQueryParamsRecord): void => {
     const paramsInURL = parseQueryParams(window.location.search);
 
     const mergedParams = {

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { ReadonlyURLSearchParams } from "next/navigation";
+import queryString, { ParsedQuery } from "query-string";
+
+export const parseQueryParams = (searchParams: ReadonlyURLSearchParams): ParsedQuery => {
+    const parsedQuery = queryString.parse(searchParams.toString());
+    return parsedQuery;
+};
+
+export const readArrayParamFromQuery = (
+    params: ParsedQuery,
+    paramName: string
+): string[] | null => {
+    const paramValue = params[paramName];
+
+    if (paramValue) {
+        if (typeof paramValue === "string") {
+            return [paramValue];
+        } else if (Array.isArray(paramValue)) {
+            return paramValue.filter((method): method is string => method !== null);
+        }
+    }
+    return null;
+};
+
+const areRecordsEqual = (obj1: ParsedQuery<string>, obj2: ParsedQuery<string>): boolean => {
+    const keys1 = Object.keys(obj1);
+    const keys2 = Object.keys(obj2);
+
+    if (keys1.length !== keys2.length) {
+        return false;
+    }
+
+    return keys1.every((key) => obj1[key] === obj2[key]);
+};
+
+export const mergeParamsIntoURL = (
+    searchParams: ReadonlyURLSearchParams,
+    paramsToUpdate: Record<string, string | null | string[]>
+): void => {
+    const paramsInURL = queryString.parse(searchParams.toString());
+
+    const mergedParams = {
+        ...paramsInURL,
+        ...paramsToUpdate,
+    };
+    const nonEmptyMergedParams = Object.fromEntries(
+        Object.entries(mergedParams).filter(
+            ([_key, value]) =>
+                (Array.isArray(value) && value.length > 0) || (!Array.isArray(value) && value)
+        )
+    );
+
+    console.log("QQ Potentially updating URL...");
+    console.dir(paramsInURL);
+    console.dir(nonEmptyMergedParams);
+
+    if (!areRecordsEqual(paramsInURL, nonEmptyMergedParams)) {
+        console.log("Updating URL with new params:", nonEmptyMergedParams);
+
+        const queryStringified = queryString.stringify(nonEmptyMergedParams);
+
+        // App Router doesn't support shallow routing, so router.push would reload the page
+        window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);
+    }
+};

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -3,8 +3,10 @@
 import { ReadonlyURLSearchParams } from "next/navigation";
 import queryString, { ParsedQuery } from "query-string";
 
+export type UrlQueryParamsRecord = ParsedQuery;
+
 export const parseQueryParams = (searchParams: ReadonlyURLSearchParams): ParsedQuery => {
-    const parsedQuery = queryString.parse(searchParams.toString());
+    const parsedQuery = queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
     return parsedQuery;
 };
 
@@ -14,17 +16,25 @@ export const readArrayParamFromQuery = (
 ): string[] | null => {
     const paramValue = params[paramName];
 
+    // QQ is this needed with arrayFormat: bracket?
+
     if (paramValue) {
         if (typeof paramValue === "string") {
             return [paramValue];
         } else if (Array.isArray(paramValue)) {
-            return paramValue.filter((method): method is string => method !== null);
+            return paramValue.filter((val): val is string => val !== null);
         }
     }
     return null;
 };
 
-const areRecordsEqual = (obj1: ParsedQuery<string>, obj2: ParsedQuery<string>): boolean => {
+// QQ: Use standard solution here
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const areStringArraysEqual = (arr1: any[], arr2: any[]): boolean => {
+    return arr1.length === arr2.length && arr1.every((val, index) => arr2[index] === val);
+};
+
+const areRecordsEqual = (obj1: UrlQueryParamsRecord, obj2: UrlQueryParamsRecord): boolean => {
     const keys1 = Object.keys(obj1);
     const keys2 = Object.keys(obj2);
 
@@ -32,14 +42,20 @@ const areRecordsEqual = (obj1: ParsedQuery<string>, obj2: ParsedQuery<string>): 
         return false;
     }
 
-    return keys1.every((key) => obj1[key] === obj2[key]);
+    return keys1.every(
+        (key) =>
+            obj1[key] === obj2[key] ||
+            (Array.isArray(obj1[key]) &&
+                Array.isArray(obj2[key]) &&
+                areStringArraysEqual(obj1[key], obj2[key]))
+    );
 };
 
 export const mergeParamsIntoURL = (
     searchParams: ReadonlyURLSearchParams,
-    paramsToUpdate: Record<string, string | null | string[]>
+    paramsToUpdate: UrlQueryParamsRecord
 ): void => {
-    const paramsInURL = queryString.parse(searchParams.toString());
+    const paramsInURL = queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
 
     const mergedParams = {
         ...paramsInURL,
@@ -53,7 +69,13 @@ export const mergeParamsIntoURL = (
     );
 
     if (!areRecordsEqual(paramsInURL, nonEmptyMergedParams)) {
-        const queryStringified = queryString.stringify(nonEmptyMergedParams);
+        console.log("QQ: about to push new location state:");
+        console.dir(paramsInURL);
+        console.dir(nonEmptyMergedParams);
+
+        const queryStringified = queryString.stringify(nonEmptyMergedParams, {
+            arrayFormat: "bracket",
+        });
 
         // App Router doesn't support shallow routing, so router.push would reload the page
         window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -25,7 +25,6 @@ export const readArrayParamFromQuery = (
     return null;
 };
 
-// QQ: Use standard solution here
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const areStringArraysEqual = (arr1: any[], arr2: any[]): boolean => {
     return arr1.length === arr2.length && arr1.every((val, index) => arr2[index] === val);
@@ -66,19 +65,9 @@ export const mergeParamsIntoURL = (
     );
 
     if (!areRecordsEqual(paramsInURL, nonEmptyMergedParams)) {
-        console.log("QQ: about to push new location state:");
-        console.dir(paramsInURL);
-        console.dir(nonEmptyMergedParams);
-
         const queryStringified = queryString.stringify(nonEmptyMergedParams, {
             arrayFormat: "bracket",
         });
-
-        console.log("UU: window.location.search: ", window.location.search);
-        console.log(
-            "UU: window.location.pathname: ",
-            `${window.location.pathname}?${queryStringified}`
-        );
 
         // App Router doesn't support shallow routing, so router.push would reload the page
         window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -5,8 +5,8 @@ import queryString, { ParsedQuery } from "query-string";
 
 export type UrlQueryParamsRecord = ParsedQuery;
 
-export const parseQueryParams = (searchParams: ReadonlyURLSearchParams): UrlQueryParamsRecord => {
-    return queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
+export const parseQueryParams = (queryParams: string): UrlQueryParamsRecord => {
+    return queryString.parse(queryParams, { arrayFormat: "bracket" });
 };
 
 export const readArrayParamFromQuery = (
@@ -52,7 +52,7 @@ export const mergeParamsIntoURL = (
     searchParams: ReadonlyURLSearchParams,
     paramsToUpdate: UrlQueryParamsRecord
 ): void => {
-    const paramsInURL = parseQueryParams(searchParams);
+    const paramsInURL = parseQueryParams(window.location.search);
 
     const mergedParams = {
         ...paramsInURL,

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -5,18 +5,15 @@ import queryString, { ParsedQuery } from "query-string";
 
 export type UrlQueryParamsRecord = ParsedQuery;
 
-export const parseQueryParams = (searchParams: ReadonlyURLSearchParams): ParsedQuery => {
-    const parsedQuery = queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
-    return parsedQuery;
+export const parseQueryParams = (searchParams: ReadonlyURLSearchParams): UrlQueryParamsRecord => {
+    return queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
 };
 
 export const readArrayParamFromQuery = (
-    params: ParsedQuery,
+    params: UrlQueryParamsRecord,
     paramName: string
 ): string[] | null => {
     const paramValue = params[paramName];
-
-    // QQ is this needed with arrayFormat: bracket?
 
     if (paramValue) {
         if (typeof paramValue === "string") {
@@ -55,7 +52,7 @@ export const mergeParamsIntoURL = (
     searchParams: ReadonlyURLSearchParams,
     paramsToUpdate: UrlQueryParamsRecord
 ): void => {
-    const paramsInURL = queryString.parse(searchParams.toString(), { arrayFormat: "bracket" });
+    const paramsInURL = parseQueryParams(searchParams);
 
     const mergedParams = {
         ...paramsInURL,

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -74,6 +74,12 @@ export const mergeParamsIntoURL = (
             arrayFormat: "bracket",
         });
 
+        console.log("UU: window.location.search: ", window.location.search);
+        console.log(
+            "UU: window.location.pathname: ",
+            `${window.location.pathname}?${queryStringified}`
+        );
+
         // App Router doesn't support shallow routing, so router.push would reload the page
         window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);
     }

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -52,13 +52,7 @@ export const mergeParamsIntoURL = (
         )
     );
 
-    console.log("QQ Potentially updating URL...");
-    console.dir(paramsInURL);
-    console.dir(nonEmptyMergedParams);
-
     if (!areRecordsEqual(paramsInURL, nonEmptyMergedParams)) {
-        console.log("Updating URL with new params:", nonEmptyMergedParams);
-
         const queryStringified = queryString.stringify(nonEmptyMergedParams);
 
         // App Router doesn't support shallow routing, so router.push would reload the page

--- a/src/components/DateInputs/DateRangeInputs.tsx
+++ b/src/components/DateInputs/DateRangeInputs.tsx
@@ -86,9 +86,14 @@ const DateRangeInputs: React.FC<Props> = (props) => {
                     textField: {
                         error: hasErrorState,
                         size: "small",
+                        inputProps: {
+                            "data-testid": "date-range-input-from",
+                            "aria-label": "From date",
+                        },
                     },
                 }}
                 disabled={props.isDisabled}
+                data-testid="date-range-input-from"
             />
             <DatePicker
                 onChange={(value) => setToValue(value)}
@@ -99,6 +104,10 @@ const DateRangeInputs: React.FC<Props> = (props) => {
                     textField: {
                         error: hasErrorState,
                         size: "small",
+                        inputProps: {
+                            "data-testid": "date-range-input-to",
+                            "aria-label": "To date",
+                        },
                     },
                 }}
                 disabled={props.isDisabled}

--- a/src/components/DateInputs/DateRangeInputs.tsx
+++ b/src/components/DateInputs/DateRangeInputs.tsx
@@ -11,6 +11,16 @@ export interface DateRangeState {
     to: Dayjs;
 }
 
+export const isDateRangeValid = (from: Dayjs, to: Dayjs): boolean => {
+    return (
+        from.isValid() &&
+        to.isValid() &&
+        from <= to &&
+        from >= reasonableMinDate &&
+        to >= reasonableMinDate
+    );
+};
+
 interface Props {
     range: DateRangeState;
     setRange: (range: DateRangeState) => void;

--- a/src/components/Tables/ButtonFilter.tsx
+++ b/src/components/Tables/ButtonFilter.tsx
@@ -83,7 +83,7 @@ export const buttonGroupFilter = <Data,>({
             if (this.isHiddenInUrl) {
                 paramRecord[key as string] = null;
             } else {
-                paramRecord[key as string] = this.state as string; // QQ what does this do on Lists?
+                paramRecord[key as string] = this.state as string;
             }
             return paramRecord;
         },

--- a/src/components/Tables/ButtonFilter.tsx
+++ b/src/components/Tables/ButtonFilter.tsx
@@ -1,36 +1,53 @@
 "use client";
 
 import React from "react";
-import { ClientSideFilter, ClientSideFilterMethod, defaultToString } from "./Filters";
+import {
+    ClientSideFilter,
+    ClientSideFilterMethod,
+    defaultToString,
+    ServerSideFilter,
+    ServerSideFilterMethod,
+} from "./Filters";
 import Button from "@mui/material/Button";
 import { capitaliseWords } from "@/common/format";
 import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 
 interface ButtonGroupFilterProps<Data> {
-    key: keyof Data;
+    key: string;
+    rowKey?: keyof Data;
     filterLabel: string;
-    filterOptions: string[];
+    itemLabelsAndKeys: [string, string][];
     initialActiveFilter: string;
-    method: ClientSideFilterMethod<Data, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHidden?: boolean;
     isHiddenInUrl?: boolean;
+}
+
+interface ServerSideButtonGroupFilterProps<Data, DbData extends Record<string, unknown>>
+    extends ButtonGroupFilterProps<Data> {
+    method: ServerSideFilterMethod<DbData, string>;
+}
+
+interface ClientSideButtonGroupFilterProps<Data> extends ButtonGroupFilterProps<Data> {
+    method: ClientSideFilterMethod<Data, string>;
 }
 
 interface ButtonProps {
     activeFilter: string;
     buttonLabel: string;
+    buttonKey: string;
     setState: (state: string) => void;
     isDisabled?: boolean;
 }
 
 const FilterButton: React.FC<ButtonProps> = (buttonProps) => {
-    const isActive = buttonProps.activeFilter === buttonProps.buttonLabel;
+    const isActive = buttonProps.activeFilter === buttonProps.buttonKey;
     return (
         <Button
             color="primary"
             variant={isActive ? "contained" : "outlined"}
-            onClick={() => buttonProps.setState(buttonProps.buttonLabel)}
+            onClick={() => buttonProps.setState(buttonProps.buttonKey)}
             disabled={buttonProps.isDisabled}
         >
             {capitaliseWords(buttonProps.buttonLabel)}
@@ -38,16 +55,17 @@ const FilterButton: React.FC<ButtonProps> = (buttonProps) => {
     );
 };
 
-export const buttonGroupFilter = <Data,>({
+export const serverSideButtonGroupFilter = <Data, DbData extends Record<string, unknown>>({
     key,
     filterLabel,
-    filterOptions,
+    itemLabelsAndKeys,
     initialActiveFilter,
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHidden = false,
     isHiddenInUrl = false,
-}: ButtonGroupFilterProps<Data>): ClientSideFilter<Data, string> => {
+}: ServerSideButtonGroupFilterProps<Data, DbData>): ServerSideFilter<Data, string, DbData> => {
     return {
         key: key,
         state: initialActiveFilter,
@@ -56,20 +74,22 @@ export const buttonGroupFilter = <Data,>({
         areStatesIdentical: (stateA, stateB) => stateA === stateB,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHidden: isHidden,
         isHiddenInUrl: isHiddenInUrl,
         filterComponent: function (
             state: string,
             setState: (state: string) => void,
             isDisabled: boolean
         ): React.ReactNode {
-            return (
+            return isHidden ? null : (
                 <>
                     {filterLabel}
-                    {filterOptions.map((optionName) => (
+                    {itemLabelsAndKeys.map(([label, key]) => (
                         <FilterButton
-                            key={optionName}
+                            key={key}
                             activeFilter={state}
-                            buttonLabel={optionName}
+                            buttonLabel={label}
+                            buttonKey={key}
                             setState={setState}
                             isDisabled={isDisabled}
                         />
@@ -94,6 +114,74 @@ export const buttonGroupFilter = <Data,>({
     };
 };
 
-export const filterRowbyButton = <Data,>(row: Data, state: string, key: keyof Data): boolean => {
-    return defaultToString(row[key]) === state;
+export const clientSideButtonGroupFilter = <Data,>({
+    key,
+    rowKey,
+    filterLabel,
+    itemLabelsAndKeys,
+    initialActiveFilter,
+    method,
+    shouldPersistOnClear = false,
+    isDisabled = false,
+    isHidden = false,
+    isHiddenInUrl = false,
+}: ClientSideButtonGroupFilterProps<Data>): ClientSideFilter<Data, string> => {
+    return {
+        key: key,
+        rowKey: rowKey,
+        state: initialActiveFilter,
+        initialState: initialActiveFilter,
+        method: method,
+        areStatesIdentical: (stateA, stateB) => stateA === stateB,
+        shouldPersistOnClear: shouldPersistOnClear,
+        isDisabled: isDisabled,
+        isHidden: isHidden,
+        isHiddenInUrl: isHiddenInUrl,
+        filterComponent: function (
+            state: string,
+            setState: (state: string) => void,
+            isDisabled: boolean
+        ): React.ReactNode {
+            return isHidden ? null : (
+                <>
+                    {filterLabel}
+                    {itemLabelsAndKeys.map(([label, key]) => (
+                        <FilterButton
+                            key={key}
+                            activeFilter={state}
+                            buttonLabel={label}
+                            buttonKey={key}
+                            setState={setState}
+                            isDisabled={isDisabled}
+                        />
+                    ))}
+                </>
+            );
+        },
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                paramRecord[key as string] = this.state as string;
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            const paramVal = urlParams[key as string];
+            return paramVal && typeof paramVal == "string" ? paramVal : null;
+        },
+    };
+};
+
+export const filterRowbyButton = <Data,>(
+    row: Data,
+    state: string,
+    rowKey?: keyof Data
+): boolean => {
+    if (!rowKey) {
+        return false;
+    }
+    return defaultToString(row[rowKey]) === state;
 };

--- a/src/components/Tables/ButtonFilter.tsx
+++ b/src/components/Tables/ButtonFilter.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { ClientSideFilter, ClientSideFilterMethod, defaultToString } from "./Filters";
 import Button from "@mui/material/Button";
 import { capitaliseWords } from "@/common/format";
+import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 
 interface ButtonGroupFilterProps<Data> {
     key: keyof Data;
@@ -13,6 +14,7 @@ interface ButtonGroupFilterProps<Data> {
     method: ClientSideFilterMethod<Data, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHiddenInUrl?: boolean;
 }
 
 interface ButtonProps {
@@ -44,6 +46,7 @@ export const buttonGroupFilter = <Data,>({
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHiddenInUrl = false,
 }: ButtonGroupFilterProps<Data>): ClientSideFilter<Data, string> => {
     return {
         key: key,
@@ -53,7 +56,7 @@ export const buttonGroupFilter = <Data,>({
         areStatesIdentical: (stateA, stateB) => stateA === stateB,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
-
+        isHiddenInUrl: isHiddenInUrl,
         filterComponent: function (
             state: string,
             setState: (state: string) => void,
@@ -73,6 +76,20 @@ export const buttonGroupFilter = <Data,>({
                     ))}
                 </>
             );
+        },
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                paramRecord[key as string] = this.state as string; // QQ what does this do on Lists?
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            const paramVal = urlParams[key as string];
+            return paramVal && typeof paramVal == "string" ? paramVal : null;
         },
     };
 };

--- a/src/components/Tables/ChecklistFilter.tsx
+++ b/src/components/Tables/ChecklistFilter.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import CheckboxGroupPopup from "../DataInput/CheckboxGroupPopup";
 import { ServerSideFilter, ServerSideFilterMethod } from "./Filters";
+import { UrlQueryParamsRecord, readArrayParamFromQuery } from "@/common/urlQueryParams";
 
 interface ChecklistFilterProps<
     Data,
@@ -15,6 +16,7 @@ interface ChecklistFilterProps<
     method: ServerSideFilterMethod<DbData, string[]>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHiddenInUrl?: boolean;
 }
 
 export const serverSideChecklistFilter = <
@@ -28,6 +30,7 @@ export const serverSideChecklistFilter = <
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHiddenInUrl = false,
 }: ChecklistFilterProps<Data, DbData>): ServerSideFilter<Data, string[], DbData> => {
     return {
         key: key,
@@ -36,6 +39,7 @@ export const serverSideChecklistFilter = <
         method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHiddenInUrl: isHiddenInUrl,
         areStatesIdentical: (stateA, stateB) =>
             stateA.length === stateB.length && stateA.every((optionA) => stateB.includes(optionA)),
         filterComponent: function (
@@ -67,6 +71,20 @@ export const serverSideChecklistFilter = <
                     isDisabled={isDisabled}
                 />
             );
+        },
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                paramRecord[key as string] = this.state as string[];
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            const paramArray = readArrayParamFromQuery(urlParams, key as string);
+            return paramArray && Array.isArray(paramArray) ? paramArray : null;
         },
     };
 };

--- a/src/components/Tables/ChecklistFilter.tsx
+++ b/src/components/Tables/ChecklistFilter.tsx
@@ -9,13 +9,15 @@ interface ChecklistFilterProps<
     Data,
     DbData extends Record<string, unknown> = Record<string, never>,
 > {
-    key: keyof Data;
+    key: string;
+    rowKey?: keyof Data;
     filterLabel: string;
     itemLabelsAndKeys: [string, string][];
     initialCheckedKeys: string[];
     method: ServerSideFilterMethod<DbData, string[]>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHidden?: boolean;
     isHiddenInUrl?: boolean;
 }
 
@@ -30,6 +32,7 @@ export const serverSideChecklistFilter = <
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHidden = false,
     isHiddenInUrl = false,
 }: ChecklistFilterProps<Data, DbData>): ServerSideFilter<Data, string[], DbData> => {
     return {
@@ -39,6 +42,7 @@ export const serverSideChecklistFilter = <
         method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHidden: isHidden,
         isHiddenInUrl: isHiddenInUrl,
         areStatesIdentical: (stateA, stateB) =>
             stateA.length === stateB.length && stateA.every((optionA) => stateB.includes(optionA)),
@@ -47,6 +51,10 @@ export const serverSideChecklistFilter = <
             setState: (state: string[]) => void,
             isDisabled: boolean
         ): React.ReactNode {
+            if (isHidden) {
+                return null;
+            }
+
             const onChangeCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
                 const checkboxKey = event.target.name as string;
                 if (event.target.checked) {

--- a/src/components/Tables/DateFilter.tsx
+++ b/src/components/Tables/DateFilter.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { ServerSideFilter, ServerSideFilterMethod } from "./Filters";
-import DateRangeInputs, { DateRangeState } from "../DateInputs/DateRangeInputs";
+import DateRangeInputs, { DateRangeState, isDateRangeValid } from "../DateInputs/DateRangeInputs";
 import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import { UrlQueryParamsRecord, readArrayParamFromQuery } from "@/common/urlQueryParams";
 
 interface DateFilterProps<Data, DbData extends Record<string, unknown>> {
     key: keyof Data;
@@ -10,6 +12,7 @@ interface DateFilterProps<Data, DbData extends Record<string, unknown>> {
     initialState: DateRangeState;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHiddenInUrl?: boolean;
 }
 
 const areDateRangesIdentical = (
@@ -32,6 +35,7 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
     initialState,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHiddenInUrl = false,
 }: DateFilterProps<Data, DbData>): ServerSideFilter<Data, DateRangeState, DbData> => {
     return {
         key: key,
@@ -40,6 +44,7 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
         method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHiddenInUrl: isHiddenInUrl,
         areStatesIdentical: (stateA, stateB) => areDateRangesIdentical(stateA, stateB),
         filterComponent: function (
             state: DateRangeState,
@@ -54,6 +59,31 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
                     isDisabled={isDisabled}
                 />
             );
+        },
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                const { from, to } = this.state;
+                paramRecord[key as string] = [from.format("YYYY-MM-DD"), to.format("YYYY-MM-DD")];
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            dayjs.extend(customParseFormat);
+
+            const dateParamValues = readArrayParamFromQuery(urlParams, key as string);
+            if (dateParamValues && dateParamValues.length === 2) {
+                const from = dayjs(dateParamValues[0] as string, "YYYY-MM-DD");
+                const to = dayjs(dateParamValues[1] as string, "YYYY-MM-DD");
+                if (isDateRangeValid(from, to)) {
+                    return { from: from, to: to };
+                }
+            }
+
+            return null;
         },
     };
 };

--- a/src/components/Tables/DateFilter.tsx
+++ b/src/components/Tables/DateFilter.tsx
@@ -6,12 +6,14 @@ import customParseFormat from "dayjs/plugin/customParseFormat";
 import { UrlQueryParamsRecord, readArrayParamFromQuery } from "@/common/urlQueryParams";
 
 interface DateFilterProps<Data, DbData extends Record<string, unknown>> {
-    key: keyof Data;
+    key: string;
+    rowKey?: keyof Data;
     label: string;
     method: ServerSideFilterMethod<DbData, DateRangeState>;
     initialState: DateRangeState;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHidden?: boolean;
     isHiddenInUrl?: boolean;
 }
 
@@ -35,6 +37,7 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
     initialState,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHidden = false,
     isHiddenInUrl = false,
 }: DateFilterProps<Data, DbData>): ServerSideFilter<Data, DateRangeState, DbData> => {
     return {
@@ -44,6 +47,7 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
         method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHidden: isHidden,
         isHiddenInUrl: isHiddenInUrl,
         areStatesIdentical: (stateA, stateB) => areDateRangesIdentical(stateA, stateB),
         filterComponent: function (
@@ -51,7 +55,7 @@ export const serverSideDateFilter = <Data, DbData extends Record<string, unknown
             setState: (state: DateRangeState) => void,
             isDisabled: boolean
         ): React.ReactNode {
-            return (
+            return isHidden ? null : (
                 <DateRangeInputs
                     key={key as string}
                     range={state}

--- a/src/components/Tables/Filters.tsx
+++ b/src/components/Tables/Filters.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { TableHeaders } from "@/components/Tables/Table";
 import { Database } from "@/databaseTypesFile";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
@@ -23,11 +22,12 @@ export type ServerSideFilterMethod<DbData extends Record<string, unknown>, State
 export type ClientSideFilterMethod<Data, State> = (
     row: Data,
     state: State,
-    key: keyof Data
+    rowKey?: keyof Data
 ) => boolean;
 
 interface BasicFilter<Data, State> {
-    key: keyof Data;
+    key: string;
+    rowKey?: keyof Data;
     filterComponent: (
         state: State,
         setState: (state: State) => void,
@@ -40,6 +40,7 @@ interface BasicFilter<Data, State> {
     readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => State | null;
     shouldPersistOnClear: boolean;
     isDisabled: boolean;
+    isHidden: boolean;
     isHiddenInUrl: boolean;
 }
 
@@ -68,13 +69,6 @@ export type DistributeServerFilter<
 export type FilterBase<Data, State> =
     | DistributeClientFilter<Data, State>
     | DistributeServerFilter<Data, State, Record<string, unknown>>;
-
-export const headerLabelFromKey = <Data, Key extends keyof Data>(
-    headers: TableHeaders<Data>,
-    key: Key
-): string => {
-    return headers.find(([headerKey]) => headerKey === key)?.[1] ?? key.toString();
-};
 
 export const defaultToString = (value: unknown): string => {
     if (typeof value === "string") {

--- a/src/components/Tables/Filters.tsx
+++ b/src/components/Tables/Filters.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { TableHeaders } from "@/components/Tables/Table";
 import { Database } from "@/databaseTypesFile";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
+import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 
 export enum PaginationType {
     Server = "SERVER",
@@ -32,11 +33,14 @@ interface BasicFilter<Data, State> {
         setState: (state: State) => void,
         isDisabled: boolean
     ) => React.ReactNode;
-    state: State;
     initialState: State;
+    state: State;
     areStatesIdentical: (stateA: State, stateB: State) => boolean;
+    generateUrlParam: () => UrlQueryParamsRecord;
+    readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => State | null;
     shouldPersistOnClear: boolean;
     isDisabled: boolean;
+    isHiddenInUrl: boolean;
 }
 
 export interface ServerSideFilter<Data, State, DbData extends Record<string, unknown>>

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -439,12 +439,12 @@ const Table = <
                         : DistributeServerFilter<Data, FilterState, DbData>,
                     FilterState
                 >
-                    setFilters={
+                    setPrimaryFilters={
                         filterConfig.primaryFiltersShown
                             ? filterConfig.setPrimaryFilters
                             : undefined
                     }
-                    filters={
+                    primaryFilters={
                         filterConfig.primaryFiltersShown ? filterConfig.primaryFilters : undefined
                     }
                     additionalFilters={

--- a/src/components/Tables/TableFiltersBar.tsx
+++ b/src/components/Tables/TableFiltersBar.tsx
@@ -8,9 +8,9 @@ import { FilterBase } from "@/components/Tables/Filters";
 import { MENU_BREAKPOINT } from "@/common/sharedConstants";
 
 export interface TableFiltersBarProps<Data, Filter extends FilterBase<Data, State>, State> {
-    setFilters?: (filters: Filter[]) => void;
+    setPrimaryFilters?: (filters: Filter[]) => void;
     setAdditionalFilters?: (filters: Filter[]) => void;
-    filters?: Filter[];
+    primaryFilters?: Filter[];
     additionalFilters?: Filter[];
 }
 
@@ -73,9 +73,9 @@ function TableFiltersBar<Data, Filter extends FilterBase<Data, State>, State>(
     props: TableFiltersBarProps<Data, Filter, State>
 ): React.ReactElement {
     const handleClear = (): void => {
-        if (props.setFilters && props.filters) {
-            props.setFilters(
-                props.filters?.map((filter) =>
+        if (props.setPrimaryFilters && props.primaryFilters) {
+            props.setPrimaryFilters(
+                props.primaryFilters?.map((filter) =>
                     filter.shouldPersistOnClear
                         ? filter
                         : {
@@ -101,7 +101,7 @@ function TableFiltersBar<Data, Filter extends FilterBase<Data, State>, State>(
 
     const [showMoreFilters, setShowMoreFilters] = useState(false);
 
-    const hasPrimaryFilters = props.filters?.length !== 0 && props.setFilters;
+    const hasPrimaryFilters = props.primaryFilters?.length !== 0 && props.setPrimaryFilters;
 
     const hasAdditionalFilters =
         props.additionalFilters?.length !== 0 && props.setAdditionalFilters;
@@ -120,12 +120,12 @@ function TableFiltersBar<Data, Filter extends FilterBase<Data, State>, State>(
                 {hasPrimaryFilters && <FilterAltOutlined />}
                 <FiltersSingleRowContainer>
                     <>
-                        {props.filters &&
-                            props.filters?.length !== 0 &&
-                            props.setFilters &&
+                        {props.primaryFilters &&
+                            props.primaryFilters?.length !== 0 &&
+                            props.setPrimaryFilters &&
                             filtersToComponents<Data, Filter, State>(
-                                props.filters,
-                                props.setFilters
+                                props.primaryFilters,
+                                props.setPrimaryFilters
                             )}
                         <Grow />
                         {hasAdditionalFilters && (

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -8,17 +8,17 @@ import {
     ClientSideFilterMethod,
     ClientSideFilter,
 } from "./Filters";
-import { TableHeaders } from "./Table";
 import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 
 interface ServerSideTextFilterProps<Data, DbData extends Record<string, unknown>> {
-    key: keyof Data;
-    headers: TableHeaders<Data>;
+    key: string;
+    rowKey?: keyof Data;
     label: string;
     initialValue?: string;
     method: ServerSideFilterMethod<DbData, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHidden?: boolean;
     isHiddenInUrl?: boolean;
 }
 
@@ -35,6 +35,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHidden = false,
     isHiddenInUrl = false,
 }: ServerSideTextFilterProps<Data, DbData>): ServerSideFilter<Data, string, DbData> => {
     return {
@@ -44,9 +45,10 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
         method: method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHidden: isHidden,
         isHiddenInUrl: isHiddenInUrl,
         filterComponent: (state, setState, isDisabled) => {
-            return (
+            return isHidden ? null : (
                 <TextFilterStyling key={label}>
                     <FreeFormTextInput
                         key={label}
@@ -80,35 +82,40 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
 };
 
 interface ClientSideTextFilterProps<Data> {
-    key: keyof Data;
-    headers: TableHeaders<Data>;
+    key: string;
+    rowKey?: keyof Data;
     label: string;
     initialValue?: string;
     method: ClientSideFilterMethod<Data, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHidden?: boolean;
     isHiddenInUrl?: boolean;
 }
 
 export const buildClientSideTextFilter = <Data,>({
     key,
+    rowKey,
     label,
     initialValue = "",
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHidden = false,
     isHiddenInUrl = false,
 }: ClientSideTextFilterProps<Data>): ClientSideFilter<Data, string> => {
     return {
         state: initialValue,
         initialState: initialValue,
         key: key,
+        rowKey: rowKey,
         method: method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHidden: isHidden,
         isHiddenInUrl: isHiddenInUrl,
         filterComponent: (state, setState) => {
-            return (
+            return isHidden ? null : (
                 <TextFilterStyling key={label}>
                     <FreeFormTextInput
                         key={label}
@@ -140,8 +147,12 @@ export const buildClientSideTextFilter = <Data,>({
     };
 };
 
-export const filterRowByText = <Data,>(row: Data, state: string, key: keyof Data): boolean => {
-    let string = defaultToString(row[key]);
+export const filterRowByText = <Data,>(row: Data, state: string, rowKey?: keyof Data): boolean => {
+    if (!rowKey) {
+        return false;
+    }
+
+    let string = defaultToString(row[rowKey]);
     string = string.toLowerCase();
     state = state.toLowerCase();
     return string.includes(state);

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -9,6 +9,7 @@ import {
     ClientSideFilter,
 } from "./Filters";
 import { TableHeaders } from "./Table";
+import { UrlQueryParamsRecord } from "@/common/urlQueryParams";
 
 interface ServerSideTextFilterProps<Data, DbData extends Record<string, unknown>> {
     key: keyof Data;
@@ -18,6 +19,7 @@ interface ServerSideTextFilterProps<Data, DbData extends Record<string, unknown>
     method: ServerSideFilterMethod<DbData, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHiddenInUrl?: boolean;
 }
 
 const TextFilterStyling = styled.div`
@@ -33,6 +35,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHiddenInUrl = false,
 }: ServerSideTextFilterProps<Data, DbData>): ServerSideFilter<Data, string, DbData> => {
     return {
         state: initialValue,
@@ -41,6 +44,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
         method: method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHiddenInUrl: isHiddenInUrl,
         filterComponent: (state, setState, isDisabled) => {
             return (
                 <TextFilterStyling key={label}>
@@ -58,6 +62,20 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
             );
         },
         areStatesIdentical: (stateA, stateB) => stateA === stateB,
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                paramRecord[key as string] = this.state as string;
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            const paramVal = urlParams[key as string];
+            return paramVal && typeof paramVal == "string" ? paramVal : null;
+        },
     };
 };
 
@@ -69,6 +87,7 @@ interface ClientSideTextFilterProps<Data> {
     method: ClientSideFilterMethod<Data, string>;
     shouldPersistOnClear?: boolean;
     isDisabled?: boolean;
+    isHiddenInUrl?: boolean;
 }
 
 export const buildClientSideTextFilter = <Data,>({
@@ -78,6 +97,7 @@ export const buildClientSideTextFilter = <Data,>({
     method,
     shouldPersistOnClear = false,
     isDisabled = false,
+    isHiddenInUrl = false,
 }: ClientSideTextFilterProps<Data>): ClientSideFilter<Data, string> => {
     return {
         state: initialValue,
@@ -86,6 +106,7 @@ export const buildClientSideTextFilter = <Data,>({
         method: method,
         shouldPersistOnClear: shouldPersistOnClear,
         isDisabled: isDisabled,
+        isHiddenInUrl: isHiddenInUrl,
         filterComponent: (state, setState) => {
             return (
                 <TextFilterStyling key={label}>
@@ -102,6 +123,20 @@ export const buildClientSideTextFilter = <Data,>({
             );
         },
         areStatesIdentical: (stateA, stateB) => stateA === stateB,
+        generateUrlParam: function (): UrlQueryParamsRecord {
+            const paramRecord: UrlQueryParamsRecord = {};
+
+            if (this.isHiddenInUrl) {
+                paramRecord[key as string] = null;
+            } else {
+                paramRecord[key as string] = this.state as string;
+            }
+            return paramRecord;
+        },
+        readStateFromUrlQueryParams: (urlParams: UrlQueryParamsRecord) => {
+            const paramVal = urlParams[key as string];
+            return paramVal && typeof paramVal == "string" ? paramVal : null;
+        },
     };
 };
 

--- a/src/components/Tables/TextFilter.tsx
+++ b/src/components/Tables/TextFilter.tsx
@@ -59,6 +59,7 @@ export const buildServerSideTextFilter = <Data, DbData extends Record<string, un
                         }}
                         size="small"
                         disabled={isDisabled}
+                        data-testid={`text-filter-${key}`}
                     />
                 </TextFilterStyling>
             );
@@ -125,6 +126,7 @@ export const buildClientSideTextFilter = <Data,>({
                             setState(event.target.value);
                         }}
                         size="small"
+                        data-testid={`text-filter-${key}`}
                     />
                 </TextFilterStyling>
             );

--- a/src/components/Tables/_tests/WrappedTable.tsx
+++ b/src/components/Tables/_tests/WrappedTable.tsx
@@ -117,12 +117,12 @@ const WrappedTableForTest: React.FC<MockTableProps> = ({
     useEffect(() => {
         const primaryFilteredData = mockData.filter((row) => {
             return primaryFilters.every((filter) => {
-                return filter.method(row, filter.state, filter.key);
+                return filter.method(row, filter.state, filter.rowKey);
             });
         });
         const secondaryFilteredData = primaryFilteredData.filter((row) => {
             return additionalFilters.every((filter) => {
-                return filter.method(row, filter.state, filter.key);
+                return filter.method(row, filter.state, filter.rowKey);
             });
         });
         setTestDataPortion(secondaryFilteredData.slice(startPoint, endPoint + 1));

--- a/src/components/Tables/_tests/testHelpers.ts
+++ b/src/components/Tables/_tests/testHelpers.ts
@@ -1,5 +1,5 @@
 import { LIST_TYPES_ARRAY } from "@/common/databaseListTypes";
-import { buttonGroupFilter, filterRowbyButton } from "../ButtonFilter";
+import { clientSideButtonGroupFilter, filterRowbyButton } from "../ButtonFilter";
 import { buildClientSideTextFilter, filterRowByText } from "../TextFilter";
 import { ClientSideFilter } from "../Filters";
 import { SortOrder } from "react-data-table-component/dist/DataTable/types";
@@ -133,16 +133,17 @@ export const fakeDataHeaders = [
 ] as const;
 
 export const fullNameTextFilterTest = buildClientSideTextFilter<TestData>({
-    key: "full_name",
-    headers: fakeDataHeaders,
+    key: "fullName",
+    rowKey: "full_name",
     label: "Name",
     method: filterRowByText,
 });
 
-export const typeButtonFilterTest = buttonGroupFilter<TestData>({
-    key: "type",
+export const typeButtonFilterTest = clientSideButtonGroupFilter<TestData>({
+    key: "typeFilter",
+    rowKey: "type",
     filterLabel: "",
-    filterOptions: LIST_TYPES_ARRAY,
+    itemLabelsAndKeys: LIST_TYPES_ARRAY.map((type) => [type, type]),
     initialActiveFilter: "regular",
     method: filterRowbyButton,
     shouldPersistOnClear: true,


### PR DESCRIPTION
## What's changed
The filter params on the Parcels and Clients page are encoded in the URL; this applies particularly when changing filter values on the page and when opening a URL that has encoded filter values.  The way that the Parcel modal loads data has been refactored as a consequence.

## TODO:
- [x] Ensure that Packing Manager View filters work as expected
- [x] Write E2E tests for updating URL and loading page
- [ ] Write component tests for the URL utility functions (merging params, removing empty)
  - Jest tests for urlQueryParams.ts have been moved out because of a Jest error caused by importing a node module

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
