### PR TITLE
VFB-387: Highlight Parcel Table rows on checkbox selection

### DIFF
--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -429,12 +429,12 @@ const Table = <
 
     const rows = dataPortion.map((data, index) => ({ rowId: index, data }));
 
-    const selectedRows = [
+    const conditionalRowStyles = [
         {
             when: (row: Row<Data>) =>
                 checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
             style: {
-                backgroundColor: `${theme.primary.background[1]}!important`,
+                backgroundColor: `${theme.primary.background[1]} !important`,
             },
         },
     ];
@@ -537,7 +537,7 @@ const Table = <
                             }
                             progressPending={isLoading}
                             pointerOnHover={pointerOnHover}
-                            conditionalRowStyles={selectedRows}
+                            conditionalRowStyles={conditionalRowStyles}
                             striped
                         />
                     </NoSsr>

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -17,7 +17,7 @@ import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
 import styled, { useTheme } from "styled-components";
-import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
+import { ConditionalStyles, Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
 import { Centerer } from "../Modal/ModalFormStyles";
 import { ClientSideSortMethod, ServerSideSortMethod } from "./sortMethods";
 import {
@@ -429,6 +429,13 @@ const Table = <
 
     const rows = dataPortion.map((data, index) => ({ rowId: index, data }));
 
+    const selectedRows = [
+        {when: (row: Row<Data>) => checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
+        style: {
+            backgroundColor: 'red!important',
+        },},
+];
+
     return (
         <div aria-live="polite">
             {(filterConfig.primaryFiltersShown || filterConfig.additionalFiltersShown) && (
@@ -527,6 +534,7 @@ const Table = <
                             }
                             progressPending={isLoading}
                             pointerOnHover={pointerOnHover}
+                            conditionalRowStyles={selectedRows}
                             striped
                         />
                     </NoSsr>

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -17,7 +17,7 @@ import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
 import styled, { useTheme } from "styled-components";
-import { ConditionalStyles, Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
+import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
 import { Centerer } from "../Modal/ModalFormStyles";
 import { ClientSideSortMethod, ServerSideSortMethod } from "./sortMethods";
 import {
@@ -430,11 +430,14 @@ const Table = <
     const rows = dataPortion.map((data, index) => ({ rowId: index, data }));
 
     const selectedRows = [
-        {when: (row: Row<Data>) => checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
-        style: {
-            backgroundColor: 'red!important',
-        },},
-];
+        {
+            when: (row: Row<Data>) =>
+                checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
+            style: {
+                backgroundColor: `${theme.primary.background[1]}!important`,
+            },
+        },
+    ];
 
     return (
         <div aria-live="polite">


### PR DESCRIPTION
## What's changed
Parcel rows are now highlighted when selected.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1139" height="217" alt="image" src="https://github.com/user-attachments/assets/404b6e84-6515-4554-bf5c-4312a62cb5ed" /> | <img width="1164" height="237" alt="image" src="https://github.com/user-attachments/assets/63a978a5-1cef-49b6-902b-4f22bf82986d" /> |
| <img width="1846" height="284" alt="image" src="https://github.com/user-attachments/assets/5b0cfa5e-bb2a-415d-931c-8cc61ab4f567" />| <img width="1860" height="335" alt="image" src="https://github.com/user-attachments/assets/1235c316-895a-4876-9266-8b3c9b41778f" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
