### PR TITLE
VFB-449 Fix inconsistent behaviour

### DIFF
--- a/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
@@ -86,7 +86,6 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
 
     const dataWithNonNullClients: ParcelForDelivery[] = [];
     for (const parcel of data) {
-        // do we still need to check for null clients?
         if (parcel.client === null) {
             const logId = await logErrorReturnLogId(
                 "Error with fetch: Parcels. No matching client found"

--- a/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/DriverOverview/getDriverOverviewData.ts
@@ -45,7 +45,11 @@ type ParcelsForDeliveryResponse =
           error: { type: ParcelsForDeliveryErrorType; logId: string };
       };
 
-type ParcelsForDeliveryErrorType = "parcelFetchFailed" | "noMatchingClient" | "noCollectionCentre";
+type ParcelsForDeliveryErrorType =
+    | "parcelFetchFailed"
+    | "noMatchingClient"
+    | "noCollectionCentre"
+    | "noActiveParcels";
 
 type DriverPdfResponse =
     | {
@@ -82,6 +86,7 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
 
     const dataWithNonNullClients: ParcelForDelivery[] = [];
     for (const parcel of data) {
+        // do we still need to check for null clients?
         if (parcel.client === null) {
             const logId = await logErrorReturnLogId(
                 "Error with fetch: Parcels. No matching client found"
@@ -94,6 +99,10 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
                 "Error with fetch: Parcels. No collection centre found"
             );
             return { data: null, error: { type: "noCollectionCentre", logId: logId } };
+        }
+
+        if (!parcel.client.is_active) {
+            continue;
         }
 
         const sortedParcelEvents = parcel.events.sort((event1, event2) => {
@@ -118,6 +127,11 @@ const getParcelsForDelivery = async (parcelIds: string[]): Promise<ParcelsForDel
             collection_centre: parcel.collection_centre,
             labelCount: Number.isNaN(labelCount) ? null : labelCount,
         });
+    }
+
+    if (dataWithNonNullClients.length === 0) {
+        const logId = await logErrorReturnLogId("All selected parcels belong to deleted clients.");
+        return { data: null, error: { type: "noActiveParcels", logId: logId } };
     }
 
     return { data: dataWithNonNullClients, error: null };

--- a/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/PendingMoreInfoReportCsvButton.tsx
@@ -25,7 +25,6 @@ const getPendingMoreInfoParcelIdsAndStatus = async (
         .gte("packing_date", getDbDate(fromDate))
         .lte("packing_date", getDbDate(toDate))
         .eq("last_status_event_name", "Pending More Info")
-        .eq("client_is_active", true)
         .not("parcel_id", "is", null);
 
     if (idFetchError) {
@@ -59,7 +58,6 @@ const getPendingMoreInfoRawParcelList = async (
             "primary_key",
             idAndStatusList.map((idAndStatus) => idAndStatus.parcel_id).filter((id) => id !== null)
         )
-        .eq("client.is_active", true)
         .order("packing_date")
         .order("client_id");
 

--- a/src/app/parcels/ActionBar/ActionButtons/ReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/ReportCsvButton.tsx
@@ -15,7 +15,7 @@ import {
     formatHygieneProducts,
     formatRequirementsByCanonicalOrder,
 } from "@/app/clients/getExpandedClientDetails";
-import { formatDatetimeAsDate } from "@/common/format";
+import { displayNameForDeletedClient, formatDatetimeAsDate } from "@/common/format";
 import { FileGenerationDataFetchResponse } from "@/components/FileGenerationButtons/common";
 import CsvButton, {
     formatNumberAsStringForCsv,
@@ -264,7 +264,7 @@ const createReportRow = (
     } else {
         return {
             ...baseRow,
-            fullName: "Deleted Client",
+            fullName: displayNameForDeletedClient,
             signpostingCallRequired: false,
             flaggedForAttention: false,
             phoneNumber: "",

--- a/src/app/parcels/ActionBar/ActionButtons/ReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/ReportCsvButton.tsx
@@ -188,89 +188,115 @@ export const getRawParcelListQuery = `
         )
     `;
 
+// After moving columns from clients to parcels, we need to ensure that the report rows are created correctly
+const createReportRow = (
+    rawParcel: rawParcel,
+    idAndStatusList: idAndStatus[],
+    isActive: boolean
+): ReportRow => {
+    const baseRow = {
+        clientIsActive: isActive,
+        voucherNumber: rawParcel.voucher_number ?? "",
+        packingDate: formatDatetimeAsDate(rawParcel.packing_date),
+        referralAgency: rawParcel.referral_agency ?? "",
+        referrerName: rawParcel.referrer_name ?? "",
+        referrerPhone: rawParcel.referrer_phone ?? "",
+        referrerEmail: rawParcel.referrer_email ?? "",
+        parcelStatus:
+            idAndStatusList.find((idAndStatus) => idAndStatus.parcel_id === rawParcel.primary_key)
+                ?.last_status_event_name ?? "(none)",
+        deliveryOrCollection: rawParcel.collection_centre?.is_shown
+            ? rawParcel.collection_centre?.name
+            : `${rawParcel.collection_centre?.name} (inactive)`,
+        deliveryCollectionDate: formatDatetimeAsDate(rawParcel.collection_datetime),
+        parcelNotes: rawParcel.notes ?? "",
+        parcelListType: rawParcel.list_type,
+        recordCreatedOn: formatDatetimeAsDate(rawParcel.created_at),
+    };
+
+    if (isActive && rawParcel.client) {
+        return {
+            ...baseRow,
+            fullName: rawParcel.client.full_name ?? "(error)",
+            signpostingCallRequired: rawParcel.client.signposting_call_required ?? false,
+            flaggedForAttention: rawParcel.client.flagged_for_attention ?? false,
+            phoneNumber: formatNumberAsStringForCsv(rawParcel.client.phone_number),
+            email: rawParcel.client.email ?? "",
+            signpostingCallReasons: formatRequirementsByCanonicalOrder(
+                rawParcel.client.signposting_call_reasons ?? null,
+                signpostingCallOptions
+            ),
+            address: formatAddressFromClientDetails(rawParcel.client),
+            deliveryInstructions: rawParcel.client.delivery_instructions ?? "",
+            extraInformation: rawParcel.client.extra_information ?? "",
+            clientNotes: rawParcel.client.notes ?? "",
+            cookingFacilities: formatRequirementsByCanonicalOrder(
+                rawParcel.client.cooking_facilities ?? null,
+                cookingFacilitiesOptions
+            ),
+            dietaryRequirements: formatRequirementsByCanonicalOrder(
+                rawParcel.client.dietary_requirements ?? null,
+                dietaryRequirementOptions
+            ),
+            hygieneProducts: formatHygieneProducts(
+                rawParcel.client.hygiene_tampons ?? null,
+                rawParcel.client.hygiene_pads ?? null,
+                rawParcel.client.hygiene_other_items ?? []
+            ),
+            babyProducts: formatBabyProducts(
+                rawParcel.client.baby_food ?? null,
+                rawParcel.client.baby_formula ?? null,
+                rawParcel.client.baby_nappies ?? null,
+                rawParcel.client.baby_other_items ?? []
+            ),
+            petFood: formatRequirementsByCanonicalOrder(
+                rawParcel.client.pet_food ?? null,
+                petFoodOptions
+            ),
+            otherItems: formatRequirementsByCanonicalOrder(
+                rawParcel.client.other_items ?? null,
+                otherRequirementOptions
+            ),
+            household: formatHouseholdFromFamilyDetails(rawParcel.client.family),
+            adults: formatBreakdownOfAdultsFromFamilyDetails(rawParcel.client.family),
+            children: formatBreakdownOfChildrenFromFamilyDetails(rawParcel.client.family),
+        };
+    } else {
+        return {
+            ...baseRow,
+            fullName: "Deleted Client",
+            signpostingCallRequired: false,
+            flaggedForAttention: false,
+            phoneNumber: "",
+            email: "",
+            signpostingCallReasons: "",
+            address: "",
+            deliveryInstructions: "",
+            extraInformation: "",
+            clientNotes: "",
+            cookingFacilities: "",
+            dietaryRequirements: "",
+            hygieneProducts: "",
+            babyProducts: "",
+            petFood: "",
+            otherItems: "",
+            household: "",
+            adults: "",
+            children: "",
+        };
+    }
+};
+
 export const convertRawParcelListToReportResult = (
     rawParcelList: rawParcel[],
     idAndStatusList: idAndStatus[]
 ): FetchReportResult => {
     return {
         error: null,
-        data: rawParcelList
-            .filter((rawParcel) => !!rawParcel.client)
-            .map((rawParcel): ReportRow => {
-                return {
-                    voucherNumber: rawParcel.voucher_number ?? "",
-                    packingDate: formatDatetimeAsDate(rawParcel.packing_date),
-                    fullName: rawParcel.client?.full_name ?? "(error)",
-                    signpostingCallRequired: rawParcel.client?.signposting_call_required ?? false,
-                    flaggedForAttention: rawParcel.client?.flagged_for_attention ?? false,
-                    phoneNumber: rawParcel.client
-                        ? formatNumberAsStringForCsv(rawParcel.client.phone_number)
-                        : "",
-                    email: rawParcel.client?.email ?? "",
-                    signpostingCallReasons: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.signposting_call_reasons ?? null,
-                        signpostingCallOptions
-                    ),
-                    address: rawParcel.client
-                        ? formatAddressFromClientDetails(rawParcel.client)
-                        : "",
-                    parcelStatus:
-                        idAndStatusList.find(
-                            (idAndStatus) => idAndStatus.parcel_id === rawParcel.primary_key
-                        )?.last_status_event_name ?? "(none)",
-                    deliveryOrCollection: rawParcel.collection_centre?.is_shown
-                        ? rawParcel.collection_centre?.name
-                        : `${rawParcel.collection_centre?.name} (inactive)`,
-                    deliveryCollectionDate: formatDatetimeAsDate(rawParcel.collection_datetime),
-                    deliveryInstructions: rawParcel.client?.delivery_instructions ?? "",
-                    extraInformation: rawParcel.client?.extra_information ?? "",
-                    parcelNotes: rawParcel?.notes ?? "",
-                    clientNotes: rawParcel.client?.notes ?? "",
-                    cookingFacilities: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.cooking_facilities ?? null,
-                        cookingFacilitiesOptions
-                    ),
-                    dietaryRequirements: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.dietary_requirements ?? null,
-                        dietaryRequirementOptions
-                    ),
-                    hygieneProducts: formatHygieneProducts(
-                        rawParcel.client?.hygiene_tampons ?? null,
-                        rawParcel.client?.hygiene_pads ?? null,
-                        rawParcel.client?.hygiene_other_items ?? []
-                    ),
-                    babyProducts: formatBabyProducts(
-                        rawParcel.client?.baby_food ?? null,
-                        rawParcel.client?.baby_formula ?? null,
-                        rawParcel.client?.baby_nappies ?? null,
-                        rawParcel.client?.baby_other_items ?? []
-                    ),
-                    petFood: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.pet_food ?? null,
-                        petFoodOptions
-                    ),
-                    otherItems: formatRequirementsByCanonicalOrder(
-                        rawParcel.client?.other_items ?? null,
-                        otherRequirementOptions
-                    ),
-                    household: rawParcel.client
-                        ? formatHouseholdFromFamilyDetails(rawParcel.client.family)
-                        : "",
-                    adults: rawParcel.client
-                        ? formatBreakdownOfAdultsFromFamilyDetails(rawParcel.client.family)
-                        : "",
-                    children: rawParcel.client
-                        ? formatBreakdownOfChildrenFromFamilyDetails(rawParcel.client.family)
-                        : "",
-                    parcelListType: rawParcel.list_type,
-                    clientIsActive: rawParcel.client?.is_active ?? false,
-                    recordCreatedOn: formatDatetimeAsDate(rawParcel.created_at),
-                    referralAgency: rawParcel?.referral_agency ?? "",
-                    referrerName: rawParcel?.referrer_name ?? "",
-                    referrerPhone: rawParcel?.referrer_phone ?? "",
-                    referrerEmail: rawParcel?.referrer_email ?? "",
-                };
-            }),
+        data: rawParcelList.map((rawParcel): ReportRow => {
+            const isActive = !!rawParcel.client?.is_active;
+            return createReportRow(rawParcel, idAndStatusList, isActive);
+        }),
     };
 };
 

--- a/src/app/parcels/ActionBar/ActionButtons/SelectedParcelsReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/SelectedParcelsReportCsvButton.tsx
@@ -19,7 +19,6 @@ const getSelectedParcelsParcelIdsAndStatus = async (
     const { data: idAndStatusList, error: idFetchError } = await supabase
         .from("parcels_plus")
         .select("parcel_id, last_status_event_name")
-        .eq("client_is_active", true)
         .not("parcel_id", "is", null)
         .in("parcel_id", parcelIds);
 

--- a/src/app/parcels/ActionBar/ActionButtons/ShippingLabelsPdfButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/ShippingLabelsPdfButton.tsx
@@ -63,7 +63,8 @@ type ParcelToShipErrorType =
     | "parcelFetchFailed"
     | "noMatchingClient"
     | "noMatchingPackingSlot"
-    | "noMatchingCollectionCentre";
+    | "noMatchingCollectionCentre"
+    | "noActiveParcels";
 
 const getParcelToShip = async (parcelId: string): Promise<ParcelToShipResponse> => {
     const { data, error } = await supabase
@@ -124,7 +125,9 @@ const getRequiredData = async (
             return { data: null, error };
         }
         const client = parcel.client;
-        const clientIsActive = parcel.client.is_active;
+        if (!parcel.client.is_active) {
+            continue;
+        }
         parcelDataList.push({
             label_quantity: labelQuantity,
             parcel_id: parcelId,
@@ -133,16 +136,22 @@ const getRequiredData = async (
             collection_centre: parcel.collection_centre?.acronym ?? "",
             collection_datetime: formatDatetime(parcel.collection_datetime),
             voucher_number: parcel.voucher_number ?? "",
-            full_name: clientIsActive ? client.full_name ?? "" : displayNameForDeletedClient,
-            phone_number: clientIsActive ? client.phone_number ?? "" : "-",
-            address_1: clientIsActive ? client.address_1 ?? "" : "", //Seeded deleted clients have is_active set to false, but their personal info fields are non-null
-            address_2: clientIsActive ? client.address_2 ?? "" : "",
-            address_town: clientIsActive ? client.address_town ?? "" : "",
-            address_county: clientIsActive ? client.address_county ?? "" : "",
-            address_postcode: clientIsActive ? client.address_postcode : "-",
-            delivery_instructions: clientIsActive ? client.delivery_instructions ?? "" : "-",
+            full_name: client.full_name ?? displayNameForDeletedClient,
+            phone_number: client.phone_number ?? "-",
+            address_1: client.address_1 ?? "",
+            address_2: client.address_2 ?? "",
+            address_town: client.address_town ?? "",
+            address_county: client.address_county ?? "",
+            address_postcode: client.address_postcode ?? "-",
+            delivery_instructions: client.delivery_instructions ?? "-",
         });
     }
+
+    if (parcelDataList.length === 0) {
+        const logId = await logErrorReturnLogId("All selected parcels belong to deleted clients.");
+        return { data: null, error: { type: "noActiveParcels", logId: logId } };
+    }
+
     return { data: parcelDataList, error: null };
 };
 

--- a/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getShoppingListData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getShoppingListData.ts
@@ -117,7 +117,6 @@ const getShoppingListDataForSingleParcel = async (
     const clientData = clientAndFamilyData.clientData;
 
     if (!clientData.is_active) {
-        // Instead of returning an error, skip this parcel by returning { data: null, error: null }
         return { data: null, error: null };
     }
 

--- a/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getShoppingListData.ts
+++ b/src/app/parcels/ActionBar/ActionButtons/ShoppingList/getShoppingListData.ts
@@ -71,6 +71,10 @@ type FetchShoppingListForPdfResponse =
     | {
           data: null;
           error: ShoppingListPdfError;
+      }
+    | {
+          data: null;
+          error: null;
       };
 
 export type ShoppingListPdfError =
@@ -113,8 +117,8 @@ const getShoppingListDataForSingleParcel = async (
     const clientData = clientAndFamilyData.clientData;
 
     if (!clientData.is_active) {
-        const logId = await logErrorReturnLogId("Generating shopping list pdf for inactive client");
-        return { data: null, error: { type: "inactiveClient", logId: logId } };
+        // Instead of returning an error, skip this parcel by returning { data: null, error: null }
+        return { data: null, error: null };
     }
 
     const { data: itemsListData, error: itemsListError } = await prepareItemsListForHousehold(
@@ -168,6 +172,16 @@ const getShoppingListData = async (parcelIds: string[]): Promise<ShoppingListPdf
             error: lists.filter((list) => list.error)[0].error as ShoppingListPdfError,
         };
     }
+
+    const numberOfDeletedClientParcels = lists.filter(
+        (list) => list.data === null && list.error === null
+    ).length;
+
+    if (numberOfDeletedClientParcels === parcelIds.length) {
+        const logId = await logErrorReturnLogId("All parcels belong to deleted clients");
+        return { data: null, error: { type: "inactiveClient", logId: logId } };
+    }
+
     return {
         data: lists
             .filter(

--- a/src/app/parcels/ActionBar/ActionButtons/SignpostingReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/SignpostingReportCsvButton.tsx
@@ -24,7 +24,6 @@ const getSignpostingParcelIdsAndStatus = async (
         .select("parcel_id, last_status_event_name")
         .gte("packing_date", getDbDate(fromDate))
         .lte("packing_date", getDbDate(toDate))
-        .eq("client_is_active", true)
         .not("parcel_id", "is", null)
         .eq("client_signposting_call_required", true);
 

--- a/src/app/parcels/ActionBar/ActionButtons/VoucherNumberReportCsvButton.tsx
+++ b/src/app/parcels/ActionBar/ActionButtons/VoucherNumberReportCsvButton.tsx
@@ -26,7 +26,6 @@ const getMissingVoucherNumberParcelIdsAndStatus = async (
         .lte("packing_date", getDbDate(toDate))
         // eslint-disable-next-line quotes
         .or('voucher_number.not.ilike.E%, voucher_number.ilike."", voucher_number.is.null')
-        .eq("client_is_active", true)
         .not("parcel_id", "is", null);
 
     if (idFetchError) {

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { getDeletedClientParcelsCount } from "@/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels";
+import DeletedClientParcelsDownloadWarning from "@/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning";
 import React, { useEffect, useRef, useState } from "react";
 import GeneralActionModal, {
     Heading,
@@ -37,6 +39,7 @@ interface ContentProps {
     onDriverNameChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     setIsDateValid: (valid: boolean) => void;
     maxParcelsToShow: number;
+    deletedClientParcelsCount: number;
 }
 
 const DriverOverviewInput = React.forwardRef<HTMLInputElement, DriverOverviewInputProps>(
@@ -87,6 +90,9 @@ const getPdfErrorMessage = (error: DriverOverviewError): string => {
         case "noCollectionCentre":
             errorMessage = "Failed to find a collection centre for one or more of the parcels.";
             break;
+        case "noActiveParcels":
+            errorMessage = "All selected parcels belong to deleted clients.";
+            break;
     }
     return `${errorMessage} LogId: ${error.logId}`;
 };
@@ -99,6 +105,7 @@ const DriverOverviewModalContent: React.FC<ContentProps> = ({
     maxParcelsToShow,
     dateTime: date,
     driverName,
+    deletedClientParcelsCount,
     onPdfCreationCompleted,
     onPdfCreationFailed,
     isInputValid,
@@ -122,6 +129,11 @@ const DriverOverviewModalContent: React.FC<ContentProps> = ({
                 parcels={selectedParcels}
                 maxParcelsToShow={maxParcelsToShow}
             />
+            {deletedClientParcelsCount > 0 && (
+                <DeletedClientParcelsDownloadWarning
+                    deletedClientParcelsCount={deletedClientParcelsCount}
+                />
+            )}
             <Centerer>
                 <DriverOverviewPdfButton
                     parcels={selectedParcels}
@@ -145,8 +157,10 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
     const [date, setDate] = useState(dayjs());
 
     const [isDateValid, setIsDateValid] = useState(true);
+    const [deletedClientParcelsCount, setDeletedClientParcelsCount] = useState<number>(0);
 
     const isInputValid = isDateValid && driverName !== null;
+    const parcelIds = props.selectedParcels.map((parcel) => parcel.parcelId);
 
     const onDriverNameChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         const trimmedDriverName = event.target.value.trim();
@@ -212,6 +226,10 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
         });
     };
 
+    useEffect(() => {
+        void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
+    }, [parcelIds]);
+
     return (
         <GeneralActionModal
             {...props}
@@ -228,6 +246,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
                     maxParcelsToShow={maxParcelsToShow}
                     dateTime={date}
                     driverName={driverName}
+                    deletedClientParcelsCount={deletedClientParcelsCount}
                     onPdfCreationCompleted={onPdfCreationCompleted}
                     onPdfCreationFailed={onPdfCreationFailed}
                     isInputValid={isInputValid}

--- a/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/GenerateMapModal.tsx
@@ -1,23 +1,33 @@
 "use client";
 
+import { getDeletedClientParcelsCount } from "@/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels";
+import DeletedClientParcelsDownloadWarning from "@/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning";
+import SelectedParcelsOverview from "@/app/parcels/ActionBar/SelectedParcelsOverview";
+import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
+import { logErrorReturnLogId } from "@/logger/logger";
 import React, { useEffect, useRef, useState } from "react";
-import GeneralActionModal, { ActionModalProps } from "./GeneralActionModal";
+import GeneralActionModal, { ActionModalProps, maxParcelsToShow } from "./GeneralActionModal";
 import { Button } from "@mui/material";
+import { sendAuditLog } from "@/server/auditLog";
 
 interface ContentProps {
+    selectedParcels: ParcelsTableRow[];
     uniquePostcodes: string[];
     setErrorMessage: (message: string) => void;
     setActionCompleted: (completed: boolean) => void;
     mapsLinkForSelectedParcels: string;
     setSuccessMessage: (message: string) => void;
     postSuccessCallback: () => void;
+    deletedClientParcelsCount: number;
 }
 
 const GenerateMapModalContent: React.FC<ContentProps> = ({
+    selectedParcels,
     uniquePostcodes,
     setErrorMessage,
     setActionCompleted,
     mapsLinkForSelectedParcels,
+    deletedClientParcelsCount,
     setSuccessMessage,
     postSuccessCallback,
 }) => {
@@ -27,27 +37,50 @@ const GenerateMapModalContent: React.FC<ContentProps> = ({
         generateMapButtonFocusRef.current?.focus();
     }, []);
 
+    const handleGenerateMap = async (): Promise<void> => {
+        if (uniquePostcodes.length === 0) {
+            const logId = await logErrorReturnLogId(
+                "All selected parcels belong to deleted clients."
+            );
+            setErrorMessage(`All selected parcels belong to deleted clients. LogId: ${logId}.`);
+
+            await sendAuditLog({
+                action: "generate map",
+                content: { parcelIds: selectedParcels.map((id) => id.parcelId) },
+                wasSuccess: false,
+                logId: logId,
+            });
+
+            setActionCompleted(true);
+            return;
+        }
+        window.open(mapsLinkForSelectedParcels, "_blank", "noopener, noreferrer");
+
+        await sendAuditLog({
+            action: "generate map",
+            content: { parcelIds: selectedParcels.map((id) => id.parcelId) },
+            wasSuccess: true,
+        });
+        setSuccessMessage("Map Generated");
+        setActionCompleted(true);
+        postSuccessCallback();
+    };
+
     return (
-        <Button
-            variant="contained"
-            onClick={() => {
-                if (uniquePostcodes.length === 0) {
-                    setErrorMessage("No selected parcels have addresses.");
-                    setActionCompleted(true);
-                    return;
-                }
-                const openInNewTab = (url: string): void => {
-                    window.open(url, "_blank", "noopener, noreferrer");
-                };
-                openInNewTab(mapsLinkForSelectedParcels);
-                setSuccessMessage("Map Generated");
-                setActionCompleted(true);
-                postSuccessCallback();
-            }}
-            ref={generateMapButtonFocusRef}
-        >
-            Generate Map
-        </Button>
+        <>
+            <SelectedParcelsOverview
+                parcels={selectedParcels}
+                maxParcelsToShow={maxParcelsToShow}
+            />
+            {deletedClientParcelsCount > 0 && (
+                <DeletedClientParcelsDownloadWarning
+                    deletedClientParcelsCount={deletedClientParcelsCount}
+                />
+            )}
+            <Button variant="contained" onClick={handleGenerateMap} ref={generateMapButtonFocusRef}>
+                Generate Map
+            </Button>
+        </>
     );
 };
 
@@ -55,11 +88,14 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
     const [actionCompleted, setActionCompleted] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [deletedClientParcelsCount, setDeletedClientParcelsCount] = useState<number>(0);
 
     const onClose = (): void => {
         props.onClose();
         setErrorMessage(null);
     };
+
+    const parcelIds = props.selectedParcels.map((parcel) => parcel.parcelId);
 
     const formattedPostcodes = props.selectedParcels.reduce<string[]>(
         (formattedPostcodes, parcel) => {
@@ -84,6 +120,10 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         }, 3000);
     };
 
+    useEffect(() => {
+        void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
+    }, [parcelIds]);
+
     return (
         <GeneralActionModal
             {...props}
@@ -93,7 +133,9 @@ const GenerateMapModal: React.FC<ActionModalProps> = (props) => {
         >
             {!actionCompleted && (
                 <GenerateMapModalContent
+                    selectedParcels={props.selectedParcels}
                     uniquePostcodes={uniquePostcodes}
+                    deletedClientParcelsCount={deletedClientParcelsCount}
                     setErrorMessage={setErrorMessage}
                     setActionCompleted={setActionCompleted}
                     mapsLinkForSelectedParcels={mapsLinkForSelectedParcels}

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -156,7 +156,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
 
     const onPdfCreationCompleted = async (): Promise<void> => {
         const { error } = await saveParcelTableRowsStatus(
-            props.selectedParcels,
+            props.selectedParcels.filter((parcel) => parcel.clientIsActive),
             "Shipping Labels Downloaded",
             labelQuantity.toString()
         );

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { getDeletedClientParcelsCount } from "@/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels";
+import DeletedClientParcelsDownloadWarning from "@/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import GeneralActionModal, {
     Heading,
@@ -31,6 +33,7 @@ interface ContentProps {
     onPdfCreationFailed: (pdfError: ShippingLabelError) => void;
     onLabelQuantityChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     duplicateDownloadedPostcodes: (string | null)[];
+    deletedClientParcelsCount: number;
 }
 
 const ShippingLabelsInput = React.forwardRef<HTMLInputElement, ShippingLabelsInputProps>(
@@ -67,6 +70,9 @@ const getPdfErrorMessage = (error: ShippingLabelError): string => {
             errorMessage =
                 "No collection centre in the database matches that of the selected parcel.";
             break;
+        case "noActiveParcels":
+            errorMessage = "All selected parcels belong to deleted clients.";
+            break;
     }
     return `${errorMessage} LogId: ${error.logId}`;
 };
@@ -79,6 +85,7 @@ const ShippingLabelModalContent: React.FC<ContentProps> = ({
     onPdfCreationFailed,
     onLabelQuantityChange,
     duplicateDownloadedPostcodes,
+    deletedClientParcelsCount,
 }) => {
     const quantityInputFocusRef = useRef<HTMLInputElement>(null);
 
@@ -96,6 +103,11 @@ const ShippingLabelModalContent: React.FC<ContentProps> = ({
                 parcels={selectedParcels}
                 maxParcelsToShow={maxParcelsToShow}
             />
+            {deletedClientParcelsCount > 0 && (
+                <DeletedClientParcelsDownloadWarning
+                    deletedClientParcelsCount={deletedClientParcelsCount}
+                />
+            )}
             {duplicateDownloadedPostcodes.length > 0 && (
                 <DuplicateDownloadWarning postcodes={duplicateDownloadedPostcodes} />
             )}
@@ -120,6 +132,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
     const [duplicateDownloadedPostcodes, setDuplicateDownloadedPostcodes] = useState<
         (string | null)[]
     >([]);
+    const [deletedClientParcelsCount, setDeletedClientParcelsCount] = useState<number>(0);
 
     const onLabelQuantityChange = useCallback(
         (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -191,6 +204,10 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
         );
     }, [parcelIds]);
 
+    useEffect(() => {
+        void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
+    }, [parcelIds]);
+
     return (
         <GeneralActionModal
             {...props}
@@ -207,6 +224,7 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
                     onPdfCreationFailed={onPdfCreationFailed}
                     onLabelQuantityChange={onLabelQuantityChange}
                     duplicateDownloadedPostcodes={duplicateDownloadedPostcodes}
+                    deletedClientParcelsCount={deletedClientParcelsCount}
                 />
             )}
         </GeneralActionModal>

--- a/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShippingLabelModal.tsx
@@ -196,18 +196,15 @@ const ShippingLabelModal: React.FC<ActionModalProps> = (props) => {
     };
 
     useEffect(() => {
-        getDuplicateDownloadedPostcodes(
+        void getDuplicateDownloadedPostcodes(
             parcelIds,
             "Shipping Labels Downloaded",
             setDuplicateDownloadedPostcodes,
             setErrorMessage
         );
-    }, [parcelIds]);
 
-    useEffect(() => {
         void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
     }, [parcelIds]);
-
     return (
         <GeneralActionModal
             {...props}

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -105,7 +105,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
 
     const onPdfCreationCompleted = async (): Promise<void> => {
         const { error } = await saveParcelTableRowsStatus(
-            props.selectedParcels,
+            props.selectedParcels.filter((parcel) => parcel.clientIsActive),
             "Shopping List Downloaded"
         );
         if (error) {

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getDeletedClientParcelsCount } from "@/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels";
 import React, { useEffect, useState } from "react";
 import GeneralActionModal, { ActionModalProps, maxParcelsToShow } from "./GeneralActionModal";
 import SelectedParcelsOverview from "../SelectedParcelsOverview";
@@ -11,12 +12,14 @@ import DuplicateDownloadWarning from "@/app/parcels/ActionBar/DuplicateDownloadW
 import { getDuplicateDownloadedPostcodes } from "@/app/parcels/ActionBar/ActionModals/getDuplicateDownloadedPostcodes";
 import { ParcelsTableRow } from "../../parcelsTable/types";
 import { saveParcelTableRowsStatus } from "../saveStatus";
+import DeletedClientParcelsDownloadWarning from "@/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning";
 
 interface ContentProps {
     selectedParcels: ParcelsTableRow[];
     onPdfCreationCompleted: () => void;
     onPdfCreationFailed: (pdfError: ShoppingListPdfError) => void;
     duplicateDownloadedPostcodes: (string | null)[];
+    deletedClientParcelsCount: number;
 }
 
 const getPdfErrorMessage = (error: ShoppingListPdfError): string => {
@@ -48,7 +51,7 @@ const getPdfErrorMessage = (error: ShoppingListPdfError): string => {
             errorMessage = "Invalid family size for shopping list PDF.";
             break;
         case "inactiveClient":
-            errorMessage = "One or more selected parcels belong to inactive clients.";
+            errorMessage = "All selected parcels belong to deleted clients.";
             break;
     }
     return `${errorMessage} LogId: ${error.logId}`;
@@ -57,6 +60,7 @@ const getPdfErrorMessage = (error: ShoppingListPdfError): string => {
 const ShoppingListModalContent: React.FC<ContentProps> = ({
     selectedParcels,
     duplicateDownloadedPostcodes,
+    deletedClientParcelsCount,
     onPdfCreationCompleted,
     onPdfCreationFailed,
 }) => {
@@ -66,6 +70,11 @@ const ShoppingListModalContent: React.FC<ContentProps> = ({
                 parcels={selectedParcels}
                 maxParcelsToShow={maxParcelsToShow}
             />
+            {deletedClientParcelsCount > 0 && (
+                <DeletedClientParcelsDownloadWarning
+                    deletedClientParcelsCount={deletedClientParcelsCount}
+                />
+            )}
             {duplicateDownloadedPostcodes.length > 0 && (
                 <DuplicateDownloadWarning postcodes={duplicateDownloadedPostcodes} />
             )}
@@ -85,6 +94,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
     const [duplicateDownloadedPostcodes, setDuplicateDownloadedPostcodes] = useState<
         (string | null)[]
     >([]);
+    const [deletedClientParcelsCount, setDeletedClientParcelsCount] = useState<number>(0);
 
     const onClose = (): void => {
         props.onClose();
@@ -128,12 +138,16 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
     };
 
     useEffect(() => {
-        getDuplicateDownloadedPostcodes(
+        void getDuplicateDownloadedPostcodes(
             parcelIds,
             "Shopping List Downloaded",
             setDuplicateDownloadedPostcodes,
             setErrorMessage
         );
+    }, [parcelIds]);
+
+    useEffect(() => {
+        void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
     }, [parcelIds]);
 
     return (
@@ -147,6 +161,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
                 <ShoppingListModalContent
                     selectedParcels={props.selectedParcels}
                     duplicateDownloadedPostcodes={duplicateDownloadedPostcodes}
+                    deletedClientParcelsCount={deletedClientParcelsCount}
                     onPdfCreationCompleted={onPdfCreationCompleted}
                     onPdfCreationFailed={onPdfCreationFailed}
                 />

--- a/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/ShoppingListModal.tsx
@@ -144,9 +144,7 @@ const ShoppingListModal: React.FC<ActionModalProps> = (props) => {
             setDuplicateDownloadedPostcodes,
             setErrorMessage
         );
-    }, [parcelIds]);
 
-    useEffect(() => {
         void getDeletedClientParcelsCount(parcelIds, setDeletedClientParcelsCount, setErrorMessage);
     }, [parcelIds]);
 

--- a/src/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels.ts
+++ b/src/app/parcels/ActionBar/ActionModals/getNumberOfDeletedClientParcels.ts
@@ -1,0 +1,20 @@
+import { getInactiveClientCountByParcelIds } from "@/app/parcels/parcelsTable/fetchParcelTableData";
+
+export const getDeletedClientParcelsCount = async (
+    parcelIds: string[],
+    dataCallback: (count: number) => void,
+    errorCallback: (msg: string) => void
+): Promise<void> => {
+    const { data, error } = await getInactiveClientCountByParcelIds(parcelIds);
+
+    if (error) {
+        errorCallback(`Failed to fetch deleted client parcels count: ${error.type}`);
+        return;
+    }
+    if (data === null) {
+        errorCallback("No data returned for deleted client parcels count.");
+        return;
+    }
+
+    dataCallback(data);
+};

--- a/src/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning.tsx
+++ b/src/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning.tsx
@@ -19,9 +19,8 @@ const DeletedClientParcelsDownloadWarning: React.FC<DeletedClientParcelsDownload
 
     return (
         <StyledAlert severity="warning">
-            {deletedClientParcelsCount} deleted client{" "}
-            {deletedClientParcelsCount === 1 ? "parcel" : "parcels"} will not be included in this
-            download.
+            {deletedClientParcelsCount} {deletedClientParcelsCount === 1 ? "parcel" : "parcels"}{" "}
+            associated with deleted clients will be excluded from this action.
         </StyledAlert>
     );
 };

--- a/src/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning.tsx
+++ b/src/app/parcels/ActionBar/DeletedClientParcelsDownloadWarning.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import Alert from "@mui/material/Alert";
+import styled from "styled-components";
+
+export interface DeletedClientParcelsDownloadWarningProps {
+    deletedClientParcelsCount: number;
+}
+
+const StyledAlert = styled(Alert)`
+    border-radius: 4px;
+`;
+
+const DeletedClientParcelsDownloadWarning: React.FC<DeletedClientParcelsDownloadWarningProps> = (
+    props
+) => {
+    const { deletedClientParcelsCount } = props;
+
+    return (
+        <StyledAlert severity="warning">
+            {deletedClientParcelsCount} deleted client{" "}
+            {deletedClientParcelsCount === 1 ? "parcel" : "parcels"} will not be included in this
+            download.
+        </StyledAlert>
+    );
+};
+
+export default DeletedClientParcelsDownloadWarning;

--- a/src/app/parcels/parcelsTable/fetchParcelTableData.ts
+++ b/src/app/parcels/parcelsTable/fetchParcelTableData.ts
@@ -282,6 +282,45 @@ export const fetchParcelStatuses = async (): Promise<ParcelStatusesReturnType> =
     return { data: parcelStatusesList, error: null };
 };
 
+export const getInactiveClientCountByParcelIds = async (
+    parcelIds: string[]
+): Promise<{
+    data: number | null;
+    error: { type: string; logId: string } | null;
+}> => {
+    if (!parcelIds.length) {
+        return { data: 0, error: null };
+    }
+
+    const { data, error } = await supabase
+        .from("parcels")
+        .select("primary_key, client_id, client:clients(is_active)")
+        .in("primary_key", parcelIds);
+
+    if (error) {
+        const message = "Failed to fetch client IDs and is active status for parcels";
+        const logId = await logErrorReturnLogId(message, { error, parcelIds });
+        return { data: null, error: { type: "failedClientIdsAndIsActiveFetch", logId } };
+    }
+
+    const validParcels = data.filter((parcel) => parcel.client !== null);
+
+    if (validParcels.length !== data.length) {
+        const nullClientParcelIds = data
+            .filter((parcel) => parcel.client === null)
+            .map((parcel) => parcel.primary_key);
+
+        await logInfoReturnLogId("Some parcels have no matching clients", { nullClientParcelIds });
+    }
+
+    const inactiveClientCount = validParcels.filter((parcel) => !parcel?.client?.is_active).length;
+
+    return {
+        data: inactiveClientCount,
+        error: null,
+    };
+};
+
 export const getClientIdAndIsActive = async (parcelId: string): Promise<FetchClientIdResult> => {
     const { data, error } = await supabase
         .from("parcels")

--- a/src/components/FileGenerationButtons/FileGenerationButton.tsx
+++ b/src/components/FileGenerationButtons/FileGenerationButton.tsx
@@ -84,6 +84,7 @@ const FileGenerationButton = <Data, ErrorType extends string>({
             disabled={disabled}
             ref={buttonToFocusRef}
             type={formSubmitButton ? "submit" : undefined}
+            sx={{ marginTop: "1em" }}
         >
             {children}
         </Button>


### PR DESCRIPTION
 ### [VFB-449: Fix inconsistent behaviour and errors when selecting deleted client parcels](https://softwiretech.atlassian.net/browse/VFB-449)

## What's changed
- For **Download Shopping Lists**, **Download Shipping Labels**, **Generate Map**, and **Download Driver Overview**:
  - Parcels associated with inactive (deleted) clients are now consistently excluded from the output.
  - An info/warning message is displayed to the user indicating how many selected parcels are associated with deleted clients and will be excluded.
  - The action proceeds with active client parcels only (does not block or error if some selected parcels are deleted).

- For **Download Day Overview**, **Download Signposting Report**, **Download Missing Voucher Report**, **Download Selected Parcels Report**, and **Download Pending More Info Report**:
  - These reports now include parcels from both active and deleted clients (no exclusion based on client status).

- Refactored and unified the logic for counting and handling deleted client parcels, using a new utility and warning component for relevant actions.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1008" height="489" alt="image" src="https://github.com/user-attachments/assets/fa938c65-2a97-41fe-961e-741149b8aea9" /> | <img width="981" height="555" alt="image" src="https://github.com/user-attachments/assets/a8ce10ad-8ca1-4729-b023-cd07780b088d" /> |
|  | <img width="929" height="187" alt="image" src="https://github.com/user-attachments/assets/0a0e35b5-85da-40d0-a5a1-5f14a7b2846a" /> |
| <img width="946" height="210" alt="image" src="https://github.com/user-attachments/assets/ac84ce52-6102-4631-b61e-edb6d21e152b" /> | <img width="1323" height="177" alt="image" src="https://github.com/user-attachments/assets/68d1cb38-a100-4043-9c37-8b3e05d6ad2b" /> |
| <img width="919" height="215" alt="image" src="https://github.com/user-attachments/assets/8fd03db1-8a6a-4688-b38a-ce0c4ff4e51e" /> | <img width="938" height="420" alt="image" src="https://github.com/user-attachments/assets/14a2ed9f-25b1-4a63-bc11-8afddc56e23c" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`