### PR TITLE
VFB-430: Multiline Input Border Fix

### DIFF
--- a/src/app/global_styles.tsx
+++ b/src/app/global_styles.tsx
@@ -6,12 +6,12 @@ import {
     Theme,
 } from "@mui/material";
 
-const GlobalStyle = createGlobalStyle`    
+const GlobalStyle = createGlobalStyle`
     * {
         box-sizing: border-box;
         margin: 0;
     }
-      
+
     html, body {
         height: auto;
         width: 100%;
@@ -24,7 +24,7 @@ const GlobalStyle = createGlobalStyle`
     }
 
     :root {
-      color-scheme: ${(props) => (props.theme.light ? "light" : "dark")}
+        color-scheme: ${(props) => (props.theme.light ? "light" : "dark")}
     }
 `;
 
@@ -113,11 +113,22 @@ const materialTheme = (chosenTheme: DefaultTheme): Theme =>
                     },
                 },
             },
+            MuiOutlinedInput: {
+                styleOverrides: {
+                    notchedOutline: {
+                        "& legend": {
+                            visibility: "visible",
+                        },
+                    },
+                },
+            },
         },
     });
+
 interface Props {
     children: React.ReactNode;
 }
+
 const MaterialAndGlobalStyle: React.FC<Props> = ({ children }) => {
     const chosenTheme = useTheme();
 


### PR DESCRIPTION
## What's changed
[VFB-430](https://softwiretech.atlassian.net/browse/VFB-430): Multiline Form Input Boxes now have their styling overridden to correctly display their hint text in the outline notch.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="137" height="70" alt="image" src="https://github.com/user-attachments/assets/c02d21bb-6638-4556-ba07-a1f62a67d8e4" />| <img width="289" height="122" alt="image" src="https://github.com/user-attachments/assets/64fe336d-0dbc-478b-9fc6-78dcbb72bb4b" />|

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`