### PR TITLE
Vfb 421 block concurrent edit notes clients

### DIFF
--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -62,7 +62,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
             const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
             if (error) {
                 setErrorMessage(
-                    `Error saving notes, please refresh the page. Log ID: ${error.logId}`
+                    `Record has been edited recently - please refresh the page. Log ID: ${error.logId}`
                 );
                 setNotes(originalNotes);
             } else {

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -1,22 +1,22 @@
+import { CircularProgress } from "@mui/material";
 import React, { ChangeEvent, useCallback, useEffect, useState } from "react";
-import DataViewer, {
-    DataForDataViewer,
-    convertDataToDataForDataViewer,
-} from "@/components/DataViewer/DataViewer";
-import getExpandedClientDetails, {
-    ExpandedClientData,
-} from "@/app/clients/getExpandedClientDetails";
+import styled from "styled-components";
 import ClientParcelsTable from "@/app/clients/ClientParcelsTable";
 import {
     ExpandedClientParcelDetails,
     getClientParcelsDetails,
 } from "@/app/clients/getClientParcelsData";
-import styled from "styled-components";
-import { ErrorSecondaryText } from "../errorStylingandMessages";
-import { CircularProgress } from "@mui/material";
+import getExpandedClientDetails, {
+    ExpandedClientData,
+} from "@/app/clients/getExpandedClientDetails";
+import { capitaliseWords } from "@/common/format";
+import DataViewer, {
+    convertDataToDataForDataViewer,
+    DataForDataViewer,
+} from "@/components/DataViewer/DataViewer";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
 import { updateClientNotes } from "./updateClientNotes";
-import { capitaliseWords } from "@/common/format";
+import { ErrorSecondaryText } from "../errorStylingandMessages";
 
 interface Props {
     clientId: string;
@@ -60,10 +60,12 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
         setErrorMessage(null);
         const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
         if (error) {
-            setErrorMessage(`Error saving notes. Log ID: ${error.logId}`);
+            setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
             setNotes(originalNotes);
+        } else {
+            setNotes(notes);
+            loadData();
         }
-        loadData();
     };
 
     const onChangeNotes = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
@@ -73,8 +75,17 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
 
     const onCancelNotes = async (): Promise<void> => {
         setErrorMessage(null);
-        setNotes(originalNotes);
-        loadData();
+        const { error } = await updateClientNotes(
+            clientId,
+            originalNotes,
+            clientDetails?.lastUpdated
+        );
+        if (error) {
+            setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
+            setNotes(originalNotes);
+        } else {
+            loadData();
+        }
     };
 
     const getExpandedClientDetailsForDataViewer = (

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -37,11 +37,11 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
         ExpandedClientParcelDetails[] | null
     >(null);
 
-    const originalNotes = clientDetails?.notes ?? null;
-
-    const [notes, setNotes] = useState<string | null>(originalNotes);
+    const [originalNotes, setOriginalNotes] = useState<string | null>("");
+    const [notes, setNotes] = useState<string | null>("");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [isEditting, setIsEditting] = useState<boolean>(false);
 
     const loadData = useCallback(() => {
         (async () => {
@@ -50,6 +50,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
             setClientParcelsDetails(
                 displayClientsParcels ? await getClientParcelsDetails(clientId) : null
             );
+            setOriginalNotes(clientDetails?.notes ? clientDetails?.notes : "");
             setIsLoading(false);
         })();
     }, [clientId, displayClientsParcels]);
@@ -57,26 +58,32 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
     useEffect(loadData, [loadData]);
 
     const onSaveNotes = async (): Promise<void> => {
-        setErrorMessage(null);
-        const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
-        if (error) {
-            setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
-            setNotes(originalNotes);
-        } else {
-            setNotes(notes);
-            loadData();
+        if (isEditting) {
+            const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
+            if (error) {
+                setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
+                setNotes(originalNotes);
+            } else {
+                setNotes(notes);
+                loadData();
+            }
+            setIsEditting(false);
         }
     };
 
     const onChangeNotes = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
         setErrorMessage(null);
         setNotes(event.target.value);
+        setIsEditting(true);
     };
 
     const onCancelNotes = async (): Promise<void> => {
-        setErrorMessage(null);
-        setNotes(originalNotes);
-        loadData();
+        if (isEditting) {
+            setErrorMessage(null);
+            setNotes(originalNotes);
+            loadData();
+            setIsEditting(false);
+        }
     };
 
     const getExpandedClientDetailsForDataViewer = (

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -75,17 +75,8 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
 
     const onCancelNotes = async (): Promise<void> => {
         setErrorMessage(null);
-        const { error } = await updateClientNotes(
-            clientId,
-            originalNotes,
-            clientDetails?.lastUpdated
-        );
-        if (error) {
-            setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
-            setNotes(originalNotes);
-        } else {
-            loadData();
-        }
+        setNotes(originalNotes);
+        loadData();
     };
 
     const getExpandedClientDetailsForDataViewer = (

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -41,7 +41,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
     const [notes, setNotes] = useState<string | null>("");
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [isEditting, setIsEditting] = useState<boolean>(false);
+    const [isEditing, setisEditing] = useState<boolean>(false);
 
     const loadData = useCallback(() => {
         (async () => {
@@ -58,7 +58,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
     useEffect(loadData, [loadData]);
 
     const onSaveNotes = async (): Promise<void> => {
-        if (isEditting) {
+        if (isEditing) {
             const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
             if (error) {
                 setErrorMessage(
@@ -69,22 +69,22 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
                 setNotes(notes);
                 loadData();
             }
-            setIsEditting(false);
+            setisEditing(false);
         }
     };
 
     const onChangeNotes = async (event: ChangeEvent<HTMLInputElement>): Promise<void> => {
         setErrorMessage(null);
         setNotes(event.target.value);
-        setIsEditting(true);
+        setisEditing(true);
     };
 
     const onCancelNotes = async (): Promise<void> => {
-        if (isEditting) {
+        if (isEditing) {
             setErrorMessage(null);
             setNotes(originalNotes);
             loadData();
-            setIsEditting(false);
+            setisEditing(false);
         }
     };
 

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -58,7 +58,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
 
     const onSaveNotes = async (): Promise<void> => {
         setErrorMessage(null);
-        const { error } = await updateClientNotes(clientId, notes);
+        const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
         if (error) {
             setErrorMessage(`Error saving notes. Log ID: ${error.logId}`);
             setNotes(originalNotes);

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -53,7 +53,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
             setOriginalNotes(clientDetails?.notes ? clientDetails?.notes : "");
             setIsLoading(false);
         })();
-    }, [clientId, displayClientsParcels]);
+    }, [clientId, displayClientsParcels, clientDetails?.notes]);
 
     useEffect(loadData, [loadData]);
 
@@ -61,7 +61,9 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
         if (isEditting) {
             const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
             if (error) {
-                setErrorMessage(`Error saving notes, please refresh the page. Log ID: ${error.logId}`);
+                setErrorMessage(
+                    `Error saving notes, please refresh the page. Log ID: ${error.logId}`
+                );
                 setNotes(originalNotes);
             } else {
                 setNotes(notes);

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -64,6 +64,7 @@ const getRawClientDetails = async (clientId: string) => {
             other_items,
             extra_information,
             signposting_call_required,
+            last_updated,
             signposting_call_reasons,
             notes,
             is_active,
@@ -109,6 +110,7 @@ export interface ExpandedClientData {
     otherRequirements: string;
     extraInformation: string;
     signpostingCallRequired: boolean;
+    lastUpdated: string;
     signpostingCallReasons: string;
     notes: string | null;
     isActive: boolean;
@@ -152,6 +154,7 @@ export const rawDataToExpandedClientDetails = (client: RawClientDetails): Expand
         ),
         extraInformation: formatExtraInformation(client.extra_information),
         signpostingCallRequired: client.signposting_call_required ?? false,
+        lastUpdated: client.last_updated,
         signpostingCallReasons:
             client.signposting_call_required === true
                 ? formatRequirementsByCanonicalOrder(

--- a/src/app/clients/updateClientNotes.ts
+++ b/src/app/clients/updateClientNotes.ts
@@ -1,4 +1,4 @@
-import { logErrorReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
 import { sendAuditLog } from "@/server/auditLog";
 import supabase from "@/supabaseClient";
 
@@ -8,7 +8,8 @@ type UpdateClientNotesResponse =
 
 export const updateClientNotes = async (
     clientId: string,
-    notes: string | null
+    notes: string | null,
+    lastUpdated: string | undefined
 ): Promise<UpdateClientNotesResponse> => {
     const baseAuditLogProps = {
         action: "update client notes",
@@ -16,13 +17,20 @@ export const updateClientNotes = async (
         content: { notes: notes, clientId },
     };
 
-    const { error } = await supabase
+    const { error, count } = await supabase
         .from("clients")
-        .update({ notes: notes })
-        .eq("primary_key", clientId);
+        .update({ notes: notes }, { count: "exact" })
+        .eq("primary_key", clientId)
+        .eq("last_updated", lastUpdated);
 
     if (error) {
         const logId = await logErrorReturnLogId("update client notes failed", { error });
+        await sendAuditLog({ ...baseAuditLogProps, wasSuccess: false, logId });
+        return { error: { type: "updateNotesFailed", logId } };
+    }
+
+    if (count === 0) {
+        const logId = await logWarningReturnLogId("Concurrent editing of parcel");
         await sendAuditLog({ ...baseAuditLogProps, wasSuccess: false, logId });
         return { error: { type: "updateNotesFailed", logId } };
     }

--- a/src/components/DataViewer/DataViewer.tsx
+++ b/src/components/DataViewer/DataViewer.tsx
@@ -18,6 +18,9 @@ export const convertDataToDataForDataViewer = (data: Data): DataForDataViewer =>
     const dataForDataViewer: DataForDataViewer = {};
 
     for (const [key, value] of Object.entries(data)) {
+        if (key === "lastUpdated") {
+            continue;
+        }
         dataForDataViewer[key] = { value: value };
     }
 


### PR DESCRIPTION
Link to [Jira]( https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?assignee=712020%3A940da565-b936-4c6a-b510-6437c82dc52d&selectedIssue=VFB-421 )
## What's changed

- Prevent loading the data to the database if a concurrent edit occurs.
- Showed a new error that would suggest to the user that they should refresh the page, the same error that is thrown in the "Edit Client" form and "Edit Parcel" form.
- Modify the notes' "onSave" and "onCancel" methods, for Clients Details Card

## Videos
### Before
https://github.com/user-attachments/assets/1b7e8d37-59bc-41be-9bf1-b0ca9641554a
### After
https://github.com/user-attachments/assets/4aa0336a-d7f2-4240-8674-14f0560dde6b

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
