### PR TITLE
VFB-496: Rename notes field in parcel details card

### DIFF
--- a/src/app/parcels/getExpandedParcelDetails.ts
+++ b/src/app/parcels/getExpandedParcelDetails.ts
@@ -173,7 +173,7 @@ const getExpandedParcelDetails = async (
                         rawParcelDetails.collection_datetime
                     ),
                     deliveryInstructions: client.delivery_instructions ?? "",
-                    notes: rawParcelDetails.notes ?? "",
+                    parcelNotes: rawParcelDetails.notes ?? "",
                     phoneNumber: client.phone_number ?? "",
                     email: client.email ?? "",
                     household: formatHouseholdFromFamilyDetails(client.family),
@@ -230,7 +230,7 @@ const getExpandedParcelDetails = async (
                 ),
                 listType: rawParcelDetails.list_type,
                 clientNotes: client.notes,
-                notes: rawParcelDetails.notes,
+                parcelNotes: rawParcelDetails.notes,
                 packingDateAndSlot: formatPackingDateAndSlot(
                     rawParcelDetails.packing_date,
                     rawParcelDetails.packing_slot?.name
@@ -256,7 +256,7 @@ interface ParcelDataIndependentOfClient extends Data {
     createdAt: string;
     listType: ListType;
     referralDetails: string;
-    notes: string | null;
+    parcelNotes: string | null;
 }
 
 interface ParcelDataForInactiveClient extends ParcelDataIndependentOfClient {


### PR DESCRIPTION
## What's changed
In `Parcel Details` card the `Notes` field has been renamed to `Parcel Notes`. This was made by changing the names in type in `getExpandedParcelDetails.ts`

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="871" height="937" alt="image" src="https://github.com/user-attachments/assets/b6390bf3-c145-49e7-b618-cc95c8901ac4" /> | <img width="872" height="995" alt="image" src="https://github.com/user-attachments/assets/bd039202-d4c6-42bc-b0cd-e592f7fc7435" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

