### PR TITLE
VFB-522: Fixed invalid error for collection timeslots

### DIFF
--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -342,6 +342,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
                 ),
                 collectionSlot: switchErrorForCollectionSlot(
                     fields,
+                    collectionCentreIsActive,
                     collectionSlotsLabelsAndValues,
                     availableDaysForCentre
                 ),

--- a/src/app/parcels/form/submitFormHelpers.ts
+++ b/src/app/parcels/form/submitFormHelpers.ts
@@ -67,6 +67,7 @@ export function switchErrorForCollectionDate(
 
 export function switchErrorForCollectionSlot(
     fields: ParcelFields,
+    collectionCentreIsActive: boolean,
     collectionSlotsLabelsAndValues: CollectionTimeSlotsLabelsAndValues,
     availableDaysForCentre: DbAvailableDaysType
 ): Errors {
@@ -77,6 +78,7 @@ export function switchErrorForCollectionSlot(
 
     // The collection slot should be one of the available options for the centre
     if (
+        !collectionCentreIsActive ||
         !collectionSlotsLabelsAndValues.some(
             (slotLabelAndValue) => slotLabelAndValue[1] === fields.collectionSlot
         ) ||


### PR DESCRIPTION
## What's changed
[VFB-522](https://softwiretech.atlassian.net/browse/VFB-522?assignee=712020%3A6bec2b54-13b2-4f60-bfb1-44b31b4bfe1f) Marking a collection centre as inactive now generates the correct invalid error for the parcels' timeslot field.

## Screenshots / Videos
| Before     | After      |
|------------|------------|
| <img width="1090" height="559" alt="image" src="https://github.com/user-attachments/assets/2e3dc595-a0ef-4c3e-ab04-27b8e6a9579b" />| <img width="1087" height="572" alt="image" src="https://github.com/user-attachments/assets/bd3d8844-2919-4548-8ba3-9cae4b04969a" /> |

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`