### PR TITLE
#790: Server-side default timestamps for status changes, with override for Admins/Managers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ jobs:
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{secrets.SUPABASE_LOCAL_ANON_KEY}}
       NEXT_PUBLIC_CYPRESS_TEST_USER: admin@example.com
       NEXT_PUBLIC_CYPRESS_TEST_PASS: admin123
+      NEXT_PUBLIC_CYPRESS_TEST_ADMIN_USER: admin@example.com
+      NEXT_PUBLIC_CYPRESS_TEST_ADMIN_PASS: admin123
+      NEXT_PUBLIC_CYPRESS_TEST_STAFF_USER: staff@example.com
+      NEXT_PUBLIC_CYPRESS_TEST_STAFF_PASS: staff123
       NEXT_PUBLIC_ENVIRONMENT: test
     steps:
       - name: Checkout this repo

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,17 +19,35 @@ export default defineConfig({
             });
 
             if (
-                process.env.NEXT_PUBLIC_CYPRESS_TEST_USER === null ||
-                process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS === null
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_USER === undefined ||
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS === undefined
             ) {
                 throw new Error(
                     "CYPRESS_TEST_USER and CYPRESS_TEST_PASS must be set in .env.local"
+                );
+            } else if (
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_ADMIN_USER === undefined ||
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_ADMIN_PASS === undefined
+            ) {
+                throw new Error(
+                    "CYPRESS_TEST_ADMIN_USER and CYPRESS_TEST_ADMIN_PASS must be set in .env.local"
+                );
+            } else if (
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_STAFF_USER === undefined ||
+                process.env.NEXT_PUBLIC_CYPRESS_TEST_STAFF_PASS === undefined
+            ) {
+                throw new Error(
+                    "CYPRESS_TEST_STAFF_USER and CYPRESS_TEST_STAFF_PASS must be set in .env.local"
                 );
             }
 
             config.env = {
                 TEST_USER: process.env.NEXT_PUBLIC_CYPRESS_TEST_USER,
                 TEST_PASS: process.env.NEXT_PUBLIC_CYPRESS_TEST_PASS,
+                TEST_ADMIN_USER: process.env.NEXT_PUBLIC_CYPRESS_TEST_ADMIN_USER,
+                TEST_ADMIN_PASS: process.env.NEXT_PUBLIC_CYPRESS_TEST_ADMIN_PASS,
+                TEST_STAFF_USER: process.env.NEXT_PUBLIC_CYPRESS_TEST_STAFF_USER,
+                TEST_STAFF_PASS: process.env.NEXT_PUBLIC_CYPRESS_TEST_STAFF_PASS,
             };
 
             return config;

--- a/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
+++ b/cypress/e2e/parcels/parcelsPageUrlParams.cy.ts
@@ -89,7 +89,8 @@ describe("Parcels page url params", () => {
     it.skip("URL params are updated when a parcel is opened", () => {
         cy.get("[id='cell-fullName-0']").click();
 
-        cy.get("[id='expandedParcelDetailsModal']").should("be.visible");
+        cy.get('div[data-testid="ParcelDetailsModal"]') // eslint-disable-line quotes
+            .should("be.visible");
 
         // This should have the parcel ID
         cy.url().should("include", "parcelId=");

--- a/cypress/e2e/parcels/statusesModal.cy.ts
+++ b/cypress/e2e/parcels/statusesModal.cy.ts
@@ -1,0 +1,129 @@
+/* eslint-disable quotes */
+import dayjs from "dayjs";
+
+describe("Apply status modal for parcels", () => {
+    it("submits an overridden timestamp for admins", () => {
+        // The overridden date is based on the current date so the tests can be run repeatedly on the same db
+        const overriddenDateTime = dayjs()
+            .subtract(3, "days")
+            .subtract(2, "hours")
+            .add(30, "minutes");
+        const expectedEventDateTime = overriddenDateTime.format("DD/MM/YYYY, HH:mm:00");
+        const statusToApply = "Called and Confirmed";
+
+        cy.loginAsAdmin();
+        cy.visit("/parcels");
+
+        // Add status to the first parcel in the table
+        cy.get("div[data-testid='ParcelsTable']")
+            .find("#row-0")
+            .find('input[type="checkbox"]')
+            .first()
+            .check();
+
+        cy.get("#status-button").click();
+        cy.get('li[role="menuitem"]').contains(statusToApply).click();
+
+        cy.get('div[data-testid="StatusesModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get('[data-testid="OverrideDateTimeCheckbox"]').click();
+
+                const dateTimeTextString = overriddenDateTime.format("DD/MM/YYYYHH:mm");
+                cy.get('input[type="text"]').type(dateTimeTextString);
+
+                cy.get("button").contains("Submit").click();
+            });
+
+        cy.get('div[data-testid="StatusesModal"]').should("not.exist");
+
+        // Open the details modal for the first parcel and look for overridden status timestamp
+        cy.get("div[data-testid='ParcelsTable']").find("#row-0").click();
+        cy.get('div[data-testid="ParcelDetailsModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get("div[data-testid='EventTable'] [role='row']")
+                    .filter(`:contains('${statusToApply}')`)
+                    .filter(`:contains('${expectedEventDateTime}')`)
+                    .should("have.length.of.at.least", 1);
+            });
+    });
+
+    it("saves current timestamp when not overridden by admin", () => {
+        const statusToApply = "Called and No Response";
+
+        cy.loginAsAdmin();
+        cy.visit("/parcels");
+
+        // Add status to the second parcel in the table
+        cy.get("div[data-testid='ParcelsTable']")
+            .find("#row-1")
+            .find('input[type="checkbox"]')
+            .first()
+            .check();
+
+        cy.get("#status-button").click();
+        cy.get('li[role="menuitem"]').contains(statusToApply).click();
+
+        cy.get('div[data-testid="StatusesModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get('[data-testid="OverrideDateTimeCheckbox"]').should("not.be.checked");
+
+                cy.get("button").contains("Submit").click();
+            });
+        const expectedEventDateTime = dayjs().format("DD/MM/YYYY, HH:mm:");
+
+        cy.get('div[data-testid="StatusesModal"]').should("not.exist");
+
+        // Open the details modal for the second parcel and look for current timestamp
+        cy.get("div[data-testid='ParcelsTable']").find("#row-1").click();
+        cy.get('div[data-testid="ParcelDetailsModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get("div[data-testid='EventTable'] [role='row']")
+                    .filter(`:contains('${statusToApply}')`)
+                    .filter(`:contains('${expectedEventDateTime}')`)
+                    .should("have.length.of.at.least", 1);
+            });
+    });
+
+    it("saves current timestamp for staff", () => {
+        const statusToApply = "Pending More Info";
+
+        cy.loginAsStaff();
+        cy.visit("/parcels");
+
+        // Add status to the second parcel in the table
+        cy.get("div[data-testid='ParcelsTable']")
+            .find("#row-2")
+            .find('input[type="checkbox"]')
+            .first()
+            .check();
+
+        cy.get("#status-button").click();
+        cy.get('li[role="menuitem"]').contains(statusToApply).click();
+
+        cy.get('div[data-testid="StatusesModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get('[data-testid="OverrideDateTimeCheckbox"]').should("not.exist");
+
+                cy.get("button").contains("Submit").click();
+            });
+        const expectedEventDateTime = dayjs().format("DD/MM/YYYY, HH:mm:");
+
+        cy.get('div[data-testid="StatusesModal"]').should("not.exist");
+
+        // Open the details modal for the second parcel and look for current timestamp
+        cy.get("div[data-testid='ParcelsTable']").find("#row-2").click();
+        cy.get('div[data-testid="ParcelDetailsModal"]')
+            .should("be.visible")
+            .within(() => {
+                cy.get("div[data-testid='EventTable'] [role='row']")
+                    .filter(`:contains('${statusToApply}')`)
+                    .filter(`:contains('${expectedEventDateTime}')`)
+                    .should("have.length.of.at.least", 1);
+            });
+    });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -20,6 +20,8 @@ declare global {
         /* eslint-disable no-unused-vars */
         interface Chainable {
             login: () => void;
+            loginAsAdmin: () => void;
+            loginAsStaff: () => void;
             checkAccessibility: (options?: object) => void;
         }
 
@@ -47,10 +49,7 @@ const loginWithRetry = (iteration = 0): void => {
     });
 };
 
-Cypress.Commands.add("login", () => {
-    const email: string = Cypress.env("TEST_USER");
-    const password: string = Cypress.env("TEST_PASS");
-
+const beginSessionAndLogin = (email: string, password: string): void => {
     cy.session(email, () => {
         cy.visit("/");
 
@@ -64,6 +63,27 @@ Cypress.Commands.add("login", () => {
     });
     // If session cache is used, it only restores cookies/storage and NOT page!
     // Remember to cy.visit(url) as the first action after a login :)
+};
+
+Cypress.Commands.add("login", () => {
+    const email: string = Cypress.env("TEST_USER");
+    const password: string = Cypress.env("TEST_PASS");
+
+    beginSessionAndLogin(email, password);
+});
+
+Cypress.Commands.add("loginAsAdmin", () => {
+    const email: string = Cypress.env("TEST_ADMIN_USER");
+    const password: string = Cypress.env("TEST_ADMIN_PASS");
+
+    beginSessionAndLogin(email, password);
+});
+
+Cypress.Commands.add("loginAsStaff", () => {
+    const email: string = Cypress.env("TEST_STAFF_USER");
+    const password: string = Cypress.env("TEST_STAFF_PASS");
+
+    beginSessionAndLogin(email, password);
 });
 
 Cypress.Commands.add("checkAccessibility", (options?) => {

--- a/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
+++ b/src/app/parcels/ActionBar/ActionModals/DriverOverviewModal.tsx
@@ -173,7 +173,7 @@ const DriverOverviewModal: React.FC<ActionModalProps> = (props) => {
             "Out for Delivery",
             `with ${driverName ?? displayNameForNullDriverName}`,
             undefined,
-            date
+            date.toISOString()
         );
         if (error) {
             setErrorMessage(getStatusErrorMessageWithLogId(error));

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -77,7 +77,7 @@ const Statuses: React.FC<Props> = ({
         void getParcelStatuses();
     }, [setModalError]);
 
-    const submitStatus = async (date: Dayjs): Promise<void> => {
+    const submitStatus = async (date?: Dayjs): Promise<void> => {
         setServerErrorMessage(null);
         if (selectedStatus === null) {
             setServerErrorMessage("Chosen status was not found.");

--- a/src/app/parcels/ActionBar/Statuses.tsx
+++ b/src/app/parcels/ActionBar/Statuses.tsx
@@ -83,12 +83,13 @@ const Statuses: React.FC<Props> = ({
             setServerErrorMessage("Chosen status was not found.");
             return;
         }
+
         const { error } = await saveParcelTableRowsStatus(
             selectedParcels,
             selectedStatus,
             null,
             undefined,
-            date
+            date?.toISOString()
         );
         if (error) {
             setServerErrorMessage(`${getStatusErrorMessage(error)} Log ID: ${error.logId}`);

--- a/src/app/parcels/ActionBar/StatusesModal.test.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.test.tsx
@@ -3,10 +3,18 @@ import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { expect, it } from "@jest/globals";
 import "@testing-library/jest-dom/jest-globals";
 import StatusesModal from "@/app/parcels/ActionBar/StatusesModal";
-import dayjs from "dayjs";
 import { ParcelsTableRow } from "@/app/parcels/parcelsTable/types";
+import { UserRole } from "@/databaseUtils";
 import StyleManager from "@/app/themes";
 import Localization from "@/app/Localization";
+import { RoleUpdateContext } from "@/app/roles";
+
+const managerAndAboveRoles: { [role: string]: UserRole }[] = [
+    { role: "admin" },
+    { role: "manager" },
+];
+const otherRoles: { [role: string]: UserRole }[] = [{ role: "staff" }, { role: "volunteer" }];
+const allRoles = [...managerAndAboveRoles, ...otherRoles];
 
 const mockData: ParcelsTableRow[] = [
     {
@@ -90,14 +98,9 @@ const mockSelectedParcels: ParcelsTableRow[] = mockData;
 const mockOnClose: jest.Mock = jest.fn();
 const mockOnSubmit: jest.Mock = jest.fn();
 
-describe("StatusesModal component", () => {
-    beforeEach(() => {
-        cleanup();
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date("2024-01-01T12:00:00"));
-        jest.clearAllMocks();
-
-        render(
+const renderModalWithRole = (role: UserRole): void => {
+    render(
+        <RoleUpdateContext.Provider value={{ role: role, setRole: jest.fn() }}>
             <Localization>
                 <StyleManager>
                     <StatusesModal
@@ -113,22 +116,57 @@ describe("StatusesModal component", () => {
                     </StatusesModal>
                 </StyleManager>
             </Localization>
-        );
+        </RoleUpdateContext.Provider>
+    );
+};
+
+describe("StatusesModal component", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
     });
 
-    it("renders without crashing", () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it.each(allRoles)("renders without crashing", ({ role }) => {
+        renderModalWithRole(role);
         expect(screen.getByText("Submit")).toBeInTheDocument();
     });
 
-    it("closes the modal when the close button is clicked", () => {
+    it.each(allRoles)("closes the modal when the close button is clicked", ({ role }) => {
+        renderModalWithRole(role);
         fireEvent.click(screen.getByLabelText("Close Button"));
         expect(mockOnClose).toHaveBeenCalledTimes(1);
     });
 
-    it("submits the selected valid date when the submit button is clicked", () => {
-        const mockDate = dayjs("2024-01-01 12:00:00");
-        fireEvent.click(screen.getByText("Submit"));
-
-        expect(mockOnSubmit).toHaveBeenCalledWith(mockDate);
+    it.each(managerAndAboveRoles)("shows the date override option for role: %o", ({ role }) => {
+        renderModalWithRole(role);
+        expect(screen.getByLabelText("Override status timestamp")).toBeInTheDocument();
+        expect(screen.getByLabelText("Override status timestamp")).not.toBeChecked();
     });
+
+    it.each(otherRoles)("does not show the date override option for role: %o", ({ role }) => {
+        renderModalWithRole(role);
+        expect(screen.queryByText("Override status timestamp")).not.toBeInTheDocument();
+    });
+
+    it.each(managerAndAboveRoles)(
+        "the date override option shows and hides the date/time pickers for role: %o",
+        ({ role }) => {
+            renderModalWithRole(role);
+            const overrideCheckbox = screen.getByLabelText("Override status timestamp");
+
+            expect(overrideCheckbox).not.toBeChecked();
+            expect(screen.queryByLabelText("Date and Time")).not.toBeInTheDocument();
+
+            fireEvent.click(overrideCheckbox);
+            expect(overrideCheckbox).toBeChecked();
+            expect(screen.getByLabelText("Date and Time")).toBeInTheDocument();
+
+            fireEvent.click(overrideCheckbox);
+            expect(overrideCheckbox).not.toBeChecked();
+            expect(screen.queryByLabelText("Date and Time")).not.toBeInTheDocument();
+        }
+    );
 });

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import styled from "styled-components";
-import Button from "@mui/material/Button";
+import { managerOrAboveRoles, RoleUpdateContext } from "@/app/roles";
+import { Checkbox, Button, FormControlLabel } from "@mui/material";
 import Modal from "@/components/Modal/Modal";
 import { DatePicker, TimePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
@@ -11,7 +12,7 @@ import { Centerer } from "@/components/Modal/ModalFormStyles";
 
 interface StatusesModalProps extends React.ComponentProps<typeof Modal> {
     selectedParcels: ParcelsTableRow[];
-    onSubmit: (date: Dayjs) => void;
+    onSubmit: (date?: Dayjs) => void;
     errorText: string | null;
 }
 
@@ -28,12 +29,28 @@ const ModalInner = styled.div`
     align-items: stretch;
 `;
 
+// QQ Tests for server-side timestamp
+// - managers & admins can see override option; staff/volunteers cannot - see WikiItems.test.tsx
+// - when override is checked, date & time pickers appear
+// - when override is unchecked, date & time pickers disappear
+// - when modal is opened, override is unchecked
+// - E2E test: submit with override checked saves with user timestamp
+// - E2E test: submit with override unchecked saves with current timestamp
+
 const StatusesModal: React.FC<StatusesModalProps> = (props) => {
+    const [dateTimeIsOverridden, setDateTimeIsOverridden] = useState<boolean>(false);
     const [date, setDate] = useState(dayjs(new Date()));
+
+    const { role } = useContext(RoleUpdateContext);
+    const userCanOverrideDateTime = role && managerOrAboveRoles.includes(role);
+
+    useEffect(() => {
+        setDateTimeIsOverridden(false);
+    }, [props.isOpen]);
 
     useEffect(() => {
         setDate(dayjs(new Date()));
-    }, [props.isOpen]);
+    }, [props.isOpen, dateTimeIsOverridden]);
 
     const onDateChange = (newDate: Dayjs | null): void =>
         setDate((date) =>
@@ -50,31 +67,62 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                 .set("minute", newDate?.minute() ?? date.minute())
         );
 
+    const handleOverrideCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        setDateTimeIsOverridden(event.target.checked);
+    };
+
     const maxParcelsToShow = 5;
 
     return (
         <Modal {...props}>
             <ModalInner>
                 {props.errorText && <ErrorSecondaryText>{props.errorText}</ErrorSecondaryText>}
-                <Centerer>
-                    <Row>
-                        Date:
-                        <DatePicker
-                            value={date}
-                            defaultValue={date}
-                            onChange={onDateChange}
-                            disableFuture
-                        />
-                        Time:
-                        <TimePicker value={date} onChange={onTimeChange} disableFuture />
-                    </Row>
-                </Centerer>
+                {userCanOverrideDateTime && (
+                    <>
+                        <Row>
+                            <FormControlLabel
+                                control={
+                                    <Checkbox
+                                        checked={dateTimeIsOverridden}
+                                        onChange={handleOverrideCheckbox}
+                                    />
+                                }
+                                label="Override status timestamp"
+                            />
+                        </Row>
+                        {dateTimeIsOverridden && (
+                            <Centerer>
+                                <Row>
+                                    Date:
+                                    <DatePicker
+                                        value={date}
+                                        defaultValue={date}
+                                        onChange={onDateChange}
+                                        disabled={!dateTimeIsOverridden}
+                                        disableFuture
+                                    />
+                                    Time:
+                                    <TimePicker
+                                        value={date}
+                                        onChange={onTimeChange}
+                                        disabled={!dateTimeIsOverridden}
+                                        disableFuture
+                                    />
+                                </Row>
+                            </Centerer>
+                        )}
+                    </>
+                )}
                 <SelectedParcelsOverview
                     parcels={props.selectedParcels}
                     maxParcelsToShow={maxParcelsToShow}
                 />
                 <Centerer>
-                    <Button type="button" variant="contained" onClick={() => props.onSubmit(date)}>
+                    <Button
+                        type="button"
+                        variant="contained"
+                        onClick={() => props.onSubmit(dateTimeIsOverridden ? date : undefined)}
+                    >
                         Submit
                     </Button>
                 </Centerer>

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -31,7 +31,7 @@ const ModalInner = styled.div`
 
 const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [dateTimeIsOverridden, setDateTimeIsOverridden] = useState<boolean>(false);
-    const [dateTime, setDate] = useState(dayjs(new Date()));
+    const [dateTime, setDateTime] = useState(dayjs(new Date()));
 
     const { role } = useContext(RoleUpdateContext);
     const userCanOverrideDateTime = role && managerOrAboveRoles.includes(role);
@@ -41,11 +41,11 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     }, [props.isOpen]);
 
     useEffect(() => {
-        setDate(dayjs(new Date()));
+        setDateTime(dayjs(new Date()));
     }, [props.isOpen, dateTimeIsOverridden]);
 
     const onDateTimeChange = (newDateTime: Dayjs | null): void => {
-        setDate((dateTime) =>
+        setDateTime((dateTime) =>
             dayjs()
                 .set("year", newDateTime?.year() ?? dateTime.year())
                 .set("month", newDateTime?.month() ?? dateTime.month())

--- a/src/app/parcels/ActionBar/StatusesModal.tsx
+++ b/src/app/parcels/ActionBar/StatusesModal.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { managerOrAboveRoles, RoleUpdateContext } from "@/app/roles";
 import { Checkbox, Button, FormControlLabel } from "@mui/material";
 import Modal from "@/components/Modal/Modal";
-import { DatePicker, TimePicker } from "@mui/x-date-pickers";
+import { DateTimePicker } from "@mui/x-date-pickers";
 import dayjs, { Dayjs } from "dayjs";
 import { ParcelsTableRow } from "../parcelsTable/types";
 import SelectedParcelsOverview from "./SelectedParcelsOverview";
@@ -29,17 +29,9 @@ const ModalInner = styled.div`
     align-items: stretch;
 `;
 
-// QQ Tests for server-side timestamp
-// - managers & admins can see override option; staff/volunteers cannot - see WikiItems.test.tsx
-// - when override is checked, date & time pickers appear
-// - when override is unchecked, date & time pickers disappear
-// - when modal is opened, override is unchecked
-// - E2E test: submit with override checked saves with user timestamp
-// - E2E test: submit with override unchecked saves with current timestamp
-
 const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const [dateTimeIsOverridden, setDateTimeIsOverridden] = useState<boolean>(false);
-    const [date, setDate] = useState(dayjs(new Date()));
+    const [dateTime, setDate] = useState(dayjs(new Date()));
 
     const { role } = useContext(RoleUpdateContext);
     const userCanOverrideDateTime = role && managerOrAboveRoles.includes(role);
@@ -52,20 +44,17 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
         setDate(dayjs(new Date()));
     }, [props.isOpen, dateTimeIsOverridden]);
 
-    const onDateChange = (newDate: Dayjs | null): void =>
-        setDate((date) =>
-            date
-                .set("year", newDate?.year() ?? date.year())
-                .set("month", newDate?.month() ?? date.month())
-                .set("date", newDate?.date() ?? date.date())
+    const onDateTimeChange = (newDateTime: Dayjs | null): void => {
+        setDate((dateTime) =>
+            dayjs()
+                .set("year", newDateTime?.year() ?? dateTime.year())
+                .set("month", newDateTime?.month() ?? dateTime.month())
+                .set("date", newDateTime?.date() ?? dateTime.date())
+                .set("hour", newDateTime?.hour() ?? dateTime.hour())
+                .set("minute", newDateTime?.minute() ?? dateTime.minute())
+                .set("second", 0)
         );
-
-    const onTimeChange = (newDate: Dayjs | null): void =>
-        setDate((date) =>
-            date
-                .set("hour", newDate?.hour() ?? date.hour())
-                .set("minute", newDate?.minute() ?? date.minute())
-        );
+    };
 
     const handleOverrideCheckbox = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setDateTimeIsOverridden(event.target.checked);
@@ -74,7 +63,7 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
     const maxParcelsToShow = 5;
 
     return (
-        <Modal {...props}>
+        <Modal {...props} testId="StatusesModal">
             <ModalInner>
                 {props.errorText && <ErrorSecondaryText>{props.errorText}</ErrorSecondaryText>}
                 {userCanOverrideDateTime && (
@@ -85,32 +74,22 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                                     <Checkbox
                                         checked={dateTimeIsOverridden}
                                         onChange={handleOverrideCheckbox}
+                                        data-testid="OverrideDateTimeCheckbox"
                                     />
                                 }
                                 label="Override status timestamp"
                             />
+                            {dateTimeIsOverridden && (
+                                <DateTimePicker
+                                    label="Date and Time"
+                                    aria-label="Date and Time"
+                                    value={dateTime}
+                                    onChange={onDateTimeChange}
+                                    disabled={!dateTimeIsOverridden}
+                                    disableFuture
+                                />
+                            )}
                         </Row>
-                        {dateTimeIsOverridden && (
-                            <Centerer>
-                                <Row>
-                                    Date:
-                                    <DatePicker
-                                        value={date}
-                                        defaultValue={date}
-                                        onChange={onDateChange}
-                                        disabled={!dateTimeIsOverridden}
-                                        disableFuture
-                                    />
-                                    Time:
-                                    <TimePicker
-                                        value={date}
-                                        onChange={onTimeChange}
-                                        disabled={!dateTimeIsOverridden}
-                                        disableFuture
-                                    />
-                                </Row>
-                            </Centerer>
-                        )}
                     </>
                 )}
                 <SelectedParcelsOverview
@@ -121,7 +100,7 @@ const StatusesModal: React.FC<StatusesModalProps> = (props) => {
                     <Button
                         type="button"
                         variant="contained"
-                        onClick={() => props.onSubmit(dateTimeIsOverridden ? date : undefined)}
+                        onClick={() => props.onSubmit(dateTimeIsOverridden ? dateTime : undefined)}
                     >
                         Submit
                     </Button>

--- a/src/app/parcels/ActionBar/saveStatus.ts
+++ b/src/app/parcels/ActionBar/saveStatus.ts
@@ -23,10 +23,11 @@ export const saveParcelStatus = async (
     statusName: StatusType,
     statusEventData?: string | null,
     action?: string,
-    date?: Dayjs
+    date?: string | Dayjs
 ): Promise<SaveParcelStatusResult> => {
     // This is server-side, so put the date through dayjs to ensure it's a Dayjs object
     const timestamp = (date ? dayjs(date) : dayjs()).toISOString();
+
     const eventsToInsert = parcelIds
         .map((parcelId: string) => {
             return {
@@ -74,7 +75,7 @@ export const saveParcelTableRowsStatus = async (
     statusName: StatusType,
     statusEventData?: string | null,
     action?: string,
-    date?: Dayjs
+    date?: string | Dayjs
 ): Promise<SaveParcelStatusResult> => {
     return saveParcelStatus(
         parcelRows.map((parcelRow) => parcelRow.parcelId),

--- a/src/app/parcels/ActionBar/saveStatus.ts
+++ b/src/app/parcels/ActionBar/saveStatus.ts
@@ -1,6 +1,6 @@
-"use client";
+"use server";
 
-import supabase from "@/supabaseClient";
+import { getSupabaseServerComponentClient } from "@/supabaseServer";
 import dayjs, { Dayjs } from "dayjs";
 import { logErrorReturnLogId } from "@/logger/logger";
 import { sendAuditLog } from "@/server/auditLog";
@@ -25,7 +25,8 @@ export const saveParcelStatus = async (
     action?: string,
     date?: Dayjs
 ): Promise<SaveParcelStatusResult> => {
-    const timestamp = (date ?? dayjs()).toISOString();
+    // This is server-side, so put the date through dayjs to ensure it's a Dayjs object
+    const timestamp = (date ? dayjs(date) : dayjs()).toISOString();
     const eventsToInsert = parcelIds
         .map((parcelId: string) => {
             return {
@@ -43,6 +44,7 @@ export const saveParcelStatus = async (
         parcelId: eventToInsert.parcel_id,
     }));
 
+    const supabase = getSupabaseServerComponentClient();
     const { data, error } = await supabase
         .from("events")
         .insert(eventsToInsert)

--- a/src/app/parcels/EventTable.tsx
+++ b/src/app/parcels/EventTable.tsx
@@ -35,6 +35,7 @@ const EventTable: React.FC<EventTableProps> = (props) => {
                 <ClientPaginatedTable
                     dataPortion={props.tableData}
                     headerKeysAndLabels={eventsTableHeaderKeysAndLabels}
+                    testId="EventTable"
                     columnDisplayFunctions={eventsTableColumnDisplayFunctions}
                     defaultShownHeaders={defaultShownHeaders}
                     checkboxConfig={{ displayed: false }}

--- a/src/app/parcels/parcelsTable/ParcelsModal.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsModal.tsx
@@ -78,7 +78,8 @@ const ParcelsModal: React.FC<ParcelsModalProps> = ({
                 onClose={() => {
                     closeParcelModal();
                 }}
-                headerId="expandedParcelDetailsModal"
+                headerId="ParcelDetailsModal"
+                testId="ParcelDetailsModal"
                 footer={
                     <Centerer>
                         <ConfirmButtons>

--- a/src/app/parcels/parcelsTable/ParcelsPage.test.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsPage.test.tsx
@@ -299,14 +299,14 @@ describe("Parcels Page", () => {
                         gender: "female",
                     },
                     {
-                        birth_year: 2009,
+                        birth_year: 2012,
                         birth_month: null,
                         recorded_as_child: null,
                         gender: null,
                     },
                 ])
             ).toEqual(
-                `${currentYear - 2019}-years-old male, ${currentYear - 2020}-years-old female, ${currentYear - 2009}-years-old unknown gender`
+                `${currentYear - 2019}-years-old male, ${currentYear - 2020}-years-old female, ${currentYear - 2012}-years-old unknown gender`
             );
 
             expect(
@@ -318,13 +318,13 @@ describe("Parcels Page", () => {
                         gender: "female",
                     },
                     {
-                        birth_year: 2009,
+                        birth_year: 2011,
                         birth_month: null,
                         recorded_as_child: null,
                         gender: "female",
                     },
                 ])
-            ).toEqual(`${currentYear - 2009}-years-old female`);
+            ).toEqual(`${currentYear - 2011}-years-old female`);
 
             expect(
                 formatBreakdownOfChildrenFromFamilyDetails([

--- a/src/app/parcels/parcelsTable/ParcelsTable.tsx
+++ b/src/app/parcels/parcelsTable/ParcelsTable.tsx
@@ -224,6 +224,7 @@ const ParcelsTable: React.FC<ParcelsTableProps> = ({
         <TableSurface>
             <ServerPaginatedTable<ParcelsTableRow, DbParcelRow, string | DateRangeState | string[]>
                 dataPortion={parcelsDataPortion}
+                testId="ParcelsTable"
                 isLoading={isLoading}
                 paginationConfig={{
                     enablePagination: true,

--- a/src/app/roles.tsx
+++ b/src/app/roles.tsx
@@ -74,4 +74,5 @@ export const RoleManager: React.FC<Props> = ({ children }) => {
 
 export const allRoles: UserRole[] = ["volunteer", "staff", "manager", "admin"];
 export const organisationRoles: UserRole[] = ["staff", "manager", "admin"];
+export const managerOrAboveRoles: UserRole[] = ["manager", "admin"];
 export const adminRoles: UserRole[] = ["admin"];

--- a/src/components/NavigationBar/NavigationBar.tsx
+++ b/src/components/NavigationBar/NavigationBar.tsx
@@ -250,7 +250,7 @@ const NavigationBar: React.FC<Props> = ({ children }) => {
                     onClose={() => {
                         setIslogOutModalOpen(false);
                     }}
-                    headerId="expandedParcelDetailsModal"
+                    headerId="LogoutModal"
                     maxWidth="xs"
                 >
                     <CenteredDiv>

--- a/src/components/Tables/Table.tsx
+++ b/src/components/Tables/Table.tsx
@@ -158,6 +158,7 @@ export type BreakPointConfig = {
 interface Props<Data, DbData extends Record<string, unknown>, PaginationType, FilterState> {
     dataPortion: Data[];
     headerKeysAndLabels: TableHeaders<Data>;
+    testId?: string;
     isLoading?: boolean;
     checkboxConfig: CheckboxConfig<Data>;
     paginationConfig: PaginationConfig;
@@ -228,6 +229,7 @@ const Table = <
 >({
     dataPortion,
     headerKeysAndLabels,
+    testId = undefined,
     isLoading = false,
     defaultShownHeaders,
     toggleableHeaders = [],
@@ -447,7 +449,7 @@ const Table = <
     ];
 
     return (
-        <div aria-live="polite">
+        <div aria-live="polite" data-testid={testId}>
             {(filterConfig.primaryFiltersShown || filterConfig.additionalFiltersShown) && (
                 <TableFiltersBar<
                     Data,


### PR DESCRIPTION
## What's changed
Timestamps are no longer set using the client time - instead default timestamps are server-side time.
Staff and volunteers can no longer override the timestamp; Admins & Managers can but it still defaults to server-side timestamp.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [X] Make sure you've tested via `npm run test`
