### PR TITLE
Vfb 397 voucher search criteria

### DIFF
--- a/src/app/parcels/form/formSections/VoucherNumberCard.tsx
+++ b/src/app/parcels/form/formSections/VoucherNumberCard.tsx
@@ -17,7 +17,7 @@ const VoucherNumberCard: React.FC<ParcelCardProps> = ({
         <GenericFormCard
             title="Voucher Number"
             required={voucherNumberIsRequired}
-            text="This is usually found in the following format: E-00000-00000 or E-000000-000000."
+            text="This is usually found in the following format: E-000000-000000 or E-00000-000000."
         >
             <FreeFormTextInput
                 label="Voucher Number"

--- a/src/app/parcels/form/formSections/VoucherNumberCard.tsx
+++ b/src/app/parcels/form/formSections/VoucherNumberCard.tsx
@@ -17,7 +17,7 @@ const VoucherNumberCard: React.FC<ParcelCardProps> = ({
         <GenericFormCard
             title="Voucher Number"
             required={voucherNumberIsRequired}
-            text="This is usually found in the following format: E-00000-00000."
+            text="This is usually found in the following format: E-00000-00000 or E-00000-00000."
         >
             <FreeFormTextInput
                 label="Voucher Number"

--- a/src/app/parcels/form/formSections/VoucherNumberCard.tsx
+++ b/src/app/parcels/form/formSections/VoucherNumberCard.tsx
@@ -17,7 +17,7 @@ const VoucherNumberCard: React.FC<ParcelCardProps> = ({
         <GenericFormCard
             title="Voucher Number"
             required={voucherNumberIsRequired}
-            text="This is usually found in the following format: E-00000-00000 or E-00000-00000."
+            text="This is usually found in the following format: E-00000-00000 or E-000000-000000."
         >
             <FreeFormTextInput
                 label="Voucher Number"

--- a/src/app/parcels/form/formSections/VoucherNumberCard.tsx
+++ b/src/app/parcels/form/formSections/VoucherNumberCard.tsx
@@ -17,7 +17,7 @@ const VoucherNumberCard: React.FC<ParcelCardProps> = ({
         <GenericFormCard
             title="Voucher Number"
             required={voucherNumberIsRequired}
-            text="This is usually found in the following format: H-00001-00001. If you don't know the voucher number, leave this section blank."
+            text="This is usually found in the following format: E-00000-00000."
         >
             <FreeFormTextInput
                 label="Voucher Number"

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -58,7 +58,10 @@ const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQu
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
-            return `${voucherColumnLabel}.not.ilike.E%`;
+            return [
+                `${voucherColumnLabel}.eq.""`,
+                `${voucherColumnLabel}.not.ilike.E%`
+            ];
         }
         return `${voucherColumnLabel}.ilike.%${substring}%`;
     }

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -58,10 +58,7 @@ const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQu
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
-            return [
-                `${voucherColumnLabel}.eq.""`,
-                `${voucherColumnLabel}.not.ilike.E%`
-            ];
+            return `or=(${voucherColumnLabel}.eq."",${voucherColumnLabel}.not.ilike.E%)`;
         }
         return `${voucherColumnLabel}.ilike.%${substring}%`;
     }

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -58,7 +58,7 @@ const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQu
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
-            return `${voucherColumnLabel}.ilike.""`;
+            return `${voucherColumnLabel}.not.ilike.E%`;
         }
         return `${voucherColumnLabel}.ilike.%${substring}%`;
     }

--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -58,7 +58,7 @@ const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQu
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
-            return `or=(${voucherColumnLabel}.eq."",${voucherColumnLabel}.not.ilike.E%)`;
+            return `or(${voucherColumnLabel}.not.ilike.E%, ${voucherColumnLabel}.ilike."")`;
         }
         return `${voucherColumnLabel}.ilike.%${substring}%`;
     }


### PR DESCRIPTION
## What's changed
-voucher search criteria changed: for “?” returns vouchers not starting with "E", instead of blank
-updated the voucher number description to match E-00000-000000 format

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="2390" height="585" alt="voucher-before" src="https://github.com/user-attachments/assets/43691a31-dcc5-4478-a519-c2f9469bef77" /> | <img width="1777" height="580" alt="voucher-after" src="https://github.com/user-attachments/assets/232ad2f3-6610-439f-b61c-e5826026fb80" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
