### PR TITLE
VFB-392: remove condition for row break and remove unused variable

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -51,7 +51,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     appliedFilters,
     areFiltersLoadingForFirstTime,
     setErrorMessage,
-    isPackingManagerView,
 }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [parcelsDataPortion, setParcelsDataPortion] = useState<ParcelsTableRow[]>([]);
@@ -244,7 +243,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                     setSortState: setSortState,
                 }}
                 defaultSortConfig={defaultParcelsSortConfig}
-                rowBreakPointConfigs={isPackingManagerView ? undefined : parcelRowBreakPointConfig}
+                rowBreakPointConfigs={parcelRowBreakPointConfig}
                 filterConfig={{
                     primaryFiltersShown: false,
                     additionalFiltersShown: false,


### PR DESCRIPTION
## What's changed
- in `ParcelsTable.tsx` file, we no longer verify if we are in the `Packing manager view` table; we show the dividing line anyway
- we removed the unused variable `isPackingManagerView`

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1186" height="443" alt="image" src="https://github.com/user-attachments/assets/90cc1cc3-c481-40df-82e1-0b2da9586459" />| <img width="1697" height="465" alt="image" src="https://github.com/user-attachments/assets/54a12404-1d77-40cf-a1a2-35d47ce4f5f6" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [ ] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [ ] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [ ] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [ ] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [ ] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [ ] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

