### PR TITLE
#688: Update npm post_checkout for new seed solution

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "generate_types:local": "supabase gen types typescript --local --schema public > src/databaseTypesFile.ts",
     "generate_types:remote": "supabase gen types typescript --schema public > src/databaseTypesFile.ts",
     "db:generate_seed": "npx ts-node supabase/seed/seed.ts > supabase/seed.sql",
-    "post_checkout": "npm install && npx supabase stop && npx supabase start && npm run reset_supabase && npx snaplet generate"
+    "post_checkout": "npm install && npx supabase stop && npx supabase start && npm run reset_supabase && npx @snaplet/seed sync"
   },
   "nyc": {
     "all": true,

--- a/supabase/seed/seed.ts
+++ b/supabase/seed/seed.ts
@@ -138,7 +138,8 @@ const main = async (): Promise<never> => {
     await seed.parcels(
         (generate) =>
             generate(7500, {
-                voucher_number: (_ctx) => copycat.scramble("A-1111-111-11-11", { preserve: ["-"] }),
+                voucher_number: (ctx) =>
+                    copycat.word(ctx.seed, { capitalize: true, minSyllables: 3 }),
                 packing_date: (ctx) =>
                     getPseudoRandomDateBetween(earliestParcelOrEventDate, farFutureDate, ctx.seed),
                 collection_datetime: (ctx) =>


### PR DESCRIPTION
## What's changed
Also fix logic for voucher number seed

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [ ] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [ ] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [ ] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

