### PR TITLE
VFB 418: Ignore Extra Info paragraph breaks

### DIFF
--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -1,5 +1,7 @@
+import { Schema } from "@/databaseUtils";
+import supabase from "@/supabaseClient";
 import { DatabaseError } from "@/app/errorClasses";
-import { ListType } from "@/common/databaseListTypes";
+import { logErrorReturnLogId } from "@/logger/logger";
 import { formatAddress } from "@/common/format";
 import {
     getAdultAgeStringUsingBirthYear,
@@ -7,18 +9,16 @@ import {
     isAdultFamilyMember,
     isChildFamilyMember,
 } from "@/common/getAgesOfFamily";
+import { ListType } from "@/common/databaseListTypes";
 import { getGenderStringFromGenderField } from "@/common/getGendersOfFamily";
-import { sortArrayByCanonicalOrder } from "@/components/Form/formFunctions";
-import { Schema } from "@/databaseUtils";
-import { logErrorReturnLogId } from "@/logger/logger";
-import supabase from "@/supabaseClient";
-import { babyOtherItemsOptions } from "./form/formSections/BabyProductsCard";
-import { cookingFacilitiesOptions } from "./form/formSections/CookingFacilitiesCard";
 import { dietaryRequirementOptions } from "./form/formSections/DietaryRequirementCard";
-import { hygieneOtherItemsOptions } from "./form/formSections/HygieneProductsCard";
+import { sortArrayByCanonicalOrder } from "@/components/Form/formFunctions";
 import { otherRequirementOptions } from "./form/formSections/OtherItemsCard";
 import { petFoodOptions } from "./form/formSections/PetFoodCard";
+import { cookingFacilitiesOptions } from "./form/formSections/CookingFacilitiesCard";
 import { signpostingCallOptions } from "./form/formSections/SignpostingCallCard";
+import { hygieneOtherItemsOptions } from "./form/formSections/HygieneProductsCard";
+import { babyOtherItemsOptions } from "./form/formSections/BabyProductsCard";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -1,7 +1,5 @@
-import { Schema } from "@/databaseUtils";
-import supabase from "@/supabaseClient";
 import { DatabaseError } from "@/app/errorClasses";
-import { logErrorReturnLogId } from "@/logger/logger";
+import { ListType } from "@/common/databaseListTypes";
 import { formatAddress } from "@/common/format";
 import {
     getAdultAgeStringUsingBirthYear,
@@ -9,16 +7,18 @@ import {
     isAdultFamilyMember,
     isChildFamilyMember,
 } from "@/common/getAgesOfFamily";
-import { ListType } from "@/common/databaseListTypes";
 import { getGenderStringFromGenderField } from "@/common/getGendersOfFamily";
-import { dietaryRequirementOptions } from "./form/formSections/DietaryRequirementCard";
 import { sortArrayByCanonicalOrder } from "@/components/Form/formFunctions";
+import { Schema } from "@/databaseUtils";
+import { logErrorReturnLogId } from "@/logger/logger";
+import supabase from "@/supabaseClient";
+import { babyOtherItemsOptions } from "./form/formSections/BabyProductsCard";
+import { cookingFacilitiesOptions } from "./form/formSections/CookingFacilitiesCard";
+import { dietaryRequirementOptions } from "./form/formSections/DietaryRequirementCard";
+import { hygieneOtherItemsOptions } from "./form/formSections/HygieneProductsCard";
 import { otherRequirementOptions } from "./form/formSections/OtherItemsCard";
 import { petFoodOptions } from "./form/formSections/PetFoodCard";
-import { cookingFacilitiesOptions } from "./form/formSections/CookingFacilitiesCard";
 import { signpostingCallOptions } from "./form/formSections/SignpostingCallCard";
-import { hygieneOtherItemsOptions } from "./form/formSections/HygieneProductsCard";
-import { babyOtherItemsOptions } from "./form/formSections/BabyProductsCard";
 
 const getExpandedClientDetails = async (clientId: string): Promise<ExpandedClientData> => {
     const rawClientDetails = await getRawClientDetails(clientId);
@@ -147,7 +147,7 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
             client.other_items,
             otherRequirementOptions
         ),
-        extraInformation: client.extra_information ?? "",
+        extraInformation: formatExtraInformation(client.extra_information),
         signpostingCallRequired: client.signposting_call_required ?? false,
         signpostingCallReasons:
             client.signposting_call_required === true
@@ -175,6 +175,10 @@ export const formatAddressFromClientDetails = (
         client.address_postcode,
         false
     );
+};
+
+export const formatExtraInformation = (extraInformation: string | null): string => {
+    return extraInformation ? extraInformation.replace(/[\r\n]+/g, "\n") : "";
 };
 
 export const formatHouseholdFromFamilyDetails = (

--- a/src/common/formatClientsData.ts
+++ b/src/common/formatClientsData.ts
@@ -1,9 +1,9 @@
 import { Schema } from "@/databaseUtils";
 import { displayPostcodeForHomelessClient, formatAddress } from "@/common/format";
 import {
-    formatBabyProducts, formatExtraInformation,
+    formatBabyProducts,
     formatHygieneProducts,
-    formatRequirementsByCanonicalOrder
+    formatRequirementsByCanonicalOrder,
 } from "@/app/clients/getExpandedClientDetails";
 import { dietaryRequirementOptions } from "@/app/clients/form/formSections/DietaryRequirementCard";
 import { otherRequirementOptions } from "@/app/clients/form/formSections/OtherItemsCard";

--- a/src/common/formatClientsData.ts
+++ b/src/common/formatClientsData.ts
@@ -1,9 +1,9 @@
 import { Schema } from "@/databaseUtils";
 import { displayPostcodeForHomelessClient, formatAddress } from "@/common/format";
 import {
-    formatBabyProducts,
+    formatBabyProducts, formatExtraInformation,
     formatHygieneProducts,
-    formatRequirementsByCanonicalOrder,
+    formatRequirementsByCanonicalOrder
 } from "@/app/clients/getExpandedClientDetails";
 import { dietaryRequirementOptions } from "@/app/clients/form/formSections/DietaryRequirementCard";
 import { otherRequirementOptions } from "@/app/clients/form/formSections/OtherItemsCard";
@@ -50,7 +50,7 @@ export const prepareClientSummary = (clientData: Schema["clients"]): ClientSumma
         name: full_name ?? "",
         contact: phone_number ?? "",
         address: address_postcode ? formattedAddress : displayPostcodeForHomelessClient,
-        extraInformation: extra_information ?? "",
+        extraInformation: formatExtraInformation(extra_information),
     };
 };
 

--- a/src/common/formatClientsData.ts
+++ b/src/common/formatClientsData.ts
@@ -2,6 +2,7 @@ import { Schema } from "@/databaseUtils";
 import { displayPostcodeForHomelessClient, formatAddress } from "@/common/format";
 import {
     formatBabyProducts,
+    formatExtraInformation,
     formatHygieneProducts,
     formatRequirementsByCanonicalOrder,
 } from "@/app/clients/getExpandedClientDetails";


### PR DESCRIPTION
## What's changed
- modified extra information card to ignore paragraph breaks
- added a formatting function for the extra information field
- applied the formatting method within all structures that try to retrieve the client details

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="765" height="816" alt="image" src="https://github.com/user-attachments/assets/cf1c69d2-837d-44d7-b62c-6c1300259e29" /> | <img width="766" height="519" alt="image" src="https://github.com/user-attachments/assets/aeaa7c05-8295-4aab-b222-36560df60160" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
