### PR TITLE
VFB-235: Modify postcode regex to have a whitespace required

### DIFF
--- a/src/app/clients/form/formSections/AddressCard.tsx
+++ b/src/app/clients/form/formSections/AddressCard.tsx
@@ -13,7 +13,7 @@ import { ClientCardProps } from "../ClientForm";
 import { Checkbox, FormControlLabel } from "@mui/material";
 
 export const postcodeRegex =
-    /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})$/;
+    /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?)))) [0-9][A-Za-z]{2})$/;
 // Regex source: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/488478/Bulk_Data_Transfer_-_additional_validation_valid_from_12_November_2015.pdf
 
 const formatPostcode = (value: string): string => {

--- a/src/app/clients/form/formSections/AddressCard.tsx
+++ b/src/app/clients/form/formSections/AddressCard.tsx
@@ -15,7 +15,7 @@ import { Checkbox, FormControlLabel } from "@mui/material";
 export const postcodeRegex =
     /^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?)))) [0-9][A-Za-z]{2})$/;
 // Regex source: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/488478/Bulk_Data_Transfer_-_additional_validation_valid_from_12_November_2015.pdf
-
+// The regex has been updated to have a mandatory whitespace in between the outward and inward code
 const formatPostcode = (value: string): string => {
     return value.toUpperCase();
 };


### PR DESCRIPTION
## What's changed
In the _Clients Form_, the user is now required to enter a postcode with the right format, with a whitespace in the middle, following the official format.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
|<img width="1445" height="582" alt="Screenshot 2025-08-12 144616" src="https://github.com/user-attachments/assets/56f1c0d9-ac40-4aa9-8fe5-18853881b144" /> |<img width="1474" height="586" alt="Screenshot 2025-08-12 144549" src="https://github.com/user-attachments/assets/35d7b07c-17da-4c0e-8763-099f9afc5786" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
