### PR TITLE
VFB-448: Selected items with empty extra fields not included

### DIFF
--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -49,12 +49,13 @@ export const formatClientRecord = (
             fields.dietaryRequirements !== null
                 ? checkboxGroupToArray(fields.dietaryRequirements)
                 : null,
-        hygiene_tampons: fields.hygieneProductsTampons,
-        hygiene_pads: fields.hygieneProductsPads,
+        hygiene_tampons:
+            fields.hygieneProductsTampons !== null ? fields.hygieneProductsTampons : "",
+        hygiene_pads: fields.hygieneProductsPads !== null ? fields.hygieneProductsPads : "",
         hygiene_other_items: checkboxGroupToArray(fields.hygieneOtherItems),
-        baby_food: fields.babyFood,
-        baby_formula: fields.babyFormula,
-        baby_nappies: fields.babyNappies,
+        baby_food: fields.babyFood !== null ? fields.babyFood : "",
+        baby_formula: fields.babyFormula !== null ? fields.babyFormula : "",
+        baby_nappies: fields.babyNappies !== null ? fields.babyNappies : "",
         baby_other_items: checkboxGroupToArray(fields.babyOtherItems),
         pet_food: checkboxGroupToArray(fields.petFood),
         other_items: checkboxGroupToArray(fields.otherItems),


### PR DESCRIPTION
## What's changed
Now, selected items should always appear in the summary as long as the checkbox is ticked, regardless of whether the extra information field is filled or not

## Screenshots / Videos
### Before
https://github.com/user-attachments/assets/e5f6b6e1-2f83-4f60-aeaf-b0df681e2fab 

### After
https://github.com/user-attachments/assets/5cca1a52-2852-41c7-bfee-ff6e0e3b4ddd 

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
