### PR TITLE
VFB-397 search criteria voucher

### DIFF
--- a/src/app/parcels/parcelsTable/filters.ts
+++ b/src/app/parcels/parcelsTable/filters.ts
@@ -58,7 +58,7 @@ const voucherSearchMethod: ParcelsFilterMethod<string> = dbFilterWithSubstringQu
     (substring) => {
         const voucherColumnLabel = "voucher_number";
         if (substring === "?") {
-            return `or(${voucherColumnLabel}.not.ilike.E%, ${voucherColumnLabel}.ilike."")`;
+            return `or(${voucherColumnLabel}.not.ilike.E%, ${voucherColumnLabel}.ilike."", ${voucherColumnLabel}.is.null)`;
         }
         return `${voucherColumnLabel}.ilike.%${substring}%`;
     }


### PR DESCRIPTION
## What's changed
- voucher search criteria changed: for “?” returns parcels with voucher number not starting with "E", or with null/empty voucher number , instead of blank
- updated the voucher number description to match E-00000-000000 or E-000000-000000 format

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="2390" height="585" alt="voucher-before" src="https://github.com/user-attachments/assets/43691a31-dcc5-4478-a519-c2f9469bef77" /> | <img width="1777" height="580" alt="voucher-after" src="https://github.com/user-attachments/assets/232ad2f3-6610-439f-b61c-e5826026fb80" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
