### PR TITLE
VFB-401: Ensure correct behavior for parcels of deleted clients

### DIFF
--- a/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
@@ -41,21 +41,18 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
     const [actionShown, setActionShown] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
-    const [allClientsDeleted, setAllClientsDeleted] = useState(false);
 
     useEffect(() => {
         const allDeleted = props.selectedParcels.every((parcel) => !parcel.clientIsActive);
-        if (allDeleted && props.selectedParcels.length > 0) {
+        if (allDeleted) {
             setErrorMessage("All selected parcels belong to deleted clients.");
             setActionShown(false);
-            setAllClientsDeleted(true);
         }
     }, [props.selectedParcels]);
 
     const onClose = (): void => {
         props.onClose();
         setErrorMessage(null);
-        setAllClientsDeleted(false);
     };
 
     const onFileCreationCompleted = async (): Promise<void> => {
@@ -87,7 +84,7 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
             errorMessage={errorMessage}
             successMessage={successMessage}
         >
-            {actionShown && !allClientsDeleted && (
+            {actionShown && (
                 <SelectedParcelsReportModalContent
                     selectedParcels={props.selectedParcels}
                     maxParcelsToShow={maxParcelsToShow}

--- a/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SelectedParcelsReportModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import GeneralActionModal, { ActionModalProps, maxParcelsToShow } from "./GeneralActionModal";
 import { sendAuditLog } from "@/server/auditLog";
 import SelectedParcelsOverview from "../SelectedParcelsOverview";
@@ -41,10 +41,21 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
     const [actionShown, setActionShown] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [allClientsDeleted, setAllClientsDeleted] = useState(false);
+
+    useEffect(() => {
+        const allDeleted = props.selectedParcels.every((parcel) => !parcel.clientIsActive);
+        if (allDeleted && props.selectedParcels.length > 0) {
+            setErrorMessage("All selected parcels belong to deleted clients.");
+            setActionShown(false);
+            setAllClientsDeleted(true);
+        }
+    }, [props.selectedParcels]);
 
     const onClose = (): void => {
         props.onClose();
         setErrorMessage(null);
+        setAllClientsDeleted(false);
     };
 
     const onFileCreationCompleted = async (): Promise<void> => {
@@ -76,7 +87,7 @@ const SelectedParcelsReportModal: React.FC<ActionModalProps> = (props) => {
             errorMessage={errorMessage}
             successMessage={successMessage}
         >
-            {actionShown && (
+            {actionShown && !allClientsDeleted && (
                 <SelectedParcelsReportModalContent
                     selectedParcels={props.selectedParcels}
                     maxParcelsToShow={maxParcelsToShow}


### PR DESCRIPTION
## What's changed
- added validation to detect if all selected parcels belong to deleted clients
- display a notification message when such cases are detected

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1875" height="722" alt="image" src="https://github.com/user-attachments/assets/1e8f6575-de0a-4cfa-a06b-589e494f9c24" /> | <img width="1859" height="718" alt="image" src="https://github.com/user-attachments/assets/c291c131-2c7e-44b3-b10d-976871ce0279" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`