### PR TITLE
VFB-388: decrease height rows for parcels and clients

### DIFF
--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -221,6 +221,7 @@ const ClientsPage: React.FC = () => {
                             isLoading={isLoading}
                             pointerOnHover={true}
                             columnDisplayFunctions={{ addressPostcode: formatNullPostcode }}
+                            reduceRowHeight={true}
                         />
                     </TableSurface>
 

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -261,6 +261,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                 }}
                 editableConfig={{ editable: false }}
                 pointerOnHover={true}
+                reduceRowHeight={true}
             />
         </TableSurface>
     );

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -442,7 +442,7 @@ const Table = <
         {
             when: () => reduceRowHeight === true,
             style: {
-                height: "0px",
+                height: "48px",
             },
         },
     ];

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -180,6 +180,7 @@ interface Props<Data, DbData extends Record<string, unknown>, PaginationType, Fi
     editableConfig: EditableConfig<Data>;
     onRowClick?: OnRowClickFunction<Data>;
     pointerOnHover?: boolean;
+    reduceRowHeight?: boolean;
 }
 interface CellProps<Data> {
     row: Row<Data>;
@@ -239,6 +240,7 @@ const Table = <
     paginationConfig,
     editableConfig,
     pointerOnHover,
+    reduceRowHeight,
 }: Props<Data, DbData, PaginationType, FilterState>): React.ReactElement => {
     const [shownHeaderKeys, setShownHeaderKeys] = useState(
         defaultShownHeaders ?? headerKeysAndLabels.map(([key]) => key)
@@ -436,6 +438,11 @@ const Table = <
             style: {
                 backgroundColor: `${theme.primary.background[1]} !important`,
             },
+
+          when: () => reduceRowHeight === true,
+          style: {
+            height: "0px",
+          },
         },
     ];
 

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -442,6 +442,8 @@ const Table = <
         {
             when: () => reduceRowHeight === true,
             style: {
+                // The default DataTable class has a predefined min-height of 48px for the row-element
+                // for this reason, any value < 48px would not decrease the height.
                 height: "48px",
             },
         },

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -438,11 +438,12 @@ const Table = <
             style: {
                 backgroundColor: `${theme.primary.background[1]} !important`,
             },
-
-          when: () => reduceRowHeight === true,
-          style: {
-            height: "0px",
-          },
+        },
+        {
+            when: () => reduceRowHeight === true,
+            style: {
+                height: "0px",
+            },
         },
     ];
 


### PR DESCRIPTION
## What's changed
Decreased spacing for rows in client and parcel pages

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1692" height="947" alt="Screenshot 2025-07-15 113655" src="https://github.com/user-attachments/assets/3133e6eb-da63-44df-abac-7474d82b7896" /> | <img width="1694" height="833" alt="Screenshot 2025-07-15 113504" src="https://github.com/user-attachments/assets/b9ace175-d167-44c2-a913-d77fd460fac9" />| <img width="1692" height="947" alt="Screenshot 2025-07-15 113655" src="https://github.com/user-attachments/assets/3133e6eb-da63-44df-abac-7474d82b7896" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`