### PR TITLE
VFB-440: Conditional Styling override

### DIFF
--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -433,18 +433,18 @@ const Table = <
 
     const conditionalRowStyles = [
         {
-            when: (row: Row<Data>) =>
-                checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
-            style: {
-                backgroundColor: `${theme.primary.background[1]} !important`,
-            },
-        },
-        {
             when: () => reduceRowHeight === true,
             style: {
                 // The default DataTable class has a predefined min-height of 48px for the row-element
                 // for this reason, any value < 48px would not decrease the height.
                 height: "48px",
+            },
+        },
+        {
+            when: (row: Row<Data>) =>
+                checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
+            style: {
+                backgroundColor: `${theme.primary.background[1]} !important`,
             },
         },
     ];


### PR DESCRIPTION
## What's changed
[VFB-440](https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?selectedIssue=VFB-440): Parcel Rows' Height reduction does not override other styling properties anymore.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1846" height="415" alt="image" src="https://github.com/user-attachments/assets/d8454b73-c307-4629-99c3-e0e05c5b73ac" />| <img width="1851" height="428" alt="image" src="https://github.com/user-attachments/assets/a2918fb4-3224-44b4-b266-ea4c06f7c8cb" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
