### PR TITLE
#697: Rebuild Packing Manager primary filters immutably

### DIFF
--- a/src/app/parcels/parcelsTable/ParcelsPage.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.tsx
@@ -142,7 +142,7 @@ const ParcelsPage: React.FC = () => {
                 prevFilters.map((filter) =>
                     filter.key === pageViewTypeQueryParam
                         ? { ...filter, state: isPackingManager ? pageViewTypePackingManager : "" }
-                        : filter
+                        : { ...filter }
                 ) as ParcelsFilters
         );
         setIsPackingManagerView(isPackingManager);


### PR DESCRIPTION
## What's changed
Fixes a bug where some filters for the Packing Manager view were being reused rather than rebuilt, so immutability wasn't respected.

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
