### PR TITLE
VFB-409-Drag-Items-ListsPage

### DIFF
--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -309,10 +309,6 @@ const Table = <
         }
     };
 
-    const [isSwapping, setIsSwapping] = useState(false);
-
-    const [draggedRowId, setDraggedRowId] = useState<number | null>(null);
-
     if (editableConfig.editable) {
         const swapRows = (rowIndex1: number, upwards: boolean): void => {
             if (isSwapping) {
@@ -350,57 +346,6 @@ const Table = <
             } else {
                 clientSideRefresh();
             }
-        };
-
-        const swapRowsWithDrag = (rowIndex1: number, rowIndex2: number): void => {
-            if (isSwapping) {
-                return;
-            }
-            setIsSwapping(true);
-
-            if (
-                rowIndex1 < 0 ||
-                rowIndex2 < 0 ||
-                rowIndex1 >= dataPortion.length ||
-                rowIndex2 >= dataPortion.length
-            ) {
-                setIsSwapping(false);
-                return;
-            }
-            const clientSideRefresh = (): void => {
-                // Update viewed table data once specific functions are done (without re-fetch)
-                const newData = [...dataPortion];
-                const temp = newData[rowIndex1];
-                newData[rowIndex1] = newData[rowIndex2];
-                newData[rowIndex2] = temp;
-
-                editableConfig.setDataPortion(newData);
-                setIsSwapping(false);
-            };
-
-            if (editableConfig.onSwapRowsWithDrag) {
-                editableConfig
-                    .onSwapRowsWithDrag(dataPortion[rowIndex1], dataPortion[rowIndex2])
-                    .then(clientSideRefresh);
-            } else {
-                clientSideRefresh();
-            }
-        };
-
-        const onDragStart = (rowId: number): void => {
-            setDraggedRowId(rowId);
-        };
-
-        const onDragOver = (event: React.DragEvent<HTMLElement>): void => {
-            event.preventDefault();
-        };
-
-        const handleDrop = (targetRowId: number): void => {
-            if (draggedRowId == null || draggedRowId === targetRowId) {
-                return;
-            }
-            swapRowsWithDrag(draggedRowId, targetRowId);
-            setDraggedRowId(null);
         };
 
         columns.unshift({
@@ -499,6 +444,69 @@ const Table = <
 
     const rows = dataPortion.map((data, index) => ({ rowId: index, data }));
 
+    const [isSwapping, setIsSwapping] = useState(false);
+
+    const [draggedRowId, setDraggedRowId] = useState<number | null>(null);
+
+    const swapRowsWithDrag = (rowIndex1: number, rowIndex2: number): void => {
+        if (isSwapping) {
+            return;
+        }
+        setIsSwapping(true);
+
+        if (
+            rowIndex1 < 0 ||
+            rowIndex2 < 0 ||
+            rowIndex1 >= dataPortion.length ||
+            rowIndex2 >= dataPortion.length
+        ) {
+            setIsSwapping(false);
+            return;
+        }
+        const clientSideRefresh = (): void => {
+            // Update viewed table data once specific functions are done (without re-fetch)
+            const newData = [...dataPortion];
+            const temp = newData[rowIndex1];
+            newData[rowIndex1] = newData[rowIndex2];
+            newData[rowIndex2] = temp;
+
+            if (editableConfig.editable) {
+                editableConfig.setDataPortion(newData);
+            }
+            setIsSwapping(false);
+        };
+
+        if (editableConfig.editable) {
+            if (editableConfig.onSwapRowsWithDrag) {
+                editableConfig
+                    .onSwapRowsWithDrag(dataPortion[rowIndex1], dataPortion[rowIndex2])
+                    .then(clientSideRefresh);
+            } else {
+                clientSideRefresh();
+            }
+        }
+    };
+
+    const onDragStart = (rowId: number): void => {
+        setDraggedRowId(rowId);
+        console.log("start");
+    };
+
+    const onDragOver = (event: React.DragEvent<HTMLElement>): void => {
+        event.preventDefault();
+        console.log("over");
+    };
+
+    const handleDrop = (targetRowId: number): void => {
+        if (draggedRowId == null || draggedRowId === targetRowId) {
+            return;
+        }
+        console.log("drop");
+
+        swapRowsWithDrag(draggedRowId, targetRowId);
+        setDraggedRowId(null);
+    };
+
     const conditionalRowStyles = [
         {
             when: (row: Row<Data>) =>
@@ -506,6 +514,12 @@ const Table = <
             style: {
                 backgroundColor: `${theme.primary.background[1]} !important`,
             },
+            props: (row: Row<Data>) => ({
+                draggable: true,
+                onDragStart: () => onDragStart(row.rowId),
+                onDragOver: onDragOver,
+                onDrop: () => handleDrop(row.rowId),
+            }),
         },
     ];
 

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -10,7 +10,7 @@ import { faHamburger } from "@fortawesome/free-solid-svg-icons/faHamburger";
 import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import React, { useState } from "react";
-import DataTable, { TableColumn, TableRow } from "react-data-table-component";
+import DataTable, { TableColumn } from "react-data-table-component";
 import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
 import styled, { useTheme } from "styled-components";
 import {
@@ -399,11 +399,7 @@ const Table = <
             if (draggedRowId == null || draggedRowId === targetRowId) {
                 return;
             }
-            const row1 = rows.find((r) => r.rowId === draggedRowId);
-            const row2 = rows.find((r) => r.rowId === targetRowId);
-            if (row1?.data && row2?.data) {
-                editableConfig?.onSwapRowsWithDrag?.(row1.data, row2.data);
-            }
+            swapRowsWithDrag(draggedRowId, targetRowId);
             setDraggedRowId(null);
         };
 

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -3,10 +3,10 @@
 import {
     faAnglesDown,
     faAnglesUp,
+    faGripHorizontal,
     faPenToSquare,
     faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { faHamburger } from "@fortawesome/free-solid-svg-icons/faHamburger";
 import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import React, { useState } from "react";
@@ -463,14 +463,14 @@ const Table = <
                                     onDragOver={onDragOver}
                                     onDrop={() => handleDrop(row.rowId)}
                                 >
-                                    <StyledIcon icon={faHamburger} />
+                                    <StyledIcon icon={faGripHorizontal} />
                                 </StyledIconButton>
                             )}
                         </DragHamburgerDiv>
                     </ActionsDiv>
                 );
             },
-            width: "5rem",
+            width: "6rem",
         });
     }
 

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -1,32 +1,33 @@
 "use client";
 
 import {
-    DistributeClientFilter,
-    DistributeServerFilter,
-    PaginationType as PaginationTypeEnum,
-} from "@/components/Tables/Filters";
-import TableFiltersBar from "@/components/Tables/TableFiltersBar";
-import {
     faAnglesDown,
     faAnglesUp,
     faPenToSquare,
     faTrashAlt,
 } from "@fortawesome/free-solid-svg-icons";
-import { StyledIcon, StyledIconButton } from "../Icons/IconButton";
+import { faHamburger } from "@fortawesome/free-solid-svg-icons/faHamburger";
 import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
+import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import React, { useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
-import styled, { useTheme } from "styled-components";
 import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
-import { Centerer } from "../Modal/ModalFormStyles";
-import { ClientSideSortMethod, ServerSideSortMethod } from "./sortMethods";
+import styled, { useTheme } from "styled-components";
 import {
     DividingLineStyleOptions,
     getDividingLineStyleOptions,
 } from "@/app/parcels/parcelsTable/conditionalStyling";
-import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
+import {
+    DistributeClientFilter,
+    DistributeServerFilter,
+    PaginationType as PaginationTypeEnum,
+} from "@/components/Tables/Filters";
+import TableFiltersBar from "@/components/Tables/TableFiltersBar";
 import { Database } from "@/databaseTypesFile";
 import ColumnTogglePopup from "./ColumnTogglePopup";
+import { ClientSideSortMethod, ServerSideSortMethod } from "./sortMethods";
+import { StyledIcon, StyledIconButton } from "../Icons/IconButton";
+import { Centerer } from "../Modal/ModalFormStyles";
 
 export type TableHeaders<Data> = readonly (readonly [keyof Data, string])[];
 
@@ -354,50 +355,67 @@ const Table = <
                     ? editableConfig.isDeletable(row.data)
                     : true;
                 return (
-                    <EditAndReorderArrowDiv>
-                        {editableConfig.onSwapRows && (
-                            <StyledIconButton
-                                onClick={() => swapRows(row.rowId, true)}
-                                aria-label="reorder row upwards"
-                                disabled={isSwapping}
-                                data-testid={`button-move-row-up-${row.rowId}`}
-                            >
-                                <StyledIcon icon={faAnglesUp} />
-                            </StyledIconButton>
-                        )}
-                        {editableConfig.onEdit && (
-                            <StyledIconButton
-                                onClick={() => editableConfig.onEdit?.(row.rowId)}
-                                aria-label="edit"
-                                data-testid={`button-edit-row-${row.rowId}`}
-                            >
-                                <StyledIcon icon={faPenToSquare} />
-                            </StyledIconButton>
-                        )}
-                        {editableConfig.onSwapRows && (
-                            <StyledIconButton
-                                onClick={() => swapRows(row.rowId, false)}
-                                aria-label="reorder row downwards"
-                                disabled={isSwapping}
-                                data-testid={`button-move-row-down-${row.rowId}`}
-                            >
-                                <StyledIcon icon={faAnglesDown} />
-                            </StyledIconButton>
-                        )}
-                        {editableConfig.onDelete && isRowDeletable && (
-                            <StyledIconButton
-                                onClick={() => {
-                                    if (editableConfig.onDelete) {
-                                        editableConfig.onDelete(row.rowId);
-                                    }
-                                }}
-                                aria-label="delete"
-                                data-testid={`button-delete-row-${row.rowId}`}
-                            >
-                                <StyledIcon icon={faTrashAlt} />
-                            </StyledIconButton>
-                        )}
-                    </EditAndReorderArrowDiv>
+                    <ActionsDiv>
+                        <EditAndReorderArrowDiv>
+                            {editableConfig.onSwapRows && (
+                                <StyledIconButton
+                                    onClick={() => swapRows(row.rowId, true)}
+                                    aria-label="reorder row upwards"
+                                    disabled={isSwapping}
+                                    data-testid={`button-move-row-up-${row.rowId}`}
+                                >
+                                    <StyledIcon icon={faAnglesUp} />
+                                </StyledIconButton>
+                            )}
+                            {editableConfig.onEdit && (
+                                <StyledIconButton
+                                    onClick={() => editableConfig.onEdit?.(row.rowId)}
+                                    aria-label="edit"
+                                    data-testid={`button-edit-row-${row.rowId}`}
+                                >
+                                    <StyledIcon icon={faPenToSquare} />
+                                </StyledIconButton>
+                            )}
+                            {editableConfig.onSwapRows && (
+                                <StyledIconButton
+                                    onClick={() => swapRows(row.rowId, false)}
+                                    aria-label="reorder row downwards"
+                                    disabled={isSwapping}
+                                    data-testid={`button-move-row-down-${row.rowId}`}
+                                >
+                                    <StyledIcon icon={faAnglesDown} />
+                                </StyledIconButton>
+                            )}
+                            {editableConfig.onDelete && isRowDeletable && (
+                                <StyledIconButton
+                                    onClick={() => {
+                                        if (editableConfig.onDelete) {
+                                            editableConfig.onDelete(row.rowId);
+                                        }
+                                    }}
+                                    aria-label="delete"
+                                    data-testid={`button-delete-row-${row.rowId}`}
+                                >
+                                    <StyledIcon icon={faTrashAlt} />
+                                </StyledIconButton>
+                            )}
+                        </EditAndReorderArrowDiv>
+                        <DragHamburgerDiv>
+                            {editableConfig.onSwapRows && (
+                                <StyledIconButton
+                                    draggable={true}
+                                    onDragStart={() => {
+                                        console.log("moving");
+                                    }}
+                                    aria-label="reorder row downwards"
+                                    disabled={isSwapping}
+                                    data-testid={`button-move-row-down-${row.rowId}`}
+                                >
+                                    <StyledIcon icon={faHamburger} />
+                                </StyledIconButton>
+                            )}
+                        </DragHamburgerDiv>
+                    </ActionsDiv>
                 );
             },
             width: "5rem",
@@ -552,6 +570,21 @@ const EditAndReorderArrowDiv = styled.div`
     grid-template-columns: repeat(2, 1fr);
     width: 100%;
     // this transform is necessary to make the buttons visually consistent with the rest of the table without redesigning the layout
+    //transform: translateX(-1.2rem);
+`;
+
+const DragHamburgerDiv = styled.div`
+    display: grid;
+    justify-content: center;
+    width: 100%;
+    // this transform is necessary to make the buttons visually consistent with the rest of the table without redesigning the layout
+    //transform: translateX(-1.2rem);
+`;
+
+const ActionsDiv = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 100%;
     transform: translateX(-1.2rem);
 `;
 

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -10,7 +10,7 @@ import { faHamburger } from "@fortawesome/free-solid-svg-icons/faHamburger";
 import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import { PostgrestFilterBuilder } from "@supabase/postgrest-js";
 import React, { useState } from "react";
-import DataTable, { TableColumn } from "react-data-table-component";
+import DataTable, { TableColumn, TableRow } from "react-data-table-component";
 import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
 import styled, { useTheme } from "styled-components";
 import {
@@ -146,6 +146,7 @@ export type EditableConfig<Data> =
           onEdit?: (data: number) => void;
           onDelete?: (data: number) => void;
           onSwapRows?: (row1: Data, row2: Data) => Promise<void>;
+          onSwapRowsWithDrag?: (row1: Data, row2: Data) => Promise<void>;
           isDeletable?: (row: Data) => boolean;
       }
     | { editable: false };
@@ -310,6 +311,8 @@ const Table = <
 
     const [isSwapping, setIsSwapping] = useState(false);
 
+    const [draggedRowId, setDraggedRowId] = useState<number | null>(null);
+
     if (editableConfig.editable) {
         const swapRows = (rowIndex1: number, upwards: boolean): void => {
             if (isSwapping) {
@@ -348,6 +351,62 @@ const Table = <
                 clientSideRefresh();
             }
         };
+
+        const swapRowsWithDrag = (rowIndex1: number, rowIndex2: number): void => {
+            if (isSwapping) {
+                return;
+            }
+            setIsSwapping(true);
+
+            if (
+                rowIndex1 < 0 ||
+                rowIndex2 < 0 ||
+                rowIndex1 >= dataPortion.length ||
+                rowIndex2 >= dataPortion.length
+            ) {
+                setIsSwapping(false);
+                return;
+            }
+            const clientSideRefresh = (): void => {
+                // Update viewed table data once specific functions are done (without re-fetch)
+                const newData = [...dataPortion];
+                const temp = newData[rowIndex1];
+                newData[rowIndex1] = newData[rowIndex2];
+                newData[rowIndex2] = temp;
+
+                editableConfig.setDataPortion(newData);
+                setIsSwapping(false);
+            };
+
+            if (editableConfig.onSwapRowsWithDrag) {
+                editableConfig
+                    .onSwapRowsWithDrag(dataPortion[rowIndex1], dataPortion[rowIndex2])
+                    .then(clientSideRefresh);
+            } else {
+                clientSideRefresh();
+            }
+        };
+
+        const onDragStart = (rowId: number): void => {
+            setDraggedRowId(rowId);
+        };
+
+        const onDragOver = (event: React.DragEvent<HTMLElement>): void => {
+            event.preventDefault();
+        };
+
+        const handleDrop = (targetRowId: number): void => {
+            if (draggedRowId == null || draggedRowId === targetRowId) {
+                return;
+            }
+            const row1 = rows.find((r) => r.rowId === draggedRowId);
+            const row2 = rows.find((r) => r.rowId === targetRowId);
+            if (row1?.data && row2?.data) {
+                editableConfig?.onSwapRowsWithDrag?.(row1.data, row2.data);
+            }
+            setDraggedRowId(null);
+        };
+
         columns.unshift({
             name: "",
             cell: (row: Row<Data>) => {
@@ -403,13 +462,10 @@ const Table = <
                         <DragHamburgerDiv>
                             {editableConfig.onSwapRows && (
                                 <StyledIconButton
-                                    draggable={true}
-                                    onDragStart={() => {
-                                        console.log("moving");
-                                    }}
-                                    aria-label="reorder row downwards"
-                                    disabled={isSwapping}
-                                    data-testid={`button-move-row-down-${row.rowId}`}
+                                    draggable
+                                    onDragStart={() => onDragStart(row.rowId)}
+                                    onDragOver={onDragOver}
+                                    onDrop={() => handleDrop(row.rowId)}
                                 >
                                     <StyledIcon icon={faHamburger} />
                                 </StyledIconButton>


### PR DESCRIPTION
## What's changed
Now we have a draggable hamburger type icon in the Lists Page, that allows us to move rows.

## Screenshots / Videos
### Before 
 <img width="1892" height="1000" alt="Screenshot 2025-07-23 154058" src="https://github.com/user-attachments/assets/926671af-cbe5-4937-8ae4-271a362c5f30" /> 

### After 

https://github.com/user-attachments/assets/e9aac574-393b-4484-802e-63d02c7db481



## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`


