### PR TITLE
#664 Edit/add forms for Clients & Parcels return to calling Parcel page/modal URL

### DIFF
--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -1,5 +1,8 @@
 import { Metadata } from "next";
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { returnPathQueryParam } from "@/common/constants";
+import { parseQueryParams } from "@/common/urlQueryParams";
 import ClientForm, { ClientErrors, ClientFields } from "@/app/clients/form/ClientForm";
 import { Errors } from "@/components/Form/formFunctions";
 
@@ -48,12 +51,23 @@ const AddClients: () => React.ReactElement = () => {
         deliveryInstructions: Errors.none,
     };
 
+    const searchParams = useSearchParams();
+    const [returnPath, setReturnPath] = useState<string | null>(null);
+
+    useEffect(() => {
+        const urlQueryParams = parseQueryParams(searchParams.toString());
+        if (urlQueryParams[returnPathQueryParam]) {
+            setReturnPath(urlQueryParams[returnPathQueryParam] as string);
+        }
+    });
+
     return (
         <main>
             <ClientForm
                 initialFields={initialFields}
                 initialFormErrors={initialFormErrors}
                 editConfig={{ editMode: false }}
+                returnPath={returnPath}
             />
         </main>
     );

--- a/src/app/clients/add/page.tsx
+++ b/src/app/clients/add/page.tsx
@@ -1,4 +1,5 @@
-import { Metadata } from "next";
+"use client";
+
 import React, { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { returnPathQueryParam } from "@/common/constants";
@@ -59,7 +60,7 @@ const AddClients: () => React.ReactElement = () => {
         if (urlQueryParams[returnPathQueryParam]) {
             setReturnPath(urlQueryParams[returnPathQueryParam] as string);
         }
-    });
+    }, [searchParams]);
 
     return (
         <main>
@@ -71,10 +72,6 @@ const AddClients: () => React.ReactElement = () => {
             />
         </main>
     );
-};
-
-export const metadata: Metadata = {
-    title: "Add Clients",
 };
 
 export default AddClients;

--- a/src/app/clients/edit/[id]/page.tsx
+++ b/src/app/clients/edit/[id]/page.tsx
@@ -2,6 +2,9 @@
 
 import React, { useEffect, useState } from "react";
 import supabase from "@/supabaseClient";
+import { useSearchParams } from "next/navigation";
+import { parseQueryParams } from "@/common/urlQueryParams";
+import { returnPathQueryParam } from "@/common/constants";
 import ClientForm, { ClientErrors } from "@/app/clients/form/ClientForm";
 import { Errors } from "@/components/Form/formFunctions";
 import autofill from "@/app/clients/edit/[id]/autofill";
@@ -16,15 +19,24 @@ interface EditClientsParameters {
 const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = ({
     params,
 }: EditClientsParameters) => {
+    const searchParams = useSearchParams();
+
     const [clientData, setClientData] = useState<Schema["clients"] | null>(null);
     const [familyData, setFamilyData] = useState<Schema["families"][] | null>(null);
     const [error, setError] = useState<string | null>();
+    const [returnPath, setReturnPath] = useState<string | null>(null);
 
     useEffect(() => {
         (async () => {
             if (!params.id) {
                 return;
             }
+
+            const urlQueryParams = parseQueryParams(searchParams.toString());
+            if (urlQueryParams[returnPathQueryParam]) {
+                setReturnPath(urlQueryParams[returnPathQueryParam] as string);
+            }
+
             setError(null);
             const { data: clientData, error: clientError } = await fetchClient(params.id, supabase);
             if (clientError) {
@@ -41,6 +53,7 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
                 return;
             }
             setClientData(clientData);
+
             const { data: familyData, error: familyError } = await fetchFamily(
                 clientData.family_id,
                 supabase
@@ -79,6 +92,7 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
                         initialFields={initialFields}
                         initialFormErrors={initialFormErrors}
                         editConfig={{ clientID: params.id, editMode: true }}
+                        returnPath={returnPath}
                     />
                 )
             )}

--- a/src/app/clients/edit/[id]/page.tsx
+++ b/src/app/clients/edit/[id]/page.tsx
@@ -67,7 +67,7 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
             }
             setFamilyData(familyData);
         })();
-    }, [params.id]);
+    }, [params.id, searchParams]);
 
     const initialFields = clientData && familyData ? autofill(clientData, familyData) : null;
 

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { returnPathQueryParam } from "@/common/constants";
+import { stringifyQueryParams } from "@/common/urlQueryParams";
 import { BooleanGroup } from "@/components/DataInput/inputHandlerFactories";
 import {
     CardProps,
@@ -45,6 +47,7 @@ interface Props {
     initialFields: ClientFields;
     initialFormErrors: ClientErrors;
     editConfig: EditConfig;
+    returnPath?: string | null;
 }
 
 type EditConfig = { editMode: true; clientID: string } | { editMode: false };
@@ -117,7 +120,12 @@ const formSections = [
     ClientNotesCard,
 ];
 
-const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editConfig }) => {
+const ClientForm: React.FC<Props> = ({
+    initialFields,
+    initialFormErrors,
+    editConfig,
+    returnPath,
+}) => {
     const router = useRouter();
     const [fields, setFields] = useState<ClientFields>(initialFields);
     const [formErrors, setFormErrors] = useState<ClientErrors>(initialFormErrors);
@@ -191,7 +199,12 @@ const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editCon
                 setSubmitDisabled(false);
                 return;
             }
-            router.push(`/clients?clientId=${clientId}`);
+
+            if (returnPath) {
+                router.push(decodeURIComponent(returnPath));
+            } else {
+                router.push(`/clients?clientId=${clientId}`);
+            }
         } else {
             const { clientId, error: addClientError } = await submitAddClientForm(fields);
             if (addClientError) {
@@ -205,7 +218,14 @@ const ClientForm: React.FC<Props> = ({ initialFields, initialFormErrors, editCon
                 setSubmitDisabled(false);
                 return;
             }
-            router.push(`/parcels/add/${clientId}`);
+
+            let targetUrl = `/parcels/add/${clientId}`;
+            if (returnPath) {
+                const paramsRecord: Record<string, string> = {};
+                paramsRecord[returnPathQueryParam] = returnPath;
+                targetUrl += `?${stringifyQueryParams(paramsRecord)}`;
+            }
+            router.push(targetUrl);
         }
     };
 

--- a/src/app/parcels/add/AddParcelForm.tsx
+++ b/src/app/parcels/add/AddParcelForm.tsx
@@ -21,6 +21,9 @@ import supabase from "@/supabaseClient";
 import Title from "@/components/Title/Title";
 import { insertParcel } from "@/app/parcels/form/submitFormHelpers";
 import { capitaliseWords } from "@/common/format";
+import { useSearchParams } from "next/navigation";
+import { parseQueryParams } from "@/common/urlQueryParams";
+import { returnPathQueryParam } from "@/common/constants";
 
 interface AddParcelProps {
     clientId: string;
@@ -48,6 +51,8 @@ const getErrorMessage = (
 };
 
 const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
+    const searchParams = useSearchParams();
+
     const [deliveryPrimaryKey, setDeliveryPrimaryKey] = useState<string | null>(null);
     const [collectionCentresLabelsAndValues, setCollectionCentresLabelsAndValues] =
         useState<CollectionCentresLabelsAndValues | null>(null);
@@ -60,6 +65,14 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
         FetchCollectionCentresError | PackingSlotsError | FetchClientError | null
     >(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [returnPath, setReturnPath] = useState<string | null>(null);
+
+    useEffect(() => {
+        const urlQueryParams = parseQueryParams(searchParams.toString());
+        if (urlQueryParams[returnPathQueryParam]) {
+            setReturnPath(urlQueryParams[returnPathQueryParam] as string);
+        }
+    }, [searchParams]);
 
     useEffect(() => {
         (async () => {
@@ -125,6 +138,7 @@ const AddParcels = ({ clientId }: AddParcelProps): React.ReactElement => {
                         collectionCentresLabelsAndValues={collectionCentresLabelsAndValues}
                         packingSlotsLabelsAndValues={packingSlotsLabelsAndValues}
                         listTypeLabelsAndValues={listTypeLabelsAndValues}
+                        returnPath={returnPath}
                     />
                 )
             )}

--- a/src/app/parcels/edit/EditParcelForm.tsx
+++ b/src/app/parcels/edit/EditParcelForm.tsx
@@ -22,6 +22,9 @@ import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import Title from "@/components/Title/Title";
 import { updateParcel } from "@/app/parcels/form/submitFormHelpers";
 import { formatDatetimeAsTime, capitaliseWords } from "@/common/format";
+import { useSearchParams } from "next/navigation";
+import { parseQueryParams } from "@/common/urlQueryParams";
+import { returnPathQueryParam } from "@/common/constants";
 
 interface EditParcelFormProps {
     parcelId: string;
@@ -76,6 +79,8 @@ const getErrorMessage = (
 };
 
 const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement => {
+    const searchParams = useSearchParams();
+
     const [isLoading, setIsLoading] = useState(true);
     const [initialFormFields, setInitialFormFields] = useState<ParcelFields>(initialParcelFields);
     const [deliveryKey, setDeliveryKey] = useState("");
@@ -91,6 +96,14 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
     const [error, setError] = useState<
         FetchCollectionCentresError | PackingSlotsError | FetchParcelError | FetchClientError | null
     >(null);
+    const [returnPath, setReturnPath] = useState<string | null>(null);
+
+    useEffect(() => {
+        const urlQueryParams = parseQueryParams(searchParams.toString());
+        if (urlQueryParams[returnPathQueryParam]) {
+            setReturnPath(urlQueryParams[returnPathQueryParam] as string);
+        }
+    }, [searchParams]);
 
     useEffect(() => {
         (async () => {
@@ -185,6 +198,7 @@ const EditParcelForm = ({ parcelId }: EditParcelFormProps): React.ReactElement =
                     collectionCentresLabelsAndValues={collectionCentres}
                     packingSlotsLabelsAndValues={packingSlots}
                     listTypeLabelsAndValues={listTypeLabelsAndValues}
+                    returnPath={returnPath}
                 />
             )}
         </>

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -112,6 +112,7 @@ interface ParcelFormProps {
     packingSlotsLabelsAndValues: PackingSlotsLabelsAndValues;
     writeParcelInfoToDatabase: WriteParcelToDatabaseFunction;
     listTypeLabelsAndValues: ListTypeLabelsAndValues;
+    returnPath?: string | null;
 }
 
 const withCollectionFormSections = [
@@ -156,9 +157,6 @@ const databaseErrorMessageFromErrorType = (
     }
 };
 
-// TODO VFB-55:
-// The param deliveryPrimaryKey will need to remain until VFB-55 is done.
-
 const ParcelForm: React.FC<ParcelFormProps> = ({
     initialFields,
     initialFormErrors,
@@ -168,6 +166,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
     collectionCentresLabelsAndValues,
     packingSlotsLabelsAndValues,
     listTypeLabelsAndValues,
+    returnPath,
 }) => {
     const router = useRouter();
     const [fields, setFields] = useState(initialFields);
@@ -277,7 +276,11 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
         const { parcelId, error } = await writeParcelInfoToDatabase(parcelRecord);
 
         if (parcelId) {
-            router.push(parcelModalRouterPath(parcelId));
+            if (returnPath) {
+                router.push(decodeURIComponent(returnPath));
+            } else {
+                router.push(parcelModalRouterPath(parcelId));
+            }
         }
 
         if (error) {

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,5 +1,5 @@
 import supabase from "@/supabaseClient";
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { generateReturnPathQueryParam } from "@/common/urlQueryParams";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
@@ -42,7 +42,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
 
     useEffect(() => {
         setReturnPathQueryParamForLinks(generateReturnPathQueryParam(window.location));
-    }, [modalIsOpen, window.location]);
+    }, [modalIsOpen]);
 
     const fetchParcel = async (): Promise<ParcelsTableRow[]> => {
         return await getParcelsByIds(supabase, [selectedParcelId as string]);

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -1,5 +1,6 @@
 import supabase from "@/supabaseClient";
-import { Suspense, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { generateReturnPathQueryParam } from "@/common/urlQueryParams";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
 import ExpandedParcelDetails from "../ExpandedParcelDetails";
 import ExpandedParcelDetailsFallback from "../ExpandedParcelDetailsFallback";
@@ -33,8 +34,15 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     const [parcelClientId, setParcelClientId] = useState<string | null>(null);
     const [isClientActive, setIsClientActive] = useState<boolean | null>(null);
     const [modalErrorMessage, setModalErrorMessage] = useState<string | null>(null);
+    const [returnPathQueryParamForLinks, setReturnPathQueryParamForLinks] = useState<string | null>(
+        null
+    );
 
     const theme = useTheme();
+
+    useEffect(() => {
+        setReturnPathQueryParamForLinks(generateReturnPathQueryParam(window.location));
+    }, [modalIsOpen, window.location]);
 
     const fetchParcel = async (): Promise<ParcelsTableRow[]> => {
         return await getParcelsByIds(supabase, [selectedParcelId as string]);
@@ -74,7 +82,9 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                 footer={
                     <Centerer>
                         <ConfirmButtons>
-                            <LinkButton link={`/parcels/edit/${selectedParcelId}`}>
+                            <LinkButton
+                                link={`/parcels/edit/${selectedParcelId}?${returnPathQueryParamForLinks}`}
+                            >
                                 Edit Parcel
                             </LinkButton>
                             <Button
@@ -89,13 +99,13 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                             {parcelClientId && (
                                 <>
                                     <LinkButton
-                                        link={`/clients?clientId=${parcelClientId}`}
+                                        link={`/clients?clientId=${parcelClientId}&${returnPathQueryParamForLinks}`}
                                         disabled={!isClientActive}
                                     >
                                         See Client Details
                                     </LinkButton>
                                     <LinkButton
-                                        link={`/clients/edit/${parcelClientId}`}
+                                        link={`/clients/edit/${parcelClientId}?${returnPathQueryParamForLinks}`}
                                         disabled={!isClientActive}
                                     >
                                         Edit Client Details

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -9,11 +9,8 @@ import {
 } from "@/app/parcels/parcelsTable/types";
 import { useSearchParams } from "next/navigation";
 import { mergeParamsIntoURL, parseQueryParams } from "@/common/urlQueryParams";
-import {
-    pageViewTypePackingManager,
-    pageViewTypeParam,
-    parcelIdParam,
-} from "@/app/parcels/parcelsTable/constants";
+import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
+import { pageViewTypePackingManager, pageViewTypeParam } from "@/common/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import {
     buildParcelFilters,

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -10,7 +10,7 @@ import {
 import { useSearchParams } from "next/navigation";
 import { mergeParamsIntoURL, parseQueryParams } from "@/common/urlQueryParams";
 import { parcelIdParam } from "@/app/parcels/parcelsTable/constants";
-import { pageViewTypePackingManager, pageViewTypeParam } from "@/common/constants";
+import { pageViewTypePackingManager, pageViewTypeQueryParam } from "@/common/constants";
 import { getParcelsByIdsWithFiltersAndSorting } from "@/app/parcels/parcelsTable/fetchParcelTableData";
 import {
     buildParcelFilters,
@@ -86,7 +86,7 @@ const ParcelsPage: React.FC = () => {
             setAreFiltersLoadingForFirstTime(false);
 
             setIsPackingManagerView(
-                filtersObject.primaryFilters.find((filter) => filter.key === pageViewTypeParam)
+                filtersObject.primaryFilters.find((filter) => filter.key === pageViewTypeQueryParam)
                     ?.state === pageViewTypePackingManager
             );
 
@@ -137,7 +137,7 @@ const ParcelsPage: React.FC = () => {
     };
 
     const setIsPackingManagerViewInternal = (isPackingManager: boolean): void => {
-        const viewFilter = primaryFilters.find((filter) => filter.key === pageViewTypeParam);
+        const viewFilter = primaryFilters.find((filter) => filter.key === pageViewTypeQueryParam);
         if (viewFilter) {
             viewFilter.state = isPackingManager ? pageViewTypePackingManager : "";
         }

--- a/src/app/parcels/parcelsTable/constants.ts
+++ b/src/app/parcels/parcelsTable/constants.ts
@@ -1,8 +1,5 @@
 export const parcelIdParam = "parcelId";
 
-export const pageViewTypeParam = "view";
-export const pageViewTypePackingManager = "Packing Manager";
-
 export const defaultNumberOfParcelsPerPage = 100;
 
 export const numberOfParcelsPerPageOptions = [10, 25, 50, 100];

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -32,7 +32,7 @@ import {
     packingManagerParcelStatuses,
     shouldFilterBeDisabledInPackingManagerView,
 } from "./packingManagerHelpers";
-import { pageViewTypePackingManager, pageViewTypeParam } from "@/common/constants";
+import { pageViewTypePackingManager, pageViewTypeQueryParam } from "@/common/constants";
 
 const parcelsFullNameSearchMethod: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",
@@ -216,7 +216,7 @@ const buildSpecialViewFilter = (today: Dayjs): ParcelsFilter<string> => {
     };
 
     return serverSideButtonGroupFilter({
-        key: pageViewTypeParam,
+        key: pageViewTypeQueryParam,
         filterLabel: "",
         itemLabelsAndKeys: [
             ["All parcels", ""],
@@ -298,7 +298,7 @@ export const buildPackingManagerPrimaryFilters = (
                     isDisabled: true,
                     isHiddenInUrl: true,
                 } as ParcelsFilter<string[]>;
-            } else if (filter.key === pageViewTypeParam) {
+            } else if (filter.key === pageViewTypeQueryParam) {
                 return {
                     ...filter,
                     state: pageViewTypePackingManager,
@@ -331,7 +331,9 @@ export const updateFiltersFromQueryParams = (
                     ...filter,
                     state: paramValForFilter,
                 } as ParcelsFilter<DateRangeState>;
-            } else if (["fullName", "addressPostcode", pageViewTypeParam].includes(filter.key)) {
+            } else if (
+                ["fullName", "addressPostcode", pageViewTypeQueryParam].includes(filter.key)
+            ) {
                 return {
                     ...filter,
                     state: paramValForFilter,

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -32,7 +32,7 @@ import {
     packingManagerParcelStatuses,
     shouldFilterBeDisabledInPackingManagerView,
 } from "./packingManagerHelpers";
-import { pageViewTypePackingManager, pageViewTypeParam } from "./constants";
+import { pageViewTypePackingManager, pageViewTypeParam } from "@/common/constants";
 
 const parcelsFullNameSearchMethod: ParcelsFilterMethod<string> = fullNameSearch<DbParcelRow>(
     "client_full_name",

--- a/src/app/parcels/parcelsTable/packingManagerHelpers.ts
+++ b/src/app/parcels/parcelsTable/packingManagerHelpers.ts
@@ -1,6 +1,6 @@
 import { ParcelsFilter } from "./types";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
-import { pageViewTypeParam } from "@/common/constants";
+import { pageViewTypeQueryParam } from "@/common/constants";
 
 export const packingManagerParcelStatuses = [
     "Shipping Labels Downloaded",
@@ -15,7 +15,7 @@ export const shouldFilterBeDisabledInPackingManagerView = (
         filter.key === "packingDate" ||
         filter.key === "packingSlot" ||
         filter.key === "lastStatus" ||
-        filter.key === pageViewTypeParam
+        filter.key === pageViewTypeQueryParam
     ) {
         return true;
     }

--- a/src/app/parcels/parcelsTable/packingManagerHelpers.ts
+++ b/src/app/parcels/parcelsTable/packingManagerHelpers.ts
@@ -1,6 +1,6 @@
 import { ParcelsFilter } from "./types";
 import { DateRangeState } from "@/components/DateInputs/DateRangeInputs";
-import { pageViewTypeParam } from "./constants";
+import { pageViewTypeParam } from "@/common/constants";
 
 export const packingManagerParcelStatuses = [
     "Shipping Labels Downloaded",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,2 @@
+export const pageViewTypeParam = "view";
+export const pageViewTypePackingManager = "Packing Manager";

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,2 +1,4 @@
-export const pageViewTypeParam = "view";
+export const pageViewTypeQueryParam = "view";
 export const pageViewTypePackingManager = "Packing Manager";
+
+export const returnPathQueryParam = "returnPath";

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -1,11 +1,16 @@
 "use client";
 
 import queryString, { ParsedQuery } from "query-string";
+import { returnPathQueryParam } from "@/common/constants";
 
 export type UrlQueryParamsRecord = ParsedQuery;
 
 export const parseQueryParams = (queryParams: string): UrlQueryParamsRecord => {
     return queryString.parse(queryParams, { arrayFormat: "bracket" });
+};
+
+export const stringifyQueryParams = (params: UrlQueryParamsRecord): string => {
+    return queryString.stringify(params, { arrayFormat: "bracket" });
 };
 
 export const readArrayParamFromQuery = (
@@ -61,11 +66,22 @@ export const mergeParamsIntoURL = (paramsToUpdate: UrlQueryParamsRecord): void =
     );
 
     if (!areRecordsEqual(paramsInURL, nonEmptyMergedParams)) {
-        const queryStringified = queryString.stringify(nonEmptyMergedParams, {
-            arrayFormat: "bracket",
-        });
+        const queryStringified = stringifyQueryParams(nonEmptyMergedParams);
 
         // App Router doesn't support shallow routing, so router.push would reload the page
         window.history.pushState({}, "", `${window.location.pathname}?${queryStringified}`);
     }
+};
+
+const encodeCurrentPathAndQueryParams = (windowLocation: Location): string => {
+    const currentPath = windowLocation.pathname;
+    const currentQueryParams = windowLocation.search;
+
+    return encodeURIComponent(`${currentPath}${currentQueryParams}`);
+};
+
+export const generateReturnPathQueryParam = (windowLocation: Location): string => {
+    const paramsRecord: Record<string, string> = {};
+    paramsRecord[returnPathQueryParam] = encodeCurrentPathAndQueryParams(windowLocation);
+    return stringifyQueryParams(paramsRecord);
 };

--- a/src/common/urlQueryParams.ts
+++ b/src/common/urlQueryParams.ts
@@ -85,3 +85,11 @@ export const generateReturnPathQueryParam = (windowLocation: Location): string =
     paramsRecord[returnPathQueryParam] = encodeCurrentPathAndQueryParams(windowLocation);
     return stringifyQueryParams(paramsRecord);
 };
+
+export const readReturnPathQueryParam = (windowLocation: Location): string | null => {
+    const params = parseQueryParams(windowLocation.search);
+    if (params[returnPathQueryParam]) {
+        return params[returnPathQueryParam] as string;
+    }
+    return null;
+};


### PR DESCRIPTION
## What's changed
The Add & Edit forms for Parcels and Clients take a returnPath query parameter to go to after submission. The use case is going from a Parcel modal (with parcel filter values encoded in the URL) to one of those forms (e.g., Edit Parcel or Edit Client) - after submission the user returns to the Parcel modal with the same filter values behind.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`


