### PR TITLE
Vfb 395 email filter regex fix

### DIFF
--- a/src/common/databaseFilters.ts
+++ b/src/common/databaseFilters.ts
@@ -5,7 +5,7 @@ import { parcelsPageDeletedClientDisplayName } from "@/app/parcels/parcelsTable/
 
 const textFilterDelimiter = ",";
 const defaultQueryFilterRegex = /[^a-zA-Z0-9 '\-+?]/g;
-const emailQueryFilterRegex = /[^a-zA-Z0-9 '\-@.+?]/g;
+const emailQueryFilterRegex = /[^a-zA-Z0-9+-_~!#$%&`./=^'{}|@]/g;
 
 export const dbFilterWithSubstringQueries = <DbData extends DbClientRow | DbParcelRow>(
     substringToSubqueryMap: (value: string) => string,

--- a/src/common/databaseFilters.ts
+++ b/src/common/databaseFilters.ts
@@ -5,7 +5,7 @@ import { parcelsPageDeletedClientDisplayName } from "@/app/parcels/parcelsTable/
 
 const textFilterDelimiter = ",";
 const defaultQueryFilterRegex = /[^a-zA-Z0-9 '\-+?]/g;
-const emailQueryFilterRegex = /[^a-zA-Z0-9+-_~!#$%&`./=^'{}|@]/g;
+const emailQueryFilterRegex = /[^a-zA-Z0-9+-~!#$&`./=^'{}|@]/g;
 
 export const dbFilterWithSubstringQueries = <DbData extends DbClientRow | DbParcelRow>(
     substringToSubqueryMap: (value: string) => string,

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -20,7 +20,7 @@ export const phoneNumberFormatSymbolsRegex = /[\s-()]/g;
 export const phoneNumberRegex = /^((0|\+44)\d{9,11}|\+(?!44)\d{7,15})?$/;
 
 export const emailFormatSymbolsRegex = /[\s]/g;
-export const emailRegex = /^[a-zA-Z0-9+\-_~!#$%&`./=^'{}|]+@[a-zA-Z0-9+\-_~!#$%&`./=^'{}|]+$/;
+export const emailRegex = /^\S+@\S+$/;
 
 export const formatPhoneNumber = (value: string): string => {
     const numericInput = value.replace(/(\D)/g, "");

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -20,7 +20,7 @@ export const phoneNumberFormatSymbolsRegex = /[\s-()]/g;
 export const phoneNumberRegex = /^((0|\+44)\d{9,11}|\+(?!44)\d{7,15})?$/;
 
 export const emailFormatSymbolsRegex = /[\s]/g;
-export const emailRegex = /^\S+@\S+$/;
+export const emailRegex = /^[^@\s]+@[^@\s]+$/;
 
 export const formatPhoneNumber = (value: string): string => {
     const numericInput = value.replace(/(\D)/g, "");

--- a/src/common/format.ts
+++ b/src/common/format.ts
@@ -20,7 +20,7 @@ export const phoneNumberFormatSymbolsRegex = /[\s-()]/g;
 export const phoneNumberRegex = /^((0|\+44)\d{9,11}|\+(?!44)\d{7,15})?$/;
 
 export const emailFormatSymbolsRegex = /[\s]/g;
-export const emailRegex = /^[^@\s]+@[^@\s]+$/;
+export const emailRegex = /^[a-zA-Z0-9+\-_~!#$%&`./=^'{}|]+@[a-zA-Z0-9+\-_~!#$%&`./=^'{}|]+$/;
 
 export const formatPhoneNumber = (value: string): string => {
     const numericInput = value.replace(/(\D)/g, "");


### PR DESCRIPTION
## What's changed

- Added all characters that can be in an email as searchable, except '_' and '%', which can cause query issues

- Only permitted characters can now be entered in an email address

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
