### PR TITLE
VFB-532: Fix Cypress tests for delivery areas and apply postcode sorting more widely

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ REPLACE_THIS_LINE
 - [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
 - [ ] I have documented the testing steps for QA
 - [ ] I have self-reviewed this PR
+- [ ] I have checked that any E2E tests do not assume that the database contains specific data, unless set by migration
 - [ ] Make sure you've verified it works via `npm run dev`
 - [ ] Make sure you've verified it works via `npm run build` and `npm run start`
 - [ ] Make sure you've fixed all linting problems with `npm run lint_fix`

--- a/cypress/e2e/admin/deliveryAreas.cy.ts
+++ b/cypress/e2e/admin/deliveryAreas.cy.ts
@@ -5,17 +5,6 @@ describe("Edit delivery areas on admins page", () => {
         cy.visit("/admin");
     });
 
-    it("Displays delivery areas in ascending order", () => {
-        toggleDeliveryAreaNameSection();
-        verifyDeliveryAreasOrder("ascending");
-    });
-
-    it("Displays delivery areas in descending order", () => {
-        toggleDeliveryAreaNameSection();
-        orderDeliveryAreas();
-        verifyDeliveryAreasOrder("descending");
-    });
-
     it("Adds a new delivery area successfully", () => {
         toggleDeliveryAreaNameSection();
 
@@ -27,7 +16,7 @@ describe("Edit delivery areas on admins page", () => {
 
         cy.get('div[aria-label="Delivery Areas Table"]') // eslint-disable-line quotes
             .find(newDeliveryArea)
-            .should("not.exist"); // If this fails then the random UUID is already there
+            .should("not.exist"); // If this fails then the postcode is already there
 
         startAddingNewDeliveryArea();
 
@@ -44,11 +33,23 @@ describe("Edit delivery areas on admins page", () => {
     it("Tries to add a duplicate delivery area and fails", () => {
         toggleDeliveryAreaNameSection();
 
-        const existingDeliveryArea = "CR0";
+        const indexOfPostcodeToDuplicate = 3;
+        cy.get('div[aria-label="Delivery Areas Table"]') // eslint-disable-line quotes
+            .find(".MuiDataGrid-row", { timeout: 5000 })
+            .should("have.length.greaterThan", indexOfPostcodeToDuplicate);
 
-        startAddingNewDeliveryArea();
-        fillOutNewDeliveryAreaAndSave(existingDeliveryArea);
-        cy.get('[role="alert"]').should("contain", "already"); // eslint-disable-line quotes
+        cy.get('div[aria-label="Delivery Areas Table"]') // eslint-disable-line quotes
+            .find('[role="row"]') // eslint-disable-line quotes
+            .eq(indexOfPostcodeToDuplicate)
+            .find('[data-field="postcode"]') // eslint-disable-line quotes
+            .invoke("text")
+            .then((text) => {
+                const existingDeliveryArea = text.trim();
+
+                startAddingNewDeliveryArea();
+                fillOutNewDeliveryAreaAndSave(existingDeliveryArea);
+                cy.get('[role="alert"]').should("contain", "already"); // eslint-disable-line quotes
+            });
     });
 
     it("Tries to add an empty delivery area and fails", () => {
@@ -96,6 +97,7 @@ describe("Edit delivery areas on admins page", () => {
 const editDeliveryAreaNameText = "edit delivery areas";
 
 function toggleDeliveryAreaNameSection(): void {
+    cy.wait("@getDeliveryAreas");
     cy.contains(editDeliveryAreaNameText, { matchCase: false }).click();
 }
 
@@ -115,7 +117,6 @@ const fillOutNewDeliveryAreaAndSave = (newDeliveryAreaName: string): void => {
 };
 
 const startAddingNewDeliveryArea = (): void => {
-    cy.wait("@getDeliveryAreas");
     cy.get('div[aria-label="Delivery Areas Table"]') // eslint-disable-line quotes
         .find('[data-testid="AddIcon"]') // eslint-disable-line quotes
         .click();
@@ -126,34 +127,6 @@ const orderDeliveryAreas = (): void => {
         .find('[data-testid="ArrowUpwardIcon"]') // eslint-disable-line quotes
         .click({ force: true });
 };
-
-function verifyDeliveryAreasOrder(order: "ascending" | "descending"): void {
-    const expectedPostcodes = [
-        "CR0",
-        "CR7",
-        "SE1",
-        "SE11",
-        "SE19",
-        "SE21",
-        "SE24",
-        "SE25",
-        "SE27",
-        "SE5",
-        "SW12",
-        "SW16",
-        "SW2",
-        "SW4",
-        "SW8",
-        "SW9",
-    ];
-
-    const orderedPostcodes =
-        order === "descending" ? [...expectedPostcodes].reverse() : expectedPostcodes;
-
-    orderedPostcodes.forEach((postcode, index) => {
-        assertDeliveryAreaAtRow({ rowIndex: index, deliveryAreaName: postcode });
-    });
-}
 
 function assertDeliveryAreaAtRow({
     rowIndex,

--- a/cypress/e2e/admin/deliveryAreas.cy.ts
+++ b/cypress/e2e/admin/deliveryAreas.cy.ts
@@ -121,23 +121,3 @@ const startAddingNewDeliveryArea = (): void => {
         .find('[data-testid="AddIcon"]') // eslint-disable-line quotes
         .click();
 };
-
-const orderDeliveryAreas = (): void => {
-    cy.get('div[aria-label="Delivery Areas Table"]') // eslint-disable-line quotes
-        .find('[data-testid="ArrowUpwardIcon"]') // eslint-disable-line quotes
-        .click({ force: true });
-};
-
-function assertDeliveryAreaAtRow({
-    rowIndex,
-    deliveryAreaName,
-}: {
-    rowIndex: number;
-    deliveryAreaName: string;
-}): void {
-    cy.contains(editDeliveryAreaNameText, { matchCase: false })
-        .parents(".MuiPaper-root")
-        .find(`[data-rowindex="${rowIndex}"]`)
-        .find('[data-field="postcode"]') // eslint-disable-line quotes
-        .should("contain.text", deliveryAreaName);
-}

--- a/src/app/parcels/parcelsTable/sortableColumns.ts
+++ b/src/app/parcels/parcelsTable/sortableColumns.ts
@@ -13,7 +13,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("packing_slot_order")
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -26,7 +26,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("packing_slot_order")
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -51,7 +51,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("packing_slot_order")
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -64,7 +64,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("packing_slot_order")
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -77,7 +77,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -89,7 +89,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("packing_date")
                 .order("packing_slot_order")
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -101,7 +101,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
                 .order("client_is_active", { ascending: false })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -113,7 +113,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -126,7 +126,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
     {
@@ -139,7 +139,7 @@ const parcelsSortableColumns: SortOptions<ParcelsTableRow, ParcelsSortMethod>[] 
                 .order("is_delivery", { ascending: false })
                 .order("collection_centre_name")
                 .order("client_is_active", { ascending: sortDirection !== "asc" })
-                .order("client_address_postcode")
+                .order("sorted_client_address_postcode")
                 .order("parcel_id"),
     },
 ];


### PR DESCRIPTION
## What's changed
The Cypress tests for Delivery Areas previously assumed that the database would have specific postcodes in it, and failed otherwise. 
Also the client postcode sortable version is now used in all sorting methods in the Parcels table.

## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
