### PR TITLE
Vfb 390 client search apostrophe fix

### DIFF
--- a/src/common/databaseFilters.ts
+++ b/src/common/databaseFilters.ts
@@ -11,7 +11,7 @@ export const dbFilterWithSubstringQueries = <DbData extends DbClientRow | DbParc
     return (query, state) => {
         const substrings = state
             .split(textFilterDelimiter)
-            .map((substring) => substring.trim().replace(/[^a-zA-Z0-9 \-+?]/g, ""))
+            .map((substring) => substring.trim().replace(/[^a-zA-Z0-9 '\-+?]/g, ""))
             .filter((substring) => substring.length > 0);
 
         if (substrings.length === 0) {


### PR DESCRIPTION
## What's changed
Names containing apostrophes now appear when searched.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1433" height="270" alt="image" src="https://github.com/user-attachments/assets/4abd6995-3558-42db-b13c-ce0273c59418" /> | <img width="1440" height="336" alt="image" src="https://github.com/user-attachments/assets/9d131b94-9152-4cbd-8be9-c39933eab177" /> |
| <img width="1440" height="373" alt="image" src="https://github.com/user-attachments/assets/36062e00-7317-4eb8-8ae4-9f8f36511e58" /> | <img width="1437" height="309" alt="image" src="https://github.com/user-attachments/assets/676db085-62fe-4029-b28e-84311be89a59" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`