### PR TITLE
VFB-435: Called no response - Extra question

### DIFF
--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -77,7 +77,7 @@ const Statuses: React.FC<Props> = ({
         void getParcelStatuses();
     }, [setModalError]);
 
-    const submitStatus = async (date: Dayjs): Promise<void> => {
+    const submitStatus = async (date: Dayjs, callNoResponseStatuses: string[]): Promise<void> => {
         setServerErrorMessage(null);
         if (selectedStatus === null) {
             setServerErrorMessage("Chosen status was not found.");
@@ -133,6 +133,7 @@ const Statuses: React.FC<Props> = ({
                 headerId="status-modal-header"
                 onSubmit={submitStatus}
                 errorText={serverErrorMessage}
+                selectedStatus={selectedStatus}
             >
                 <></>
             </StatusesModal>

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -83,10 +83,13 @@ const Statuses: React.FC<Props> = ({
             setServerErrorMessage("Chosen status was not found.");
             return;
         }
+
+        const callNoResponseStatusesList: string = callNoResponseStatuses.join(" / ");
+
         const { error } = await saveParcelTableRowsStatus(
             selectedParcels,
             selectedStatus,
-            null,
+            callNoResponseStatusesList,
             undefined,
             date
         );

--- a/src/app/parcels/ActionBar/StatusesModal.test.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.test.tsx
@@ -131,4 +131,47 @@ describe("StatusesModal component", () => {
 
         expect(mockOnSubmit).toHaveBeenCalledWith(mockDate, []);
     });
+
+    it("selects 'Called and No Response' checkboxes and verifies the selection", () => {
+        cleanup();
+        render(
+            <Localization>
+                <StyleManager>
+                    <StatusesModal
+                        isOpen={true}
+                        onClose={mockOnClose}
+                        selectedParcels={mockSelectedParcels}
+                        onSubmit={mockOnSubmit}
+                        errorText={null}
+                        headerId="status-modal-header"
+                        header="Apply Status: Called and No Response"
+                        selectedStatus="Called and No Response"
+                    >
+                        children={null}
+                    </StatusesModal>
+                </StyleManager>
+            </Localization>
+        );
+
+        const voicemailCheckbox = screen.getByLabelText("Voicemail");
+        const textCheckbox = screen.getByLabelText("Text");
+        const emailCheckbox = screen.getByLabelText("Email");
+
+        expect(voicemailCheckbox).not.toBeChecked();
+        expect(textCheckbox).not.toBeChecked();
+        expect(emailCheckbox).not.toBeChecked();
+
+        fireEvent.click(voicemailCheckbox);
+        fireEvent.click(emailCheckbox);
+
+        expect(voicemailCheckbox).toBeChecked();
+        expect(textCheckbox).not.toBeChecked();
+        expect(emailCheckbox).toBeChecked();
+
+        fireEvent.click(screen.getByText("Submit"));
+
+        const mockDate = dayjs("2024-01-01 12:00:00");
+
+        expect(mockOnSubmit).toHaveBeenCalledWith(mockDate, ["Voicemail", "Email"]);
+    });
 });

--- a/src/app/parcels/ActionBar/StatusesModal.test.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.test.tsx
@@ -132,7 +132,7 @@ describe("StatusesModal component", () => {
         expect(mockOnSubmit).toHaveBeenCalledWith(mockDate, []);
     });
 
-    it("selects 'Called and No Response' checkboxes and verifies the selection", () => {
+    it("saves the checked extra question fields when 'Called and No Response' status is selected", () => {
         cleanup();
         render(
             <Localization>

--- a/src/app/parcels/ActionBar/StatusesModal.test.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.test.tsx
@@ -129,6 +129,6 @@ describe("StatusesModal component", () => {
         const mockDate = dayjs("2024-01-01 12:00:00");
         fireEvent.click(screen.getByText("Submit"));
 
-        expect(mockOnSubmit).toHaveBeenCalledWith(mockDate);
+        expect(mockOnSubmit).toHaveBeenCalledWith(mockDate, []);
     });
 });

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -15,6 +15,11 @@ const NO_RESPONSE_FOLLOW_UP = ["Voicemail", "Text", "Email"];
 const NO_RESPONSE_STATUS = "Called and No Response";
 const MAX_PARCELS_TO_SHOW = 5;
 
+const FOLLOW_UP_LABELS_AND_KEYS: [string, string][] = NO_RESPONSE_FOLLOW_UP.map((followUp) => [
+    followUp,
+    followUp,
+]);
+
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
     onSubmit: (date: Dayjs, callNoResponseFollowUp: string[]) => void;
@@ -99,10 +104,7 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                     <FormElementWithSpacing>
                         <CheckboxGroupInput
                             groupLabel="Did you send any of the following?"
-                            labelsAndKeys={NO_RESPONSE_FOLLOW_UP.map((followUp) => [
-                                followUp,
-                                followUp,
-                            ])}
+                            labelsAndKeys={FOLLOW_UP_LABELS_AND_KEYS}
                             checkedKeys={callNoResponseFollowUp}
                             onChange={(event) => toggleCallNoResponseFollowUp(event.target.name)}
                         />

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -8,7 +8,7 @@ import { ParcelsTableRow } from "../parcelsTable/types";
 import SelectedParcelsOverview from "./SelectedParcelsOverview";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
-import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
+import { Checkbox, FormControlLabel, FormGroup, FormLabel } from "@mui/material";
 
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
@@ -89,6 +89,17 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                 />
                 {props.selectedStatus === "Called and No Response" && (
                     <FormGroup>
+                        <FormLabel
+                            component="p"
+                            style={{
+                                fontSize: 18,
+                                marginBottom: 8,
+                                marginTop: 8,
+                                color: "inherit",
+                            }}
+                        >
+                            Did you send any of the following?
+                        </FormLabel>
                         <FormControlLabel
                             control={
                                 <Checkbox

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -32,6 +32,8 @@ const ModalInner = styled.div`
 
 const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [date, setDate] = useState(dayjs(new Date()));
+    const [callNoResponseStatuses, setCallNoResponseStatuses] = useState<string[]>([]);
+    const noResponseStatuses = ["Voicemail", "Text", "Email"];
 
     useEffect(() => {
         setDate(dayjs(new Date()));
@@ -53,8 +55,6 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
         );
 
     const maxParcelsToShow = 5;
-
-    const [callNoResponseStatuses, setCallNoResponseStatuses] = useState<string[]>([]);
 
     useEffect(() => {
         if (props.isOpen) {
@@ -106,33 +106,18 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                         >
                             Did you send any of the following?
                         </FormLabel>
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={callNoResponseStatuses.includes("Voicemail")}
-                                    onChange={() => toggleCallNoResponseStatuses("Voicemail")}
-                                />
-                            }
-                            label="Voicemail"
-                        />
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={callNoResponseStatuses.includes("Text")}
-                                    onChange={() => toggleCallNoResponseStatuses("Text")}
-                                />
-                            }
-                            label="Text"
-                        />
-                        <FormControlLabel
-                            control={
-                                <Checkbox
-                                    checked={callNoResponseStatuses.includes("Email")}
-                                    onChange={() => toggleCallNoResponseStatuses("Email")}
-                                />
-                            }
-                            label="Email"
-                        />
+                        {noResponseStatuses.map((status) => (
+                            <FormControlLabel
+                                key={status}
+                                control={
+                                    <Checkbox
+                                        checked={callNoResponseStatuses.includes(status)}
+                                        onChange={() => toggleCallNoResponseStatuses(status)}
+                                    />
+                                }
+                                label={status}
+                            />
+                        ))}
                     </FormGroup>
                 )}
                 <Centerer>

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -56,6 +56,12 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
 
     const [callNoResponseStatuses, setCallNoResponseStatuses] = useState<string[]>([]);
 
+    useEffect(() => {
+        if (props.isOpen) {
+            setCallNoResponseStatuses([]);
+        }
+    }, [props.isOpen]);
+
     const toggleCallNoResponseStatuses = (newNoResponseStatus: string): void => {
         setCallNoResponseStatuses((prevCallNoResponseStatuses) =>
             prevCallNoResponseStatuses.includes(newNoResponseStatus)

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -36,6 +36,7 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [callNoResponseFollowUp, setCallNoResponseFollowUp] = useState<string[]>([]);
 
     const noResponseStatus = "Called and No Response";
+    const noResponseFollowUp = ["Voicemail", "Text", "Email"];
 
     useEffect(() => {
         setDate(dayjs(new Date()));
@@ -73,8 +74,6 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                 : [...prevCallNoResponseFollowUp, newNoResponseFollowUp]
         );
     };
-
-    const noResponseFollowUp = ["Voicemail", "Text", "Email"];
 
     return (
         <Modal {...props}>

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -8,11 +8,12 @@ import { ParcelsTableRow } from "../parcelsTable/types";
 import SelectedParcelsOverview from "./SelectedParcelsOverview";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
-import { Checkbox, FormControlLabel, FormGroup, FormLabel } from "@mui/material";
+import { FormElementWithSpacing } from "@/components/Form/formStyling";
+import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
 
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
-    onSubmit: (date: Dayjs, callNoResponseStatuses: string[]) => void;
+    onSubmit: (date: Dayjs, callNoResponseFollowUp: string[]) => void;
     selectedStatus?: string | null;
     errorText: string | null;
 }
@@ -32,8 +33,9 @@ const ModalInner = styled.div`
 
 const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [date, setDate] = useState(dayjs(new Date()));
-    const [callNoResponseStatuses, setCallNoResponseStatuses] = useState<string[]>([]);
-    const noResponseStatuses = ["Voicemail", "Text", "Email"];
+    const [callNoResponseFollowUp, setCallNoResponseFollowUp] = useState<string[]>([]);
+
+    const noResponseStatus = "Called and No Response";
 
     useEffect(() => {
         setDate(dayjs(new Date()));
@@ -58,19 +60,21 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
 
     useEffect(() => {
         if (props.isOpen) {
-            setCallNoResponseStatuses([]);
+            setCallNoResponseFollowUp([]);
         }
     }, [props.isOpen]);
 
-    const toggleCallNoResponseStatuses = (newNoResponseStatus: string): void => {
-        setCallNoResponseStatuses((prevCallNoResponseStatuses) =>
-            prevCallNoResponseStatuses.includes(newNoResponseStatus)
-                ? prevCallNoResponseStatuses.filter(
-                      (prevStatus) => prevStatus !== newNoResponseStatus
+    const toggleCallNoResponseFollowUp = (newNoResponseFollowUp: string): void => {
+        setCallNoResponseFollowUp((prevCallNoResponseFollowUp) =>
+            prevCallNoResponseFollowUp.includes(newNoResponseFollowUp)
+                ? prevCallNoResponseFollowUp.filter(
+                      (prevStatus) => prevStatus !== newNoResponseFollowUp
                   )
-                : [...prevCallNoResponseStatuses, newNoResponseStatus]
+                : [...prevCallNoResponseFollowUp, newNoResponseFollowUp]
         );
     };
+
+    const noResponseFollowUp = ["Voicemail", "Text", "Email"];
 
     return (
         <Modal {...props}>
@@ -93,38 +97,24 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                     parcels={props.selectedParcels}
                     maxParcelsToShow={maxParcelsToShow}
                 />
-                {props.selectedStatus === "Called and No Response" && (
-                    <FormGroup>
-                        <FormLabel
-                            component="p"
-                            style={{
-                                fontSize: 18,
-                                marginBottom: 8,
-                                marginTop: 8,
-                                color: "inherit",
-                            }}
-                        >
-                            Did you send any of the following?
-                        </FormLabel>
-                        {noResponseStatuses.map((status) => (
-                            <FormControlLabel
-                                key={status}
-                                control={
-                                    <Checkbox
-                                        checked={callNoResponseStatuses.includes(status)}
-                                        onChange={() => toggleCallNoResponseStatuses(status)}
-                                    />
-                                }
-                                label={status}
-                            />
-                        ))}
-                    </FormGroup>
+                {props.selectedStatus === noResponseStatus && (
+                    <FormElementWithSpacing>
+                        <CheckboxGroupInput
+                            groupLabel="Did you send any of the following?"
+                            labelsAndKeys={noResponseFollowUp.map((followUp) => [
+                                followUp,
+                                followUp,
+                            ])}
+                            checkedKeys={callNoResponseFollowUp}
+                            onChange={(event) => toggleCallNoResponseFollowUp(event.target.name)}
+                        />
+                    </FormElementWithSpacing>
                 )}
                 <Centerer>
                     <Button
                         type="button"
                         variant="contained"
-                        onClick={() => props.onSubmit(date, callNoResponseStatuses)}
+                        onClick={() => props.onSubmit(date, callNoResponseFollowUp)}
                     >
                         Submit
                     </Button>

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -11,6 +11,10 @@ import { Centerer } from "@/components/Modal/ModalFormStyles";
 import { FormElementWithSpacing } from "@/components/Form/formStyling";
 import CheckboxGroupInput from "@/components/DataInput/CheckboxGroupInput";
 
+const NO_RESPONSE_FOLLOW_UP = ["Voicemail", "Text", "Email"];
+const NO_RESPONSE_STATUS = "Called and No Response";
+const MAX_PARCELS_TO_SHOW = 5;
+
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
     onSubmit: (date: Dayjs, callNoResponseFollowUp: string[]) => void;
@@ -35,9 +39,6 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [date, setDate] = useState(dayjs(new Date()));
     const [callNoResponseFollowUp, setCallNoResponseFollowUp] = useState<string[]>([]);
 
-    const noResponseStatus = "Called and No Response";
-    const noResponseFollowUp = ["Voicemail", "Text", "Email"];
-
     useEffect(() => {
         setDate(dayjs(new Date()));
     }, [props.isOpen]);
@@ -56,8 +57,6 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                 .set("hour", newDate?.hour() ?? date.hour())
                 .set("minute", newDate?.minute() ?? date.minute())
         );
-
-    const maxParcelsToShow = 5;
 
     useEffect(() => {
         if (props.isOpen) {
@@ -94,13 +93,13 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                 </Centerer>
                 <SelectedParcelsOverview
                     parcels={props.selectedParcels}
-                    maxParcelsToShow={maxParcelsToShow}
+                    maxParcelsToShow={MAX_PARCELS_TO_SHOW}
                 />
-                {props.selectedStatus === noResponseStatus && (
+                {props.selectedStatus === NO_RESPONSE_STATUS && (
                     <FormElementWithSpacing>
                         <CheckboxGroupInput
                             groupLabel="Did you send any of the following?"
-                            labelsAndKeys={noResponseFollowUp.map((followUp) => [
+                            labelsAndKeys={NO_RESPONSE_FOLLOW_UP.map((followUp) => [
                                 followUp,
                                 followUp,
                             ])}

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -8,10 +8,12 @@ import { ParcelsTableRow } from "../parcelsTable/types";
 import SelectedParcelsOverview from "./SelectedParcelsOverview";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 import { Centerer } from "@/components/Modal/ModalFormStyles";
+import { Checkbox, FormControlLabel, FormGroup } from "@mui/material";
 
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
-    onSubmit: (date: Dayjs) => void;
+    onSubmit: (date: Dayjs, callNoResponseStatuses: string[]) => void;
+    selectedStatus?: string | null;
     errorText: string | null;
 }
 
@@ -52,6 +54,18 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
 
     const maxParcelsToShow = 5;
 
+    const [callNoResponseStatuses, setCallNoResponseStatuses] = useState<string[]>([]);
+
+    const toggleCallNoResponseStatuses = (newNoResponseStatus: string): void => {
+        setCallNoResponseStatuses((prevCallNoResponseStatuses) =>
+            prevCallNoResponseStatuses.includes(newNoResponseStatus)
+                ? prevCallNoResponseStatuses.filter(
+                      (prevStatus) => prevStatus !== newNoResponseStatus
+                  )
+                : [...prevCallNoResponseStatuses, newNoResponseStatus]
+        );
+    };
+
     return (
         <Modal {...props}>
             <ModalInner>
@@ -73,8 +87,43 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                     parcels={props.selectedParcels}
                     maxParcelsToShow={maxParcelsToShow}
                 />
+                {props.selectedStatus === "Called and No Response" && (
+                    <FormGroup>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={callNoResponseStatuses.includes("Voicemail")}
+                                    onChange={() => toggleCallNoResponseStatuses("Voicemail")}
+                                />
+                            }
+                            label="Voicemail"
+                        />
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={callNoResponseStatuses.includes("Text")}
+                                    onChange={() => toggleCallNoResponseStatuses("Text")}
+                                />
+                            }
+                            label="Text"
+                        />
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={callNoResponseStatuses.includes("Email")}
+                                    onChange={() => toggleCallNoResponseStatuses("Email")}
+                                />
+                            }
+                            label="Email"
+                        />
+                    </FormGroup>
+                )}
                 <Centerer>
-                    <Button type="button" variant="contained" onClick={() => props.onSubmit(date)}>
+                    <Button
+                        type="button"
+                        variant="contained"
+                        onClick={() => props.onSubmit(date, callNoResponseStatuses)}
+                    >
                         Submit
                     </Button>
                 </Centerer>


### PR DESCRIPTION
## Jira ticket
https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?selectedIssue=VFB-435

## What's changed
- In `StatusesModal.tsx`
  - Add selected statuses to props
  - If selected status is `Call and No Response`, a checkbox will appear
  - Add local state for selected tick boxes
  - Pass selected options to `onSubmit` method
 
- In `Statuses.tsx`
  - Modify `submitStatus` to handle selected statuses
  - Append selected statuses to the shown string as in the example format

## Screenshots
| Before     | After      |
|------------|------------|
| <img width="876" height="289" alt="image" src="https://github.com/user-attachments/assets/c41ae875-1104-412a-b88b-5fb3d0bed480" /> | <img width="874" height="482" alt="image" src="https://github.com/user-attachments/assets/454a6459-5b38-4152-a817-cca056563ccb" /> |
| <img width="801" height="116" alt="image" src="https://github.com/user-attachments/assets/c6517de9-38a9-423b-b4f9-ea71cf5ef075" /> | <img width="804" height="127" alt="image" src="https://github.com/user-attachments/assets/fd2b31db-13c0-45a8-8483-252fda855b14" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
