### PR TITLE
Vfb 463 remove notes column parcels

### DIFF
--- a/src/app/parcels/parcelsTable/headers.ts
+++ b/src/app/parcels/parcelsTable/headers.ts
@@ -13,7 +13,6 @@ export const parcelTableHeaderKeysAndLabels: TableHeaders<ParcelsTableRow> = [
     ["packingSlot", "Packing Slot"],
     ["lastStatus", "Last Status"],
     ["createdAt", "Created At"],
-    ["notes", "Notes"],
 ];
 
 export const parcelTableDefaultShownHeaders: (keyof ParcelsTableRow)[] = [
@@ -38,5 +37,4 @@ export const parcelTableToggleableHeaders: (keyof ParcelsTableRow)[] = [
     "packingSlot",
     "lastStatus",
     "createdAt",
-    "notes",
 ];


### PR DESCRIPTION
### Jira Ticket
- [VFB-463: Remove the Notes column from the Parcels Table](https://softwiretech.atlassian.net/browse/VFB-463)

## What's changed
- Removed the "Notes" column from the toggleable headers in the `Parcels Table`

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="225" height="535" alt="image" src="https://github.com/user-attachments/assets/ec6f7335-107a-481d-ac25-44f9f2665ed2" /> | <img width="305" height="585" alt="image" src="https://github.com/user-attachments/assets/e5be3186-3562-4cb6-8e94-a55e9da8f866" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`