### PR TITLE
Vfb 428 fix refresh when parcel status change

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -55,7 +55,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     };
 
     const postSetStatusCallback = (): void => {
-        refreshDetails();
+        // refreshDetails();
     };
 
     return (
@@ -123,9 +123,10 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                                 parcelId={selectedParcelId}
                                 setParcelClientId={setParcelClientId}
                                 setIsClientActive={setIsClientActive}
-                                refreshCallback={(refresh) => {
-                                    refreshParcelDetailsRef.current = refresh;
-                                }}
+                                refreshCallback={() => console.log("refresh")}
+                                // refreshCallback={(refresh) => {
+                                //     refreshParcelDetailsRef.current = refresh;
+                                // }}
                             />
                         </Suspense>
                     </ContentDiv>

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -55,7 +55,7 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
     };
 
     const postSetStatusCallback = (): void => {
-        // refreshDetails();
+        refreshDetails();
     };
 
     return (
@@ -123,10 +123,9 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                                 parcelId={selectedParcelId}
                                 setParcelClientId={setParcelClientId}
                                 setIsClientActive={setIsClientActive}
-                                refreshCallback={() => console.log("refresh")}
-                                // refreshCallback={(refresh) => {
-                                //     refreshParcelDetailsRef.current = refresh;
-                                // }}
+                                refreshCallback={(refresh) => {
+                                    refreshParcelDetailsRef.current = refresh;
+                                }}
                             />
                         </Suspense>
                     </ContentDiv>

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -25,7 +25,6 @@ import { getParcelsTableDataAndAllIds } from "@/app/parcels/parcelsTable/fetchPa
 import supabase from "@/supabaseClient";
 import { searchForBreakPoints } from "@/app/parcels/parcelsTable/conditionalStyling";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
-import { event } from "cypress/types/jquery";
 
 interface ParcelsTableProps {
     checkedParcelIds: string[];
@@ -132,7 +131,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             fetchParcelsTimer.current = null;
         }
         if (table_name !== "events") {
-
             setIsLoading(true);
         }
         fetchParcelsTimer.current = setTimeout(() => {
@@ -143,30 +141,27 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     useEffect(() => {
         const subscriptionChannel = supabase
             .channel("parcels-table-changes")
-            .on(
-                "postgres_changes",
-                { event: "*", schema: "public", table: "parcels" },
-                () => loadCountAndDataWithTimer("parcels")
+
+            .on("postgres_changes", { event: "*", schema: "public", table: "parcels" }, () =>
+                loadCountAndDataWithTimer("parcels")
             )
-            .on(
-                "postgres_changes",
-                { event: "*", schema: "public", table: "events" },
-                () => loadCountAndDataWithTimer("events")
+
+            .on("postgres_changes", { event: "*", schema: "public", table: "events" }, () =>
+                loadCountAndDataWithTimer("events")
             )
-            .on(
-                "postgres_changes",
-                { event: "*", schema: "public", table: "families" },
-                () => loadCountAndDataWithTimer("families")
+
+            .on("postgres_changes", { event: "*", schema: "public", table: "families" }, () =>
+                loadCountAndDataWithTimer("families")
             )
+
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "collection_centres" },
                 () => loadCountAndDataWithTimer("collection_centres")
             )
-            .on(
-                "postgres_changes",
-                { event: "*", schema: "public", table: "clients" },
-                () => loadCountAndDataWithTimer("clients")
+
+            .on("postgres_changes", { event: "*", schema: "public", table: "clients" }, () =>
+                loadCountAndDataWithTimer("clients")
             )
             .subscribe((status, err) => {
                 if (subscriptionStatusRequiresErrorMessage(status, err, "parcels and related")) {

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -25,6 +25,7 @@ import { getParcelsTableDataAndAllIds } from "@/app/parcels/parcelsTable/fetchPa
 import supabase from "@/supabaseClient";
 import { searchForBreakPoints } from "@/app/parcels/parcelsTable/conditionalStyling";
 import { subscriptionStatusRequiresErrorMessage } from "@/common/subscriptionStatusRequiresErrorMessage";
+import { event } from "cypress/types/jquery";
 
 interface ParcelsTableProps {
     checkedParcelIds: string[];
@@ -125,13 +126,15 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         }
     }, [areFiltersLoadingForFirstTime, fetchAndDisplayParcelsData]);
 
-    const loadCountAndDataWithTimer = (): void => {
+    const loadCountAndDataWithTimer = (table_name: string): void => {
         if (fetchParcelsTimer.current) {
             clearTimeout(fetchParcelsTimer.current);
             fetchParcelsTimer.current = null;
         }
+        if (table_name !== "events") {
 
-        setIsLoading(true);
+            setIsLoading(true);
+        }
         fetchParcelsTimer.current = setTimeout(() => {
             void fetchAndDisplayParcelsData();
         }, 500);
@@ -143,27 +146,27 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "parcels" },
-                loadCountAndDataWithTimer
+                () => loadCountAndDataWithTimer("parcels")
             )
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "events" },
-                loadCountAndDataWithTimer
+                () => loadCountAndDataWithTimer("events")
             )
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "families" },
-                loadCountAndDataWithTimer
+                () => loadCountAndDataWithTimer("families")
             )
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "collection_centres" },
-                loadCountAndDataWithTimer
+                () => loadCountAndDataWithTimer("collection_centres")
             )
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "clients" },
-                loadCountAndDataWithTimer
+                () => loadCountAndDataWithTimer("clients")
             )
             .subscribe((status, err) => {
                 if (subscriptionStatusRequiresErrorMessage(status, err, "parcels and related")) {

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -125,7 +125,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         }
     }, [areFiltersLoadingForFirstTime, fetchAndDisplayParcelsData]);
 
-    const loadCountAndDataWithTimer = (table_name: string): void => {
+    const loadCountAndDataWithTimer = (table_name?: string): void => {
         if (fetchParcelsTimer.current) {
             clearTimeout(fetchParcelsTimer.current);
             fetchParcelsTimer.current = null;
@@ -142,26 +142,32 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         const subscriptionChannel = supabase
             .channel("parcels-table-changes")
 
-            .on("postgres_changes", { event: "*", schema: "public", table: "parcels" }, () =>
-                loadCountAndDataWithTimer("parcels")
+            .on(
+                "postgres_changes",
+                { event: "*", schema: "public", table: "parcels" },
+                () => loadCountAndDataWithTimer
             )
 
             .on("postgres_changes", { event: "*", schema: "public", table: "events" }, () =>
                 loadCountAndDataWithTimer("events")
             )
 
-            .on("postgres_changes", { event: "*", schema: "public", table: "families" }, () =>
-                loadCountAndDataWithTimer("families")
+            .on(
+                "postgres_changes",
+                { event: "*", schema: "public", table: "families" },
+                () => loadCountAndDataWithTimer
             )
 
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "collection_centres" },
-                () => loadCountAndDataWithTimer("collection_centres")
+                () => loadCountAndDataWithTimer
             )
 
-            .on("postgres_changes", { event: "*", schema: "public", table: "clients" }, () =>
-                loadCountAndDataWithTimer("clients")
+            .on(
+                "postgres_changes",
+                { event: "*", schema: "public", table: "clients" },
+                () => loadCountAndDataWithTimer
             )
             .subscribe((status, err) => {
                 if (subscriptionStatusRequiresErrorMessage(status, err, "parcels and related")) {

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -141,29 +141,24 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     useEffect(() => {
         const subscriptionChannel = supabase
             .channel("parcels-table-changes")
-
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "parcels" },
                 () => loadCountAndDataWithTimer
             )
-
             .on("postgres_changes", { event: "*", schema: "public", table: "events" }, () =>
                 loadCountAndDataWithTimer("events")
             )
-
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "families" },
                 () => loadCountAndDataWithTimer
             )
-
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "collection_centres" },
                 () => loadCountAndDataWithTimer
             )
-
             .on(
                 "postgres_changes",
                 { event: "*", schema: "public", table: "clients" },


### PR DESCRIPTION
Link to [Jira]( https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?assignee=712020%3A940da565-b936-4c6a-b510-6437c82dc52d&selectedIssue=VFB-428 )
## What's changed

- Removed the loading animation, so now the table doesn't move up when modifying the parcel's status.
- When a table is modified, now the name of it is checked before the loading animation appears. (If the table was events, then the loading animation doesn't appear).

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <video src="https://github.com/user-attachments/assets/be3187cb-bf61-43b1-a0c1-01a54b6b5070">  | <video src="https://github.com/user-attachments/assets/002018f0-e9a0-493b-a4ed-0f9414e82f1a"> |


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`