### PR TITLE
VFB-446: Conditional Styling Override v2

### DIFF
--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -221,7 +221,6 @@ const ClientsPage: React.FC = () => {
                             isLoading={isLoading}
                             pointerOnHover={true}
                             columnDisplayFunctions={{ addressPostcode: formatNullPostcode }}
-                            reduceRowHeight={true}
                         />
                     </TableSurface>
 

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -259,7 +259,13 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                 }}
                 editableConfig={{ editable: false }}
                 pointerOnHover={true}
-                reduceRowHeight={true}
+                customStyles={{
+                    rows: {
+                        style: {
+                            height: "48px",
+                        },
+                    },
+                }}
             />
         </TableSurface>
     );

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -442,8 +442,9 @@ const Table = <
         },
         {
             when: (row: Row<Data>) =>
-                checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
+              checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
             style: {
+                ...(reduceRowHeight === true && { height: "48px" }),
                 backgroundColor: `${theme.primary.background[1]} !important`,
             },
         },

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -442,7 +442,7 @@ const Table = <
         },
         {
             when: (row: Row<Data>) =>
-              checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
+                checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
             style: {
                 ...(reduceRowHeight === true && { height: "48px" }),
                 backgroundColor: `${theme.primary.background[1]} !important`,

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -15,7 +15,7 @@ import {
 import { StyledIcon, StyledIconButton } from "../Icons/IconButton";
 import { Checkbox, CircularProgress, NoSsr } from "@mui/material";
 import React, { useState } from "react";
-import DataTable, { TableColumn } from "react-data-table-component";
+import DataTable, { TableColumn, TableStyles } from "react-data-table-component";
 import styled, { useTheme } from "styled-components";
 import { Primitive, SortOrder } from "react-data-table-component/dist/DataTable/types";
 import { Centerer } from "../Modal/ModalFormStyles";
@@ -154,6 +154,7 @@ export type BreakPointConfig = {
     breakPoints: number[];
     dividingLineStyle: keyof DividingLineStyleOptions;
 };
+
 interface Props<Data, DbData extends Record<string, unknown>, PaginationType, FilterState> {
     dataPortion: Data[];
     headerKeysAndLabels: TableHeaders<Data>;
@@ -180,8 +181,9 @@ interface Props<Data, DbData extends Record<string, unknown>, PaginationType, Fi
     editableConfig: EditableConfig<Data>;
     onRowClick?: OnRowClickFunction<Data>;
     pointerOnHover?: boolean;
-    reduceRowHeight?: boolean;
+    customStyles?: TableStyles;
 }
+
 interface CellProps<Data> {
     row: Row<Data>;
     columnDisplayFunctions: ColumnDisplayFunctions<Data>;
@@ -240,7 +242,7 @@ const Table = <
     paginationConfig,
     editableConfig,
     pointerOnHover,
-    reduceRowHeight,
+    customStyles,
 }: Props<Data, DbData, PaginationType, FilterState>): React.ReactElement => {
     const [shownHeaderKeys, setShownHeaderKeys] = useState(
         defaultShownHeaders ?? headerKeysAndLabels.map(([key]) => key)
@@ -433,18 +435,9 @@ const Table = <
 
     const conditionalRowStyles = [
         {
-            when: () => reduceRowHeight === true,
-            style: {
-                // The default DataTable class has a predefined min-height of 48px for the row-element
-                // for this reason, any value < 48px would not decrease the height.
-                height: "48px",
-            },
-        },
-        {
             when: (row: Row<Data>) =>
                 checkboxConfig.displayed && checkboxConfig.isRowChecked(row.data),
             style: {
-                ...(reduceRowHeight === true && { height: "48px" }),
                 backgroundColor: `${theme.primary.background[1]} !important`,
             },
         },
@@ -499,6 +492,7 @@ const Table = <
                 >
                     <NoSsr>
                         <DataTable
+                            customStyles={customStyles}
                             columns={columns}
                             data={rows}
                             keyField="rowId"


### PR DESCRIPTION
## What's changed
[VFB-446](https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?selectedIssue=VFB-446): The conditional styling properties overrode one another because of a priority issue. Now, the highlight on selection additionally checks for the height reduction property.

This is an additional fix to the bug found in [VFB-440](https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?selectedIssue=VFB-440) (old PR link - [here](https://github.com/LambethFoodbank/foodbankapp/pull/751)).

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1846" height="415" alt="image" src="https://github.com/user-attachments/assets/d8454b73-c307-4629-99c3-e0e05c5b73ac" />| <img width="1847" height="446" alt="image" src="https://github.com/user-attachments/assets/32b7269d-ab75-4642-8345-7caa5180c086" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
