### PR TITLE
VFB-446: Update style for checkbox icon

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -259,13 +259,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                 }}
                 editableConfig={{ editable: false }}
                 pointerOnHover={true}
-                customStyles={{
-                    rows: {
-                        style: {
-                            height: "48px",
-                        },
-                    },
-                }}
             />
         </TableSurface>
     );

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -425,7 +425,7 @@ const Table = <
                     checked={checkboxConfig.isRowChecked(row.data)}
                     onChange={() => checkboxConfig.onCheckboxClicked(row.data)}
                     sx={{
-                        "&.MuiButtonBase-root": { padding: "3px" },
+                        "&.MuiButtonBase-root": { position: "absolute" },
                     }}
                 />
             ),

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -426,7 +426,6 @@ const Table = <
                     onChange={() => checkboxConfig.onCheckboxClicked(row.data)}
                     sx={{
                         "&.MuiButtonBase-root": { padding: "3px" },
-                        "&.MuiSvgIcon-root": { fontSize: "24px" },
                     }}
                 />
             ),

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -424,6 +424,10 @@ const Table = <
                     inputProps={{ "aria-label": `Select row ${row.rowId}` }}
                     checked={checkboxConfig.isRowChecked(row.data)}
                     onChange={() => checkboxConfig.onCheckboxClicked(row.data)}
+                    sx={{
+                        "&.MuiButtonBase-root": { padding: "3px" },
+                        "&.MuiSvgIcon-root": { fontSize: "24px" },
+                    }}
                 />
             ),
             width: "47px",


### PR DESCRIPTION
- if we set the height then the row won't grow to fit the text
- updated the checkbox to reduce the padding so that the rows can be 48px when the cell content fits on one line