### PR TITLE
VFB-437 Close pop-up after action completes

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
@@ -109,7 +109,7 @@ const DateChangeModal: React.FC<ActionModalProps> = (props) => {
             // Auto-close the modal after 3 seconds
             setTimeout(() => {
                 props.onClose();
-            }, 3000); // 3-second delay
+            }, 3000);
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DateChangeModal.tsx
@@ -105,6 +105,11 @@ const DateChangeModal: React.FC<ActionModalProps> = (props) => {
         } else {
             setSuccessMessage(`Packing Date Changed to ${newPackingDate}`);
             props.postSuccessCallback();
+
+            // Auto-close the modal after 3 seconds
+            setTimeout(() => {
+                props.onClose();
+            }, 3000); // 3-second delay
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
@@ -69,6 +69,11 @@ const DayOverviewModal: React.FC<ActionModalProps> = (props) => {
             content: { parcelIds: props.selectedParcels.map((parcel) => parcel.parcelId) },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onPdfCreationFailed = (pdfError: DayOverviewPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DayOverviewModal.tsx
@@ -70,10 +70,10 @@ const DayOverviewModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onPdfCreationFailed = (pdfError: DayOverviewPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
@@ -85,8 +85,7 @@ const DeleteParcelModal: React.FC<ActionModalProps> = (props) => {
         if (error) {
             setErrorMessage(getStatusErrorMessageWithLogId(error));
         } else {
-            const message = `${numberOfParcelsToDelete > 1 ? "Parcels" : "Parcel"} Deleted`;
-            setSuccessMessage(message);
+            setSuccessMessage(`${numberOfParcelsToDelete > 1 ? "Parcels" : "Parcel"} Deleted`);
             props.postSuccessCallback();
 
             // Auto-close the modal after 3 seconds

--- a/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DeleteParcelModal.tsx
@@ -85,8 +85,14 @@ const DeleteParcelModal: React.FC<ActionModalProps> = (props) => {
         if (error) {
             setErrorMessage(getStatusErrorMessageWithLogId(error));
         } else {
-            setSuccessMessage(`${numberOfParcelsToDelete > 1 ? "Parcels" : "Parcel"} Deleted`);
+            const message = `${numberOfParcelsToDelete > 1 ? "Parcels" : "Parcel"} Deleted`;
+            setSuccessMessage(message);
             props.postSuccessCallback();
+
+            // Auto-close the modal after 3 seconds
+            setTimeout(() => {
+                onClose();
+            }, 3000);
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -191,10 +191,10 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onPdfCreationFailed = (pdfError: DriverOverviewError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -190,6 +190,11 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
             },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onPdfCreationFailed = (pdfError: DriverOverviewError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -81,7 +81,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     return (

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -75,6 +75,15 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
 
     const mapsLinkForSelectedParcels = `https://www.google.com/maps/dir/${uniquePostcodes.join("/")}//`;
 
+    const postSuccessCallback = (): void => {
+        props.postSuccessCallback();
+
+        // Auto-close the modal after 3 seconds
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
+    };
+
     return (
         <GeneralActionModal
             {...props}
@@ -89,7 +98,7 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
                     setActionCompleted={setActionCompleted}
                     mapsLinkForSelectedParcels={mapsLinkForSelectedParcels}
                     setSuccessMessage={setSuccessMessage}
-                    postSuccessCallback={props.postSuccessCallback}
+                    postSuccessCallback={postSuccessCallback}
                 />
             )}
         </GeneralActionModal>

--- a/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
@@ -89,10 +89,10 @@ const PendingMoreInfoReportModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onFileCreationFailed = (csvError: FetchPendingMoreInfoReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/PendingMoreInfoReportModal.tsx
@@ -88,6 +88,11 @@ const PendingMoreInfoReportModal: React.FC<ActionModalProps> = (props) => {
             },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onFileCreationFailed = (csvError: FetchPendingMoreInfoReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
@@ -56,6 +56,11 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
             content: { parcelIds: props.selectedParcels.map((parcel) => parcel.parcelId) },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onFileCreationFailed = (csvError: FetchSelectedParcelsReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
@@ -57,10 +57,10 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onFileCreationFailed = (csvError: FetchSelectedParcelsReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -161,6 +161,11 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
             },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onPdfCreationFailed = (pdfError: ShippingLabelError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -162,10 +162,10 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onPdfCreationFailed = (pdfError: ShippingLabelError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -113,7 +113,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
         // Delay closing the modal to allow user to handle file explorer dialog
         setTimeout(() => {
             props.onClose();
-        }, 4000); // 4 second delay
+        }, 3000); // 3-second delay
     };
 
     const onPdfCreationFailed = (pdfError: ShoppingListPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -109,6 +109,11 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
             content: { parcelIds: parcelIds },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 4000); // 4 second delay
     };
 
     const onPdfCreationFailed = (pdfError: ShoppingListPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -110,10 +110,10 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onPdfCreationFailed = (pdfError: ShoppingListPdfError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
@@ -88,6 +88,11 @@ const SignPostingReportModal: React.FC<ActionModalProps> = (props) => {
             },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onFileCreationFailed = (csvError: FetchSignpostingReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SignpostingReportModal.tsx
@@ -89,10 +89,10 @@ const SignPostingReportModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onFileCreationFailed = (csvError: FetchSignpostingReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
@@ -124,6 +124,11 @@ const SlotChangeModal: React.FC<ActionModalProps> = (props) => {
         } else {
             setSuccessMessage(`Packing Slot Changed to ${newPackingSlotText}`);
             props.postSuccessCallback();
+
+            // Auto-close the modal after 3 seconds
+            setTimeout(() => {
+                props.onClose();
+            }, 3000); // 3-second delay
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
@@ -128,7 +128,7 @@ const SlotChangeModal: React.FC<ActionModalProps> = (props) => {
             // Auto-close the modal after 3 seconds
             setTimeout(() => {
                 props.onClose();
-            }, 3000); // 3-second delay
+            }, 3000);
         }
         setActionCompleted(true);
     };

--- a/src/app/parcels/ActionBar/ActionModals/VoucherReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/VoucherReportModal.tsx
@@ -89,10 +89,10 @@ const MissingVoucherNumberReportModal: React.FC<ActionModalProps> = (props) => {
         });
         props.postSuccessCallback();
 
-        // Delay closing the modal to allow user to handle file explorer dialog
+        // Auto-close the modal after 3 seconds
         setTimeout(() => {
             props.onClose();
-        }, 3000); // 3-second delay
+        }, 3000);
     };
 
     const onFileCreationFailed = (csvError: FetchMissingVoucherNumberReportError): void => {

--- a/src/app/parcels/ActionBar/ActionModals/VoucherReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/VoucherReportModal.tsx
@@ -88,6 +88,11 @@ const MissingVoucherNumberReportModal: React.FC<ActionModalProps> = (props) => {
             },
         });
         props.postSuccessCallback();
+
+        // Delay closing the modal to allow user to handle file explorer dialog
+        setTimeout(() => {
+            props.onClose();
+        }, 3000); // 3-second delay
     };
 
     const onFileCreationFailed = (csvError: FetchMissingVoucherNumberReportError): void => {


### PR DESCRIPTION
## What's changed
- Added auto-close functionality to action modals after successful completion

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1835" height="927" alt="image" src="https://github.com/user-attachments/assets/f54cbde1-4dbd-49e5-b2a9-10e9c39e60e5" /> | <video src="https://github.com/user-attachments/assets/56f5629c-4f9b-4dcc-86e3-092e6c5d6325">  |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
