### PR TITLE
#670: Voucher number & phone number are required form fields (not in DB)

### DIFF
--- a/src/app/clients/form/formSections/PhoneNumberCard.tsx
+++ b/src/app/clients/form/formSections/PhoneNumberCard.tsx
@@ -10,6 +10,8 @@ import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ClientCardProps } from "../ClientForm";
 import { formatPhoneNumber, phoneNumberRegex } from "@/common/format";
 
+const phoneNumberIsRequired = true;
+
 const PhoneNumberCard: React.FC<ClientCardProps> = ({
     formErrors,
     errorSetter,
@@ -17,14 +19,14 @@ const PhoneNumberCard: React.FC<ClientCardProps> = ({
     fields,
 }) => {
     return (
-        <GenericFormCard title="Phone Number" required={false}>
+        <GenericFormCard title="Phone Number" required={phoneNumberIsRequired}>
             <FreeFormTextInput
                 label="Phone Number"
                 defaultValue={getDefaultTextValue(fields, "phoneNumber")}
                 error={errorExists(formErrors.phoneNumber)}
                 helperText={getErrorText(formErrors.phoneNumber)}
                 onChange={onChangeText(fieldSetter, errorSetter, "phoneNumber", {
-                    required: false,
+                    required: phoneNumberIsRequired,
                     regex: phoneNumberRegex,
                     formattingFunction: formatPhoneNumber,
                 })}

--- a/src/app/parcels/form/formSections/CollectionDateCard.tsx
+++ b/src/app/parcels/form/formSections/CollectionDateCard.tsx
@@ -25,7 +25,6 @@ const CollectionDateCard: React.FC<ParcelCardProps> = ({
                     }}
                     label="Date"
                     value={fields.collectionDate ? dayjs(fields.collectionDate) : null}
-                    disablePast
                 />
                 <ErrorText>{getErrorText(formErrors.collectionDate)}</ErrorText>
             </>

--- a/src/app/parcels/form/formSections/PackingDateCard.tsx
+++ b/src/app/parcels/form/formSections/PackingDateCard.tsx
@@ -25,7 +25,6 @@ const PackingDateCard: React.FC<ParcelCardProps> = ({
                     }}
                     label="Date"
                     value={fields.packingDate ? dayjs(fields.packingDate) : null}
-                    disablePast
                 />
                 <ErrorText>{getErrorText(formErrors.packingDate)}</ErrorText>
             </>

--- a/src/app/parcels/form/formSections/VoucherNumberCard.tsx
+++ b/src/app/parcels/form/formSections/VoucherNumberCard.tsx
@@ -5,7 +5,7 @@ import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ErrorText } from "@/components/Form/formStyling";
 import { ParcelCardProps } from "../ParcelForm";
 
-const voucherNumberIsRequired = false;
+const voucherNumberIsRequired = true;
 
 const VoucherNumberCard: React.FC<ParcelCardProps> = ({
     errorSetter,

--- a/src/components/Form/formFunctions.ts
+++ b/src/components/Form/formFunctions.ts
@@ -5,7 +5,7 @@ import {
     SelectChangeEventHandler,
 } from "@/components/DataInput/inputHandlerFactories";
 import { Database } from "@/databaseTypesFile";
-import dayjs, { Dayjs } from "dayjs";
+import { Dayjs } from "dayjs";
 
 export type Setter<SpecificFields extends Fields> = (
     fieldValuesToUpdate: Partial<SpecificFields>
@@ -237,13 +237,6 @@ export const onChangeDate = <SpecificFields extends Fields>(
     onChangeDateOrTime(fieldSetter, errorSetter, key, value);
     if (value === null || isNaN(Date.parse(value.toString()))) {
         return;
-    }
-
-    const earliestPossibleDateTime = dayjs().startOf("day");
-    if (value.isBefore(earliestPossibleDateTime)) {
-        errorSetter({ [key]: Errors.pastDate } as {
-            [key in keyof FormErrors<SpecificFields>]: Errors;
-        });
     }
 };
 


### PR DESCRIPTION
## What's changed
Two fields marked as required in the forms - not enforced in the database, though, due to existing data.


## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
