### PR TITLE
VFB-430: fixed label getting crossed by the input-box in certain form…

### DIFF
--- a/src/components/DataInput/DropDownSelect.tsx
+++ b/src/components/DataInput/DropDownSelect.tsx
@@ -48,6 +48,7 @@ const GenericSelect = <ValueType,>(props: GenericProps<ValueType>): React.ReactE
                 value={props.value ?? undefined}
                 onChange={props.onChange}
                 labelId={props.selectLabelId}
+                label={props.listTitle}
                 inputRef={dropdownInputFocusRef}
                 error={props.error}
             >


### PR DESCRIPTION
## What's changed
The labels for dropdown input boxes in `Clients` and `Parcels `Forms no longer have the label text crossed out by the outline of the input box.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="724" height="256" alt="Screenshot 2025-08-06 151553" src="https://github.com/user-attachments/assets/022235d2-f839-40ae-80d3-ee5065d69d56" /> | <img width="796" height="253" alt="Screenshot 2025-08-06 151043" src="https://github.com/user-attachments/assets/f3398ae4-f348-41f4-82a7-9f1004074593" /> |
| <img width="742" height="244" alt="Screenshot 2025-08-06 151605" src="https://github.com/user-attachments/assets/591cd6ec-e760-4212-a3a5-34170270a90a" /> | <img width="770" height="245" alt="Screenshot 2025-08-06 151056" src="https://github.com/user-attachments/assets/d53f276e-6558-4d34-96f9-88070ac01160" /> |
| <img width="753" height="721" alt="Screenshot 2025-08-06 151616" src="https://github.com/user-attachments/assets/2f124a08-7da4-4646-b112-a2a7b380eab5" /> | <img width="738" height="714" alt="Screenshot 2025-08-06 151107" src="https://github.com/user-attachments/assets/cf6dbfda-1a76-4d45-b052-8c9024462d06" /> |
| <img width="1479" height="628" alt="Screenshot 2025-08-06 151539" src="https://github.com/user-attachments/assets/aeae0ccb-e8f0-4cdf-a501-513531935ab0" /> | <img width="1496" height="630" alt="Screenshot 2025-08-06 151130" src="https://github.com/user-attachments/assets/dc2f2aca-35f2-4a92-89f5-3a973c03f1a3" /> |


## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
