### PR TITLE
VFB-391: Add Green dividing line on Packing Manager View

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -217,7 +217,6 @@ const ParcelsPage: React.FC = () => {
                         appliedFilters={currentlyAppliedFilters}
                         areFiltersLoadingForFirstTime={areFiltersLoadingForFirstTime}
                         setErrorMessage={setErrorMessage}
-                        isPackingManagerView={isPackingManagerView}
                     />
                     <ParcelsModal
                         modalIsOpen={modalIsOpen}

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -39,7 +39,6 @@ interface ParcelsTableProps {
     )[];
     areFiltersLoadingForFirstTime: boolean;
     setErrorMessage: (errorMessage: string | null) => void;
-    isPackingManagerView: boolean;
 }
 
 const ParcelsTable: React.FC<ParcelsTableProps> = ({

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -51,7 +51,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     appliedFilters,
     areFiltersLoadingForFirstTime,
     setErrorMessage,
-    isPackingManagerView,
 }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [parcelsDataPortion, setParcelsDataPortion] = useState<ParcelsTableRow[]>([]);
@@ -244,7 +243,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                     setSortState: setSortState,
                 }}
                 defaultSortConfig={defaultParcelsSortConfig}
-                rowBreakPointConfigs={isPackingManagerView ? undefined : parcelRowBreakPointConfig}
+                rowBreakPointConfigs={parcelRowBreakPointConfig}
                 filterConfig={{
                     primaryFiltersShown: false,
                     additionalFiltersShown: false,


### PR DESCRIPTION
## What's changed
- removed `isPackingManagerView`
- removed the condition from `rowBreakPointConfigs`

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1677" height="300" alt="image" src="https://github.com/user-attachments/assets/258627a5-a88c-4bd2-87f9-33014502162b" /> | <img width="1687" height="289" alt="image" src="https://github.com/user-attachments/assets/b53afe6a-ed39-4d05-9c46-f62f79f8c1d2" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
