### PR TITLE
VFB-504: Nullify Deleted Client Fields

### DIFF
--- a/supabase/migrations/20250909093351_add_email_field_to_anonymising_client_fn.sql
+++ b/supabase/migrations/20250909093351_add_email_field_to_anonymising_client_fn.sql
@@ -1,0 +1,48 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public."deactivateClient"(clientid uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$DECLARE
+    updated_family_id UUID;
+BEGIN
+UPDATE clients
+SET
+    full_name = null,
+    phone_number = null,
+    address_1 = null,
+    address_2 = null,
+    address_town = null,
+    address_county = null,
+    address_postcode = null,
+    delivery_instructions = null,
+    dietary_requirements = null,
+    pet_food = null,
+    other_items = null,
+    extra_information = null,
+    flagged_for_attention = null,
+    signposting_call_required = null,
+    is_active = false,
+    notes = null,
+    cooking_facilities = null,
+    signposting_call_reasons = null,
+    hygiene_tampons = null,
+    hygiene_pads = null,
+    hygiene_other_items = null,
+    baby_food = null,
+    baby_formula = null,
+    baby_nappies = null,
+    baby_other_items = null,
+    additional_phone_numbers = null,
+    email = null
+WHERE
+    primary_key = clientId;
+
+SELECT family_id INTO updated_family_id
+FROM clients
+WHERE primary_key = clientId;
+
+DELETE FROM families WHERE family_id = updated_family_id;
+
+END;$function$
+;


### PR DESCRIPTION
## What's changed
[VFB-504](https://softwiretech.atlassian.net/jira/software/c/projects/VFB/boards/1130?assignee=712020%3A6bec2b54-13b2-4f60-bfb1-44b31b4bfe1f&selectedIssue=VFB-504): The `deactivateClient()` function now nullifies all new client fields. 

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [x] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [x] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [x] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [x] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [x] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [x] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [x] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

