### PR TITLE
VFB-396: Add Referral Columns To Parcels Page

### DIFF
--- a/src/app/parcels/parcelsTable/headers.ts
+++ b/src/app/parcels/parcelsTable/headers.ts
@@ -9,6 +9,10 @@ export const parcelTableHeaderKeysAndLabels: TableHeaders<ParcelsTableRow> = [
     ["phoneNumber", "Phone"],
     ["email", "Email"],
     ["voucherNumber", "Voucher"],
+    ["referralAgency", "Referral Agency"],
+    ["referrerName", "Referrer Name"],
+    ["referrerEmail", "Referrer Email"],
+    ["referrerPhone", "Referrer Phone"],
     ["deliveryCollection", "Method"],
     ["packingDate", "Packing Date"],
     ["packingSlot", "Packing Slot"],
@@ -27,13 +31,14 @@ export const parcelTableDefaultShownHeaders: (keyof ParcelsTableRow)[] = [
     "lastStatus",
 ];
 
-export const parcelTableToggleableHeaders: (keyof ParcelsTableRow)[] = [
+export const parcelTableToggleableHeaders: (keyof ParcelsTableRow | any)[] = [
     "fullName",
     "familyCategory",
     "addressPostcode",
     "phoneNumber",
     "email",
     "voucherNumber",
+    "Referral Details",
     "deliveryCollection",
     "packingDate",
     "packingSlot",

--- a/src/app/parcels/parcelsTable/headers.ts
+++ b/src/app/parcels/parcelsTable/headers.ts
@@ -31,7 +31,7 @@ export const parcelTableDefaultShownHeaders: (keyof ParcelsTableRow)[] = [
     "lastStatus",
 ];
 
-export const parcelTableToggleableHeaders: (keyof ParcelsTableRow | any)[] = [
+export const parcelTableToggleableHeaders: (keyof ParcelsTableRow | "Referral Details")[] = [
     "fullName",
     "familyCategory",
     "addressPostcode",

--- a/src/components/Tables/ColumnTogglePopup.tsx
+++ b/src/components/Tables/ColumnTogglePopup.tsx
@@ -31,13 +31,13 @@ const ColumnTogglePopup = <Data,>({
         "referrerName",
         "referrerEmail",
         "referrerPhone",
-    ] as const;
+    ];
 
     const onChangeCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
         const checkboxKey = event.target.name;
         const isReferralDetails = checkboxKey === "Referral Details";
         const keysToUpdate = isReferralDetails
-            ? (referralDetails as unknown as (keyof Data)[])
+            ? (referralDetails as (keyof Data)[])
             : [checkboxKey as keyof Data];
 
         const newKeys = event.target.checked
@@ -53,7 +53,7 @@ const ColumnTogglePopup = <Data,>({
                 labelsAndKeys={(toggleableHeaders ?? []).map((key) => {
                     const headerLabel =
                         headers.find(([headerKey]) => headerKey === key)?.[1] ?? key.toString();
-                    return [headerLabel, key.toString()];
+                    return [headerLabel, key as string];
                 })}
                 checkedKeys={shownHeaderKeys.map((key) => key as string)}
                 onChange={onChangeCheckbox}

--- a/src/components/Tables/ColumnTogglePopup.tsx
+++ b/src/components/Tables/ColumnTogglePopup.tsx
@@ -6,12 +6,10 @@ import CheckboxGroupPopup from "../DataInput/CheckboxGroupPopup";
 import { ViewColumnOutlined } from "@mui/icons-material";
 import styled from "styled-components";
 
-type ToggleableKey = "Referral Details" | "referralAgency" | "referrerName" | "referrerEmail" | "referrerPhone";
-
 interface ColumnTogglePopupProps<Data> {
-    toggleableHeaders?: readonly (keyof Data)[];
+    toggleableHeaders?: readonly (keyof Data | string)[];
     shownHeaderKeys: readonly (keyof Data)[];
-    setShownHeaderKeys: (headers: (keyof Data | string)[]) => void;
+    setShownHeaderKeys: (headers: (keyof Data)[]) => void;
     headers: TableHeaders<Data>;
 }
 
@@ -36,14 +34,17 @@ const ColumnTogglePopup = <Data,>({
     ] as const;
 
     const onChangeCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
-        const checkboxKey = event.target.name as keyof Data;
+        const checkboxKey = event.target.name;
         const isReferralDetails = checkboxKey === "Referral Details";
-        const keysToUpdate = isReferralDetails ? referralDetails : [checkboxKey];
+        const keysToUpdate = isReferralDetails
+            ? (referralDetails as unknown as (keyof Data)[])
+            : [checkboxKey as keyof Data];
 
         const newKeys = event.target.checked
             ? Array.from(new Set([...shownHeaderKeys, ...keysToUpdate]))
-            : shownHeaderKeys.filter((key) => !keysToUpdate.includes(key));
-        setShownHeaderKeys(newKeys);
+            : shownHeaderKeys.filter((key) => !keysToUpdate.includes(key as keyof Data));
+
+        setShownHeaderKeys(newKeys as (keyof Data)[]);
     };
 
     return (
@@ -52,7 +53,7 @@ const ColumnTogglePopup = <Data,>({
                 labelsAndKeys={(toggleableHeaders ?? []).map((key) => {
                     const headerLabel =
                         headers.find(([headerKey]) => headerKey === key)?.[1] ?? key.toString();
-                    return [headerLabel, key as string];
+                    return [headerLabel, key.toString()];
                 })}
                 checkedKeys={shownHeaderKeys.map((key) => key as string)}
                 onChange={onChangeCheckbox}

--- a/src/components/Tables/ColumnTogglePopup.tsx
+++ b/src/components/Tables/ColumnTogglePopup.tsx
@@ -6,10 +6,12 @@ import CheckboxGroupPopup from "../DataInput/CheckboxGroupPopup";
 import { ViewColumnOutlined } from "@mui/icons-material";
 import styled from "styled-components";
 
+type ToggleableKey = "Referral Details" | "referralAgency" | "referrerName" | "referrerEmail" | "referrerPhone";
+
 interface ColumnTogglePopupProps<Data> {
     toggleableHeaders?: readonly (keyof Data)[];
     shownHeaderKeys: readonly (keyof Data)[];
-    setShownHeaderKeys: (headers: (keyof Data)[]) => void;
+    setShownHeaderKeys: (headers: (keyof Data | string)[]) => void;
     headers: TableHeaders<Data>;
 }
 
@@ -24,13 +26,24 @@ const ColumnTogglePopup = <Data,>({
     setShownHeaderKeys,
     headers,
 }: ColumnTogglePopupProps<Data>): React.ReactElement => {
+    // "Referral Details" is needed to allow toggling functionality
+    const referralDetails = [
+        "Referral Details",
+        "referralAgency",
+        "referrerName",
+        "referrerEmail",
+        "referrerPhone",
+    ] as const;
+
     const onChangeCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
         const checkboxKey = event.target.name as keyof Data;
-        if (event.target.checked) {
-            setShownHeaderKeys([...shownHeaderKeys, checkboxKey]);
-        } else {
-            setShownHeaderKeys(shownHeaderKeys.filter((shownKey) => shownKey !== checkboxKey));
-        }
+        const isReferralDetails = checkboxKey === "Referral Details";
+        const keysToUpdate = isReferralDetails ? referralDetails : [checkboxKey];
+
+        const newKeys = event.target.checked
+            ? Array.from(new Set([...shownHeaderKeys, ...keysToUpdate]))
+            : shownHeaderKeys.filter((key) => !keysToUpdate.includes(key));
+        setShownHeaderKeys(newKeys);
     };
 
     return (

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -175,7 +175,7 @@ interface Props<Data, DbData extends Record<string, unknown>, PaginationType, Fi
     >;
     rowBreakPointConfigs?: BreakPointConfig[];
     defaultShownHeaders?: readonly (keyof Data)[];
-    toggleableHeaders?: readonly (keyof Data)[];
+    toggleableHeaders?: readonly (keyof Data | string)[];
     columnDisplayFunctions?: ColumnDisplayFunctions<Data>;
     columnStyleOptions?: ColumnStyles<Data>;
     editableConfig: EditableConfig<Data>;


### PR DESCRIPTION
### [VFB-396](https://softwiretech.atlassian.net/browse/VFB-396)
## What's changed
- Added referral fields as optional columns in the table
- Introduced "Referral Details" as a group toggle header
- Updated `toggleableHeaders` type from `readonly (keyof Data)[]` to `readonly (keyof Data | string)[]`

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1912" height="824" alt="image" src="https://github.com/user-attachments/assets/6c846206-6093-41e1-a743-203f4641b1f0" />| <img width="1909" height="820" alt="image" src="https://github.com/user-attachments/assets/40037f1a-9c09-430e-ae46-8d21d3ddfabc" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`