### PR TITLE
VFB-484: Fix autofill issue for family members

### DIFF
--- a/src/app/clients/form/formSections/NumberAdultsCard.tsx
+++ b/src/app/clients/form/formSections/NumberAdultsCard.tsx
@@ -26,6 +26,16 @@ const numberOfAdultsRange = (value: string): boolean => {
     );
 };
 
+export const resizePersonsArray = (current: Person[], target: number): Person[] => {
+    if (current.length === target) {
+        return current;
+    }
+
+    return current.length < target
+        ? [...current, ...Array(target - current.length).fill({} as Person)]
+        : current.slice(0, target);
+};
+
 const setAdultsFields = (
     fieldSetter: ClientSetter,
     adults: Person[],
@@ -55,16 +65,12 @@ const NumberAdultsCard: React.FC<ClientCardProps> = ({
     fields,
 }) => {
     useEffect(() => {
-        if (fields.numberOfAdults > fields.adults.length) {
-            const newAdults = [...fields.adults];
-            while (newAdults.length < fields.numberOfAdults) {
-                newAdults.push({});
-            }
-            fieldSetter({ adults: newAdults });
-        } else if (fields.numberOfAdults < fields.adults.length) {
-            fieldSetter({ adults: fields.adults.slice(0, fields.numberOfAdults) });
+        const resized = resizePersonsArray(fields.adults, fields.numberOfAdults);
+        if (resized !== fields.adults) {
+            fieldSetter({ adults: resized });
         }
     }, [fields.numberOfAdults, fields.adults, fieldSetter]);
+
     return (
         <GenericFormCard
             title="Number of Adults"
@@ -87,11 +93,9 @@ const NumberAdultsCard: React.FC<ClientCardProps> = ({
                         additionalCondition: numberOfAdultsRange,
                     })}
                 />
-                {fields.adults.map((adult: Person, index: number) => {
-                    if (index >= fields.numberOfAdults) {
-                        return null;
-                    }
-                    return (
+                {fields.adults
+                    .slice(0, fields.numberOfAdults)
+                    .map((adult: Person, index: number) => (
                         <StyledCard key={adult.primaryKey ?? `new-adult-${index}`}>
                             <FormText>Adult {index + 1}</FormText>
                             <ControlledSelect
@@ -122,8 +126,7 @@ const NumberAdultsCard: React.FC<ClientCardProps> = ({
                                 )}
                             />
                         </StyledCard>
-                    );
-                })}
+                    ))}
             </>
         </GenericFormCard>
     );

--- a/src/app/clients/form/formSections/NumberAdultsCard.tsx
+++ b/src/app/clients/form/formSections/NumberAdultsCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
 import {
     errorExists,
@@ -54,6 +54,17 @@ const NumberAdultsCard: React.FC<ClientCardProps> = ({
     fieldSetter,
     fields,
 }) => {
+    useEffect(() => {
+        if (fields.numberOfAdults > fields.adults.length) {
+            const newAdults = [...fields.adults];
+            while (newAdults.length < fields.numberOfAdults) {
+                newAdults.push({});
+            }
+            fieldSetter({ adults: newAdults });
+        } else if (fields.numberOfAdults < fields.adults.length) {
+            fieldSetter({ adults: fields.adults.slice(0, fields.numberOfAdults) });
+        }
+    }, [fields.numberOfAdults, fields.adults, fieldSetter]);
     return (
         <GenericFormCard
             title="Number of Adults"
@@ -77,6 +88,9 @@ const NumberAdultsCard: React.FC<ClientCardProps> = ({
                     })}
                 />
                 {fields.adults.map((adult: Person, index: number) => {
+                    if (index >= fields.numberOfAdults) {
+                        return null;
+                    }
                     return (
                         <StyledCard key={adult.primaryKey ?? `new-adult-${index}`}>
                             <FormText>Adult {index + 1}</FormText>

--- a/src/app/clients/form/formSections/NumberChildrenCard.tsx
+++ b/src/app/clients/form/formSections/NumberChildrenCard.tsx
@@ -23,6 +23,7 @@ import {
     genderSelectValueForUnknown,
     getGenderSelectLabelsAndValues,
 } from "@/common/getGendersOfFamily";
+import { resizePersonsArray } from "@/app/clients/form/formSections/NumberAdultsCard";
 
 const maxNumberChildren = (value: string): boolean => {
     return parseInt(value) <= 20;
@@ -60,16 +61,12 @@ const NumberChildrenCard: React.FC<ClientCardProps> = ({
     fields,
 }) => {
     useEffect(() => {
-        if (fields.numberOfChildren > fields.children.length) {
-            const newChildren = [...fields.children];
-            while (newChildren.length < fields.numberOfChildren) {
-                newChildren.push({});
-            }
-            fieldSetter({ children: newChildren });
-        } else if (fields.numberOfChildren < fields.children.length) {
-            fieldSetter({ children: fields.children.slice(0, fields.numberOfChildren) });
+        const resized = resizePersonsArray(fields.children, fields.numberOfChildren);
+        if (resized !== fields.children) {
+            fieldSetter({ children: resized });
         }
     }, [fields.numberOfChildren, fields.children, fieldSetter]);
+
     return (
         <GenericFormCard
             title="Number of Children"
@@ -94,11 +91,9 @@ const NumberChildrenCard: React.FC<ClientCardProps> = ({
                         additionalCondition: maxNumberChildren,
                     })}
                 />
-                {fields.children.map((child: Person, index: number) => {
-                    if (index >= fields.numberOfChildren) {
-                        return null;
-                    }
-                    return (
+                {fields.children
+                    .slice(0, fields.numberOfChildren)
+                    .map((child: Person, index: number) => (
                         <StyledCard key={child.primaryKey ?? `new-child-${index}`}>
                             <FormText>Child {index + 1}</FormText>
                             <ControlledSelect
@@ -145,8 +140,7 @@ const NumberChildrenCard: React.FC<ClientCardProps> = ({
                                 )}
                             />
                         </StyledCard>
-                    );
-                })}
+                    ))}
             </>
         </GenericFormCard>
     );

--- a/src/app/clients/form/formSections/NumberChildrenCard.tsx
+++ b/src/app/clients/form/formSections/NumberChildrenCard.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import FreeFormTextInput from "@/components/DataInput/FreeFormTextInput";
 import {
     errorExists,
@@ -59,6 +59,17 @@ const NumberChildrenCard: React.FC<ClientCardProps> = ({
     fieldSetter,
     fields,
 }) => {
+    useEffect(() => {
+        if (fields.numberOfChildren > fields.children.length) {
+            const newChildren = [...fields.children];
+            while (newChildren.length < fields.numberOfChildren) {
+                newChildren.push({});
+            }
+            fieldSetter({ children: newChildren });
+        } else if (fields.numberOfChildren < fields.children.length) {
+            fieldSetter({ children: fields.children.slice(0, fields.numberOfChildren) });
+        }
+    }, [fields.numberOfChildren, fields.children, fieldSetter]);
     return (
         <GenericFormCard
             title="Number of Children"
@@ -84,6 +95,9 @@ const NumberChildrenCard: React.FC<ClientCardProps> = ({
                     })}
                 />
                 {fields.children.map((child: Person, index: number) => {
+                    if (index >= fields.numberOfChildren) {
+                        return null;
+                    }
                     return (
                         <StyledCard key={child.primaryKey ?? `new-child-${index}`}>
                             <FormText>Child {index + 1}</FormText>

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -199,7 +199,8 @@ export const formatHouseholdFromFamilyDetails = (
     }
 
     const familyCategory = familyCountToFamilyCategory(family.length);
-    const occupantDisplay = `Occupant${adultCount + childCount > 1 ? "s" : ""}`;
+    const totalFamilyMembers = adultCount + childCount;
+    const occupantDisplay = `${totalFamilyMembers === 0 ? "" : "Occupant"}${totalFamilyMembers > 1 ? "s" : ""}`;
 
     return `${familyCategory} ${occupantDisplay} (${adultChildBreakdown.join(", ")})`;
 };

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -79,7 +79,7 @@ const getRawClientDetails = async (clientId: string) => {
 
 export const familyCountToFamilyCategory = (count: number): string => {
     if (count == 0) {
-        return "No family";
+        return "No Family";
     }
 
     if (count == 1) {

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -78,7 +78,11 @@ const getRawClientDetails = async (clientId: string) => {
 };
 
 export const familyCountToFamilyCategory = (count: number): string => {
-    if (count <= 1) {
+    if (count == 0) {
+        return "No family";
+    }
+
+    if (count == 1) {
         return "Single";
     }
 

--- a/src/app/clients/getExpandedClientDetails.ts
+++ b/src/app/clients/getExpandedClientDetails.ts
@@ -78,11 +78,11 @@ const getRawClientDetails = async (clientId: string) => {
 };
 
 export const familyCountToFamilyCategory = (count: number): string => {
-    if (count == 0) {
+    if (count === 0) {
         return "No Family";
     }
 
-    if (count == 1) {
+    if (count === 1) {
         return "Single";
     }
 
@@ -200,9 +200,14 @@ export const formatHouseholdFromFamilyDetails = (
 
     const familyCategory = familyCountToFamilyCategory(family.length);
     const totalFamilyMembers = adultCount + childCount;
-    const occupantDisplay = `${totalFamilyMembers === 0 ? "" : "Occupant"}${totalFamilyMembers > 1 ? "s" : ""}`;
+    const occupantDisplay =
+        totalFamilyMembers === 0 ? "" : `Occupant${totalFamilyMembers > 1 ? "s" : ""}`;
+    const breakdownString = adultChildBreakdown.join(", ");
 
-    return `${familyCategory} ${occupantDisplay} (${adultChildBreakdown.join(", ")})`;
+    if (breakdownString.length === 0) {
+        return familyCategory;
+    }
+    return `${familyCategory} ${occupantDisplay} (${breakdownString})`;
 };
 
 export const formatBreakdownOfAdultsFromFamilyDetails = (


### PR DESCRIPTION
## What's changed
Now, auto-fill saves properly the Number of Adults and Number of Children fields input when adding a client.
Updated the Family Size display logic on the Parcels/Clients page.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| https://github.com/user-attachments/assets/07796b90-7efb-4339-a6a4-177b299290d9 <br> <img width="926" height="1022" alt="Screenshot 2025-08-19 170236" src="https://github.com/user-attachments/assets/7d19cabb-df8e-456f-951c-63465df61335" /> <img width="1415" height="102" alt="Screenshot 2025-08-19 172328" src="https://github.com/user-attachments/assets/f2834ba7-c58f-4484-affa-81001fbea3ec" /> | https://github.com/user-attachments/assets/853780d7-68ff-44ff-ae72-f0402817e4f3 <br> <img width="939" height="1029" alt="Screenshot 2025-08-19 170346" src="https://github.com/user-attachments/assets/a935a058-9199-4c71-b58a-0b824da05147" /> <img width="1429" height="98" alt="Screenshot 2025-08-19 172300" src="https://github.com/user-attachments/assets/4c084e97-0d99-4651-9998-c9d0b5c6cb99" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

