### PR TITLE
Install Node 24 in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,6 +3,7 @@ frontend:
   phases:
     preBuild:
       commands:
+        - nvm install 24
         - nvm use 24
         - npm ci
     build:


### PR DESCRIPTION
## What's changed
Amplify is only allowing Node 20 or 22, but recent upgrades to the package.json and GitHub action runner changes have required moving to Node 24 in the code


## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
