### PR TITLE
#697: Table 'Select All' checkbox is only ticked if nonempty

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -195,7 +195,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         if (isAllCheckBoxSelected) {
             setCheckedParcelIds([]);
             setAllCheckBoxSelected(false);
-        } else {
+        } else if (allFilteredParcelIds.length > 0) {
             setCheckedParcelIds(allFilteredParcelIds);
             setAllCheckBoxSelected(true);
         }
@@ -210,7 +210,8 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     }, [allFilteredParcelIds, checkedParcelIds, setCheckedParcelIds]);
 
     useEffect(() => {
-        const allChecked = checkedParcelIds.length === filteredParcelCount;
+        const allChecked =
+            checkedParcelIds.length === filteredParcelCount && filteredParcelCount > 0;
         if (allChecked !== isAllCheckBoxSelected) {
             setAllCheckBoxSelected(allChecked);
         }

--- a/src/components/Tables/_tests/WrappedTable.tsx
+++ b/src/components/Tables/_tests/WrappedTable.tsx
@@ -49,7 +49,8 @@ const WrappedTableForTest: React.FC<MockTableProps> = ({
     const [isAllCheckBoxSelected, setAllCheckBoxSelected] = useState(false);
 
     useEffect(() => {
-        const allChecked = checkedRowIds.length === testDataPortion.length;
+        const allChecked =
+            checkedRowIds.length === testDataPortion.length && testDataPortion.length > 0;
         if (allChecked !== isAllCheckBoxSelected) {
             setAllCheckBoxSelected(allChecked);
         }


### PR DESCRIPTION
## What's changed
The Parcels Table previously ticked the Select All box by comparing the length of the selected IDs list to the number of parcels in the table, without checking whether there actually were any in the table.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
