### PR TITLE
#789: Discard stale data fetches

### DIFF
--- a/src/app/admin/usersTable/UsersTable.tsx
+++ b/src/app/admin/usersTable/UsersTable.tsx
@@ -40,6 +40,7 @@ const UsersTable: React.FC = () => {
     const endIndex = currentPage * userCountPerPage - 1;
 
     const usersTableFetchAbortController = useRef<AbortController | null>(null);
+    const latestFetchRequestId = useRef<number>(0);
 
     const [tableAlertOptions, setTableAlertOptions] = useState<AlertOptions>({
         success: undefined,
@@ -56,24 +57,26 @@ const UsersTable: React.FC = () => {
 
     const fetchAndDisplayUserData = useCallback(async () => {
         setIsLoading(true);
+
+        latestFetchRequestId.current += 1;
+        const currentFetchRequestId = latestFetchRequestId.current;
+
         if (usersTableFetchAbortController.current) {
             usersTableFetchAbortController.current.abort("stale request");
         }
-
         usersTableFetchAbortController.current = new AbortController();
 
-        if (usersTableFetchAbortController.current) {
-            setErrorMessage(null);
+        setErrorMessage(null);
+        const { data, error } = await getUsersDataAndCount(
+            supabase,
+            startIndex,
+            endIndex,
+            primaryFilters,
+            sortState,
+            usersTableFetchAbortController.current.signal
+        );
 
-            const { data, error } = await getUsersDataAndCount(
-                supabase,
-                startIndex,
-                endIndex,
-                primaryFilters,
-                sortState,
-                usersTableFetchAbortController.current.signal
-            );
-
+        if (currentFetchRequestId === latestFetchRequestId.current) {
             if (error) {
                 switch (error.type) {
                     case "abortedFetchingProfilesTable":
@@ -102,6 +105,7 @@ const UsersTable: React.FC = () => {
                 setCurrentUserId(currentUser.id);
             }
         }
+
         usersTableFetchAbortController.current = null;
         setIsLoading(false);
     }, [startIndex, endIndex, primaryFilters, sortState]);

--- a/src/app/clients/clientsTable/ClientsPage.tsx
+++ b/src/app/clients/clientsTable/ClientsPage.tsx
@@ -42,13 +42,14 @@ const ClientsPage: React.FC = () => {
     const [sortState, setSortState] = useState<ClientsSortState>({ sortEnabled: false });
     const [primaryFilters, setPrimaryFilters] = useState<ClientsFilter[]>(clientsFilters);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    const clientTableFetchAbortController = useRef<AbortController | null>(null);
     const [isSelectedClientActive, setIsSelectedClientActive] = useState<boolean | null>(null);
     const [isClientActiveErrorMessage, setIsClientActiveErrorMessage] = useState<string | null>(
         null
     );
     const [deleteClientErrorMessage, setDeleteClientErrorMessage] = useState<string | null>(null);
     const [isDeleteClientDialogOpen, setIsDeleteClientDialogOpen] = useState<boolean>(false);
+    const clientTableFetchAbortController = useRef<AbortController | null>(null);
+    const latestFetchRequestId = useRef<number>(0);
 
     const [perPage, setPerPage] = useState(10);
     const [currentPage, setCurrentPage] = useState(1);
@@ -57,21 +58,26 @@ const ClientsPage: React.FC = () => {
 
     const fetchAndDisplayClientsData = useCallback(async () => {
         setIsLoading(true);
+
+        latestFetchRequestId.current += 1;
+        const currentFetchRequestId = latestFetchRequestId.current;
+
         if (clientTableFetchAbortController.current) {
             clientTableFetchAbortController.current.abort("stale request");
         }
         clientTableFetchAbortController.current = new AbortController();
-        if (clientTableFetchAbortController.current) {
-            setErrorMessage(null);
-            const { data, error } = await getClientsDataAndCount(
-                supabase,
-                startPoint,
-                endPoint,
-                primaryFilters,
-                sortState,
-                clientTableFetchAbortController.current.signal
-            );
 
+        setErrorMessage(null);
+        const { data, error } = await getClientsDataAndCount(
+            supabase,
+            startPoint,
+            endPoint,
+            primaryFilters,
+            sortState,
+            clientTableFetchAbortController.current.signal
+        );
+
+        if (currentFetchRequestId === latestFetchRequestId.current) {
             if (error) {
                 switch (error.type) {
                     case "abortedFetchingClientsTable":
@@ -87,10 +93,11 @@ const ClientsPage: React.FC = () => {
                 setClientsDataPortion(data.clientData);
                 setFilteredClientCount(data.count);
             }
-            clientTableFetchAbortController.current = null;
-            setIsLoading(false);
-            setIsLoadingForFirstTime(false);
         }
+
+        clientTableFetchAbortController.current = null;
+        setIsLoading(false);
+        setIsLoadingForFirstTime(false);
     }, [startPoint, endPoint, primaryFilters, sortState]);
 
     useEffect(() => {

--- a/src/app/lists/ListsPage.tsx
+++ b/src/app/lists/ListsPage.tsx
@@ -108,6 +108,7 @@ const ListsPage: React.FC = () => {
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const listsTableFetchAbortController = useRef<AbortController | null>(null);
     const [primaryFilters, setPrimaryFilters] = useState<ListFilter[]>(filters);
+    const latestFetchRequestId = useRef<number>(0);
 
     function handleSetError(error: string | null): void {
         setErrorMessage(error);
@@ -115,13 +116,19 @@ const ListsPage: React.FC = () => {
 
     const fetchAndSetData = useCallback(async (): Promise<void> => {
         setIsLoading(true);
+
+        latestFetchRequestId.current += 1;
+        const currentFetchRequestId = latestFetchRequestId.current;
+
         if (listsTableFetchAbortController.current) {
             listsTableFetchAbortController.current.abort("stale request");
         }
         listsTableFetchAbortController.current = new AbortController();
-        if (listsTableFetchAbortController.current) {
-            setErrorMessage(null);
-            const { data, error } = await fetchListsData();
+
+        setErrorMessage(null);
+        const { data, error } = await fetchListsData();
+
+        if (currentFetchRequestId === latestFetchRequestId.current) {
             if (error) {
                 setIsLoading(false);
                 setErrorMessage(getErrorMessage(error));
@@ -130,9 +137,10 @@ const ListsPage: React.FC = () => {
 
             setListData(formatListData(data.listsData));
             setComment(data.comment);
-            listsTableFetchAbortController.current = null;
-            setIsLoading(false);
         }
+
+        listsTableFetchAbortController.current = null;
+        setIsLoading(false);
     }, [setIsLoading, setErrorMessage, setListData, setComment]);
 
     useEffect(() => {

--- a/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/SlotChangeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import GeneralActionModal, {
     ActionModalProps,
     Heading,
@@ -84,18 +84,22 @@ const SlotChangeModal: React.FC<ActionModalProps> = (props) => {
     const [displayModal, setDisplayModal] = useState<boolean>(true);
     const [warningMessage, setWarningMessage] = useState<string>("");
 
-    (async () => {
-        const { data: packingSlotsData, error: packingSlotsError } =
-            await fetchPackingSlotsInfo(supabase);
-        if (packingSlotsError) {
-            setErrorMessage(
-                `Failed to fetch packing slots data. Log Id: ${packingSlotsError.logId}`
-            );
-            setDisplayModal(false);
-            return;
-        }
-        setPackingSlots(packingSlotsData);
-    })();
+    useEffect(() => {
+        (async () => {
+            const { data: packingSlotsData, error: packingSlotsError } =
+                await fetchPackingSlotsInfo(supabase);
+
+            if (packingSlotsError) {
+                setErrorMessage(
+                    `Failed to fetch packing slots data. Log Id: ${packingSlotsError.logId}`
+                );
+                setDisplayModal(false);
+                return;
+            }
+
+            setPackingSlots(packingSlotsData);
+        })();
+    }, []);
 
     const onSlotSubmit = async (): Promise<void> => {
         if (slot === "") {

--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -137,11 +137,14 @@ const ParcelsPage: React.FC = () => {
     };
 
     const setIsPackingManagerViewInternal = (isPackingManager: boolean): void => {
-        const viewFilter = primaryFilters.find((filter) => filter.key === pageViewTypeQueryParam);
-        if (viewFilter) {
-            viewFilter.state = isPackingManager ? pageViewTypePackingManager : "";
-        }
-
+        setPrimaryFilters(
+            (prevFilters) =>
+                prevFilters.map((filter) =>
+                    filter.key === pageViewTypeQueryParam
+                        ? { ...filter, state: isPackingManager ? pageViewTypePackingManager : "" }
+                        : filter
+                ) as ParcelsFilters
+        );
         setIsPackingManagerView(isPackingManager);
     };
 

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -77,17 +77,12 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         latestFetchRequestId.current += 1;
         const currentFetchRequestId = latestFetchRequestId.current;
 
-        console.log("QQ: Fetching parcels data with request ID:", currentFetchRequestId);
-
         if (parcelsTableFetchAbortController.current) {
-            console.log(`QQ: Aborting previous fetch request (${currentFetchRequestId - 1})`);
             parcelsTableFetchAbortController.current.abort("stale request");
         }
-
         parcelsTableFetchAbortController.current = new AbortController();
 
         setErrorMessage(null);
-
         const { data, error } = await getParcelsTableDataAndAllIds(
             supabase,
             appliedFilters,
@@ -99,18 +94,11 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
 
         if (currentFetchRequestId === latestFetchRequestId.current) {
             if (error) {
-                console.log(
-                    `QQ: Fetch request (${currentFetchRequestId}) encountered an error:`,
-                    error
-                );
-
                 const newErrorMessage = getParcelDataErrorMessage(error.type);
                 if (newErrorMessage !== null) {
                     setErrorMessage(`${newErrorMessage} Log ID: ${error.logId}`);
                 }
             } else {
-                console.log(`QQ: Fetch request (${currentFetchRequestId}) completed successfully`);
-
                 setParcelsDataPortion(data.parcelTableRows);
                 setFilteredParcelCount(data.allParcelIds.length);
                 setAllFilteredParcelIds(data.allParcelIds);
@@ -129,9 +117,6 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                     );
                 }
             }
-        } else {
-            // QQ If this fetch was stale, we don't want to update the state
-            console.log(`QQ: Fetch request (${currentFetchRequestId}) was stale, ignoring results`);
         }
 
         parcelsTableFetchAbortController.current = null;

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -71,32 +71,46 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
     const endPoint = currentPage * parcelCountPerPage - 1;
 
     const parcelsTableFetchAbortController = useRef<AbortController | null>(null);
+    const latestFetchRequestId = useRef<number>(0);
 
     const fetchAndDisplayParcelsData = useCallback(async (): Promise<void> => {
+        latestFetchRequestId.current += 1;
+        const currentFetchRequestId = latestFetchRequestId.current;
+
+        console.log("QQ: Fetching parcels data with request ID:", currentFetchRequestId);
+
         if (parcelsTableFetchAbortController.current) {
+            console.log(`QQ: Aborting previous fetch request (${currentFetchRequestId - 1})`);
             parcelsTableFetchAbortController.current.abort("stale request");
         }
 
         parcelsTableFetchAbortController.current = new AbortController();
 
-        if (parcelsTableFetchAbortController.current) {
-            setErrorMessage(null);
+        setErrorMessage(null);
 
-            const { data, error } = await getParcelsTableDataAndAllIds(
-                supabase,
-                appliedFilters,
-                sortState,
-                parcelsTableFetchAbortController.current.signal,
-                startPoint,
-                endPoint
-            );
+        const { data, error } = await getParcelsTableDataAndAllIds(
+            supabase,
+            appliedFilters,
+            sortState,
+            parcelsTableFetchAbortController.current.signal,
+            startPoint,
+            endPoint
+        );
 
+        if (currentFetchRequestId === latestFetchRequestId.current) {
             if (error) {
+                console.log(
+                    `QQ: Fetch request (${currentFetchRequestId}) encountered an error:`,
+                    error
+                );
+
                 const newErrorMessage = getParcelDataErrorMessage(error.type);
                 if (newErrorMessage !== null) {
                     setErrorMessage(`${newErrorMessage} Log ID: ${error.logId}`);
                 }
             } else {
+                console.log(`QQ: Fetch request (${currentFetchRequestId}) completed successfully`);
+
                 setParcelsDataPortion(data.parcelTableRows);
                 setFilteredParcelCount(data.allParcelIds.length);
                 setAllFilteredParcelIds(data.allParcelIds);
@@ -115,10 +129,13 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
                     );
                 }
             }
-
-            parcelsTableFetchAbortController.current = null;
-            setIsLoading(false);
+        } else {
+            // QQ If this fetch was stale, we don't want to update the state
+            console.log(`QQ: Fetch request (${currentFetchRequestId}) was stale, ignoring results`);
         }
+
+        parcelsTableFetchAbortController.current = null;
+        setIsLoading(false);
     }, [appliedFilters, endPoint, sortState, startPoint, setErrorMessage]);
 
     useEffect(() => {


### PR DESCRIPTION
## What's changed
If the results of a slow data fetch come in after a table has already been updated from a subsequent quicker fetch, then the stale results are ignored. Previously the table data was updated with the stale content.

Also did a couple of other fixes I found along the way:
- Make the Packing Manager View filter immutable
- Fix Packing Slot modal code that should have been in a useEffect

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
