### PR TITLE
VFB-495: renamed most of the concurrency error messages

### DIFF
--- a/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
+++ b/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
@@ -2,7 +2,7 @@ import { PostgrestError } from "@supabase/supabase-js";
 import { Tables } from "@/databaseTypesFile";
 import { Schema } from "@/databaseUtils";
 import { DaysOfWeekType } from "@/common/databaseDaysOfWeek";
-import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId } from "@/logger/logger";
 import supabase from "@/supabaseClient";
 import { DbAvailableDaysType } from "@/common/fetch";
 
@@ -203,7 +203,7 @@ export const updateDbCollectionCentre = async (
     }
 
     if (count === 0) {
-        return { error: { type: "ConcurrentEditCollectionCentre", logId: null} };
+        return { error: { type: "ConcurrentEditCollectionCentre", logId: null } };
     }
 
     return { error: null };

--- a/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
+++ b/src/app/admin/collectionCentresTable/CollectionCentreActions.ts
@@ -177,7 +177,7 @@ export const insertNewCollectionCentre = async (
 export type UpdateCollectionCentreResult = {
     error: {
         type: "UpdateCollectionCentreFailed" | "ConcurrentEditCollectionCentre";
-        logId: string;
+        logId: string | null;
     } | null;
 };
 
@@ -203,8 +203,7 @@ export const updateDbCollectionCentre = async (
     }
 
     if (count === 0) {
-        const logId = await logWarningReturnLogId("Concurrent editing of collection centre");
-        return { error: { type: "ConcurrentEditCollectionCentre", logId } };
+        return { error: { type: "ConcurrentEditCollectionCentre", logId: null} };
     }
 
     return { error: null };

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -227,8 +227,7 @@ const CollectionCentresTable: React.FC = () => {
                     let message = `Failed to update the collection centre. Log ID: ${updateCollectionCentreError.logId}`;
 
                     if (updateCollectionCentreError.type === "ConcurrentEditCollectionCentre") {
-                        message =
-                            "Record has been edited recently - please refresh the page.";
+                        message = "Record has been edited recently - please refresh the page.";
                     }
                     setErrorMessage(message);
                     throw new Error(message);

--- a/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
+++ b/src/app/admin/collectionCentresTable/CollectionCentresTable.tsx
@@ -159,11 +159,13 @@ const CollectionCentresTable: React.FC = () => {
         );
 
         if (updateCollectionCentreError) {
-            await sendAuditLog({
-                ...baseAuditLog,
-                wasSuccess: false,
-                logId: updateCollectionCentreError.logId,
-            });
+            if (updateCollectionCentreError.type !== "ConcurrentEditCollectionCentre") {
+                await sendAuditLog({
+                    ...baseAuditLog,
+                    wasSuccess: false,
+                    logId: updateCollectionCentreError.logId ?? "",
+                });
+            }
             setIsLoading(false);
             return { error: updateCollectionCentreError };
         }
@@ -226,8 +228,7 @@ const CollectionCentresTable: React.FC = () => {
 
                     if (updateCollectionCentreError.type === "ConcurrentEditCollectionCentre") {
                         message =
-                            "Record has been edited recently - please refresh the page." +
-                            `Log ID: ${updateCollectionCentreError.logId}`;
+                            "Record has been edited recently - please refresh the page.";
                     }
                     setErrorMessage(message);
                     throw new Error(message);

--- a/src/app/admin/packingSlotsTable/PackingSlotActions.ts
+++ b/src/app/admin/packingSlotsTable/PackingSlotActions.ts
@@ -86,7 +86,7 @@ export const insertNewPackingSlot = async (
 type UpdatePackingSlotResult = {
     error: {
         type: "UpdatePackingSlotsFailed" | "ConcurrentEditPackingSlots";
-        logId: string;
+        logId: string | null;
     } | null;
 };
 
@@ -118,8 +118,7 @@ export const updateDbPackingSlot = async (
         return { error: { type: "UpdatePackingSlotsFailed", logId } };
     }
     if (count === 0) {
-        const logId = await logWarningReturnLogId("Concurrent editing of packing slots");
-        return { error: { type: "ConcurrentEditPackingSlots", logId } };
+        return { error: { type: "ConcurrentEditPackingSlots", logId: null } };
     }
 
     return { error: null };

--- a/src/app/admin/packingSlotsTable/PackingSlotActions.ts
+++ b/src/app/admin/packingSlotsTable/PackingSlotActions.ts
@@ -5,7 +5,7 @@ import {
 } from "@/app/admin/packingSlotsTable/PackingSlotsTable";
 import { DatabaseError } from "@/app/errorClasses";
 import { Tables } from "@/databaseTypesFile";
-import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId } from "@/logger/logger";
 import supabase from "@/supabaseClient";
 
 type DbPackingSlot = Tables<"packing_slots">;

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -214,17 +214,16 @@ const PackingSlotsTable: React.FC = () => {
 
                     if (updatePackingSlotError.type === "ConcurrentEditPackingSlots") {
                         message =
-                            "Record has been edited recently - please refresh the page." +
-                            `Log ID: ${updatePackingSlotError.logId}`;
+                            "Record has been edited recently - please refresh the page.";
+                    } else {
+                        void sendAuditLog({
+                            ...baseAuditLog,
+                            wasSuccess: false,
+                            logId: updatePackingSlotError.logId ?? "",
+                        });
                     }
 
                     setErrorMessage(message);
-
-                    void sendAuditLog({
-                        ...baseAuditLog,
-                        wasSuccess: false,
-                        logId: updatePackingSlotError.logId,
-                    });
 
                     throw new Error(message);
                 } else {

--- a/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
+++ b/src/app/admin/packingSlotsTable/PackingSlotsTable.tsx
@@ -213,8 +213,7 @@ const PackingSlotsTable: React.FC = () => {
                     let message = `Failed to update the packing slot. Log ID: ${updatePackingSlotError.logId}`;
 
                     if (updatePackingSlotError.type === "ConcurrentEditPackingSlots") {
-                        message =
-                            "Record has been edited recently - please refresh the page.";
+                        message = "Record has been edited recently - please refresh the page.";
                     } else {
                         void sendAuditLog({
                             ...baseAuditLog,

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -81,7 +81,10 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
             const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
             if (error) {
                 setErrorMessage(
-                    error.type === "concurrentEdit" ? `Record has been edited recently - please refresh the page.` : `Failed to fetch Client Details, please refresh.`);
+                    error.type === "concurrentEdit"
+                        ? "Record has been edited recently - please refresh the page."
+                        : "Failed to fetch Client Details, please refresh."
+                );
                 setNotes(originalNotes);
             } else {
                 setNotes(notes);

--- a/src/app/clients/ExpandedClientDetails.tsx
+++ b/src/app/clients/ExpandedClientDetails.tsx
@@ -81,8 +81,7 @@ const ExpandedClientDetails: React.FC<Props> = ({ clientId, displayClientsParcel
             const { error } = await updateClientNotes(clientId, notes, clientDetails?.lastUpdated);
             if (error) {
                 setErrorMessage(
-                    `Record has been edited recently - please refresh the page. Log ID: ${error.logId}`
-                );
+                    error.type === "concurrentEdit" ? `Record has been edited recently - please refresh the page.` : `Failed to fetch Client Details, please refresh.`);
                 setNotes(originalNotes);
             } else {
                 setNotes(notes);

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -190,6 +190,11 @@ const ClientForm: React.FC<Props> = ({
                             `Update failed, please refresh. If the error persists, the client may have been deleted. Log ID: ${editClientError.logId}`
                         );
                         break;
+                    case "concurrentEdit":
+                        setSubmitErrorMessage(
+                            "Record has been edited recently - please refresh the page."
+                        );
+                        break;
                 }
                 setSubmitDisabled(false);
                 return;

--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -1,7 +1,7 @@
 import { InsertSchema, UpdateSchema } from "@/databaseUtils";
 import { checkboxGroupToArray, Person } from "@/components/Form/formFunctions";
 import supabase from "@/supabaseClient";
-import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId } from "@/logger/logger";
 import { ClientFields } from "./ClientForm";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 import { ListType } from "@/common/databaseListTypes";
@@ -115,7 +115,7 @@ type editClientResult =
     | { clientId: string; error: null }
     | {
           clientId: null;
-          error: { type: editClientErrors; logId: string | null} | null;
+          error: { type: editClientErrors; logId: string | null } | null;
       };
 
 export const submitEditClientForm = async (

--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -110,12 +110,12 @@ export const submitAddClientForm = async (fields: ClientFields): Promise<addClie
     return { clientId: clientId, error: null };
 };
 
-type editClientErrors = "failedToUpdateClientAndFamily" | "noRowsUpdated";
+type editClientErrors = "failedToUpdateClientAndFamily" | "noRowsUpdated" | "concurrentEdit";
 type editClientResult =
     | { clientId: string; error: null }
     | {
           clientId: null;
-          error: { type: editClientErrors; logId: string } | null;
+          error: { type: editClientErrors; logId: string | null} | null;
       };
 
 export const submitEditClientForm = async (
@@ -154,11 +154,7 @@ export const submitEditClientForm = async (
     }
 
     if (clientDataAndCount.updatedrows === 0) {
-        const logId = await logWarningReturnLogId(
-            "Concurrent editing of client or editing deleted client"
-        );
-        await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-        return { clientId: null, error: { type: "noRowsUpdated", logId } };
+        return { clientId: null, error: { type: "concurrentEdit", logId: null } };
     }
 
     await sendAuditLog({

--- a/src/app/clients/updateClientNotes.ts
+++ b/src/app/clients/updateClientNotes.ts
@@ -4,7 +4,8 @@ import supabase from "@/supabaseClient";
 
 type UpdateClientNotesResponse =
     | { error: null }
-    | { error: { type: "updateNotesFailed"; logId: string } };
+    | { error: { type: "updateNotesFailed"; logId: string } }
+    | { error: { type: "concurrentEdit" } };
 
 export const updateClientNotes = async (
     clientId: string,
@@ -30,9 +31,7 @@ export const updateClientNotes = async (
     }
 
     if (count === 0) {
-        const logId = await logWarningReturnLogId("Concurrent editing of parcel");
-        await sendAuditLog({ ...baseAuditLogProps, wasSuccess: false, logId });
-        return { error: { type: "updateNotesFailed", logId } };
+        return { error: { type: "concurrentEdit" } };
     }
 
     await sendAuditLog({ ...baseAuditLogProps, wasSuccess: true });

--- a/src/app/clients/updateClientNotes.ts
+++ b/src/app/clients/updateClientNotes.ts
@@ -1,4 +1,4 @@
-import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId } from "@/logger/logger";
 import { sendAuditLog } from "@/server/auditLog";
 import supabase from "@/supabaseClient";
 

--- a/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/CommonDateAndSlot.tsx
@@ -7,7 +7,6 @@ import supabase from "@/supabaseClient";
 import { PostgrestSingleResponse } from "@supabase/supabase-js";
 
 export const getUpdateErrorMessage = ({
-    parcelId,
     error,
 }: {
     parcelId: string | null;
@@ -31,7 +30,7 @@ export const getUpdateErrorMessage = ({
     if (errorMessage === "") {
         return;
     }
-    return `${errorMessage} Parcel Id: ${parcelId} Log Id: ${error?.logId}`;
+    return errorMessage;
 };
 
 type UpdateField = "packingDate" | "packingSlot";

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -199,7 +199,7 @@ const parcelModalRouterPath = (parcelId: string): string => `/parcels?parcelId=$
 
 const databaseErrorMessageFromErrorType = (
     errorType: WriteParcelToDatabaseErrors,
-    logId: string
+    logId: string | null,
 ): string => {
     switch (errorType) {
         case "failedToInsertParcel":
@@ -209,7 +209,7 @@ const databaseErrorMessageFromErrorType = (
         case "failedToUpdateDeliveryInstructions":
             return `Failed to update delivery instructions. Log ID: ${logId}`;
         case "concurrentUpdateConflict":
-            return `Record has been edited recently - please refresh the page. LogID: ${logId}`;
+            return `Record has been edited recently - please refresh the page.`;
     }
 };
 

--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -199,7 +199,7 @@ const parcelModalRouterPath = (parcelId: string): string => `/parcels?parcelId=$
 
 const databaseErrorMessageFromErrorType = (
     errorType: WriteParcelToDatabaseErrors,
-    logId: string | null,
+    logId: string | null
 ): string => {
     switch (errorType) {
         case "failedToInsertParcel":
@@ -209,7 +209,7 @@ const databaseErrorMessageFromErrorType = (
         case "failedToUpdateDeliveryInstructions":
             return `Failed to update delivery instructions. Log ID: ${logId}`;
         case "concurrentUpdateConflict":
-            return `Record has been edited recently - please refresh the page.`;
+            return "Record has been edited recently - please refresh the page.";
     }
 };
 

--- a/src/app/parcels/form/submitFormHelpers.ts
+++ b/src/app/parcels/form/submitFormHelpers.ts
@@ -130,7 +130,7 @@ type UpdateParcelErrorType =
     | "failedToUpdateParcel"
     | "failedToUpdateDeliveryInstructions"
     | "concurrentUpdateConflict";
-export type UpdateParcelError = { type: UpdateParcelErrorType; logId: string };
+export type UpdateParcelError = { type: UpdateParcelErrorType; logId: string | null };
 type UpdateParcelReturnType = {
     error: UpdateParcelError | null;
     parcelId: string | null;
@@ -179,9 +179,7 @@ export const updateParcel: UpdateParcelWithPrimaryKey =
         const { rows_updated } = parcelDataAndCount[0];
 
         if (rows_updated === 0) {
-            const logId = await logWarningReturnLogId("Concurrent editing of parcel");
-            await sendAuditLog({ ...auditLog, wasSuccess: false, logId });
-            return { parcelId: null, error: { type: "concurrentUpdateConflict", logId } };
+            return { parcelId: null, error: { type: "concurrentUpdateConflict", logId: null } };
         }
 
         await sendAuditLog({ ...auditLog, wasSuccess: true });

--- a/src/app/parcels/form/submitFormHelpers.ts
+++ b/src/app/parcels/form/submitFormHelpers.ts
@@ -1,6 +1,6 @@
 import supabase from "@/supabaseClient";
 import { InsertSchema, UpdateSchema } from "@/databaseUtils";
-import { logErrorReturnLogId, logWarningReturnLogId } from "@/logger/logger";
+import { logErrorReturnLogId } from "@/logger/logger";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 import { Errors } from "@/components/Form/formFunctions";
 import { ParcelFields } from "@/app/parcels/form/ParcelForm";


### PR DESCRIPTION
## What's changed

- Rewrote the concurrency error messages to 'Record has been edited recently - please refresh the page.', not containing a logId.
- Concurrency errors now don't create audit logs or use logWarning or logError

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
