### PR TITLE
#628: Action/Status bar uses correct filters in Packing Manager view

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -126,7 +126,7 @@ const ParcelsPage: React.FC = () => {
 
         return await getParcelsByIdsWithFiltersAndSorting(
             supabase,
-            primaryFilters.concat(additionalFilters),
+            currentlyAppliedFilters,
             sortState,
             checkedParcelIds
         );


### PR DESCRIPTION
## What's changed
Previously the Actions & Statuses buttons were using the filters associated with "All parcels view" even when in "Packing manager view"

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`


