### PR TITLE
VFB-442: Pending More Info Report Undefined Query Result

### DIFF
--- a/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
@@ -177,10 +177,7 @@ const getPendingMoreInfoReportData = async (
 
     if (!rawParcelList || rawParcelList.length === 0) {
         const logId = await logErrorReturnLogId(
-            "No parcels with specified status to create Pending More Info report",
-            {
-                error: parcelFetchError,
-            }
+            "No parcels with specified status to create Pending More Info report"
         );
         return {
             data: null,

--- a/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
@@ -175,6 +175,22 @@ const getPendingMoreInfoReportData = async (
         };
     }
 
+    if (!rawParcelList || rawParcelList.length === 0) {
+        const logId = await logErrorReturnLogId(
+            "No parcels with specified status to create Pending More Info report",
+            {
+                error: parcelFetchError,
+            }
+        );
+        return {
+            data: null,
+            error: {
+                type: "noPendingMoreInfoRowsForInterval",
+                logId,
+            },
+        };
+    }
+
     return {
         error: null,
         data: rawParcelList

--- a/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
@@ -96,7 +96,11 @@ const PendingMoreInfoReportModal: React.FC<ActionModalProps> = (props) => {
     };
 
     const onFileCreationFailed = (csvError: FetchPendingMoreInfoReportError): void => {
-        setErrorMessage("Failed to fetch pendingMoreInfo report data");
+        if (csvError.type == "noPendingMoreInfoRowsForInterval") {
+            setErrorMessage("No parcels with specified status to create Pending More Info report");
+        } else {
+            setErrorMessage("Failed to fetch pendingMoreInfo report data");
+        }
         setActionCompleted(true);
         void sendAuditLog({
             action: "generate pendingMoreInfo report",


### PR DESCRIPTION
## What's changed
[VFB-442](https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?selectedIssue=VFB-442): Trying to download a Pending More Info Report for an interval with no available parcels now displays an error.

(Bug fix for [VFB-400](https://softwiretech.atlassian.net/browse/VFB-400))

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="928" height="275" alt="image" src="https://github.com/user-attachments/assets/e01dfdd5-72fd-412e-8c73-708c4ef61670" />| <img width="754" height="211" alt="image" src="https://github.com/user-attachments/assets/91d7fbbb-48fd-4000-ba79-9a851cb38422" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
