### PR TITLE
Vfb 530 sort delivery areas on admin page

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 2.9.6
+          version: 2.84.2
 
       - name: Start Supabase local development setup
         run: supabase start

--- a/.github/workflows/verify-generated-database-types.yml
+++ b/.github/workflows/verify-generated-database-types.yml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 2.9.6
+          version: 2.84.2
 
       - name: Start Supabase local development setup
         run: supabase start

--- a/src/app/admin/deliveryAreasTable/DeliveryAreasActions.ts
+++ b/src/app/admin/deliveryAreasTable/DeliveryAreasActions.ts
@@ -6,7 +6,7 @@ import { PostgrestError } from "@supabase/supabase-js";
 import { AuditLog, sendAuditLog } from "@/server/auditLog";
 
 export const fetchDeliveryAreas = async (): Promise<DeliveryAreasRow[]> => {
-    const { data, error } = await supabase.from("delivery_areas").select();
+    const { data, error } = await supabase.from("delivery_areas_plus").select();
 
     if (error) {
         const logId = await logErrorReturnLogId("Error with fetch: Delivery areas", error);
@@ -15,8 +15,9 @@ export const fetchDeliveryAreas = async (): Promise<DeliveryAreasRow[]> => {
 
     return data.map(
         (row): DeliveryAreasRow => ({
-            id: row.id,
-            postcode: row.postcode,
+            id: row.delivery_area_id ?? "",
+            postcode: row.postcode ?? "",
+            postcodeSortKey: row.postcode_sort_key ?? "",
             isNew: false,
         })
     );

--- a/src/app/admin/deliveryAreasTable/DeliveryAreasTable.tsx
+++ b/src/app/admin/deliveryAreasTable/DeliveryAreasTable.tsx
@@ -11,6 +11,7 @@ import {
     GridRowModes,
     GridRowModesModel,
     GridRowsProp,
+    GridSortModel,
     GridToolbarContainer,
 } from "@mui/x-data-grid";
 import Button from "@mui/material/Button";
@@ -86,6 +87,9 @@ function getBaseAuditLogForDeliveryAreasAction(
 const DeliveryAreasTable: React.FC = () => {
     const [rows, setRows] = useState<DeliveryAreasRow[]>([]);
     const [rowModesModel, setRowModesModel] = useState<GridRowModesModel>({});
+    const [sortModel, setSortModel] = React.useState<GridSortModel>([
+        { field: "postcodeSortKey", sort: "asc" },
+    ]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -220,6 +224,14 @@ const DeliveryAreasTable: React.FC = () => {
         }));
     };
 
+    const handleSortModelChange = (newModel: GridSortModel): void => {
+        if (newModel.length > 0 && newModel[0].field === "postcode") {
+            setSortModel([
+                { field: "postcodeSortKey", sort: sortModel[0].sort === "asc" ? "desc" : "asc" },
+            ]);
+        }
+    };
+
     const deliveryAreasColumns: GridColDef[] = [
         {
             field: "postcode",
@@ -227,9 +239,14 @@ const DeliveryAreasTable: React.FC = () => {
             headerAlign: "center",
             flex: 1,
             editable: true,
+            sortable: true,
             align: "center",
             renderHeader: (params) => <Header {...params} />,
             disableColumnMenu: true,
+        },
+        {
+            field: "postcodeSortKey",
+            headerName: "Postcode Sort Key",
         },
         {
             field: "actions",
@@ -290,14 +307,17 @@ const DeliveryAreasTable: React.FC = () => {
                 <StyledDataGrid
                     rows={rows}
                     aria-label="Delivery Areas Table"
+                    columns={deliveryAreasColumns}
                     initialState={{
-                        sorting: {
-                            sortModel: [{ field: "postcodeSortKey", sort: "asc" }],
+                        columns: {
+                            columnVisibilityModel: {
+                                postcodeSortKey: false,
+                            },
                         },
                     }}
+                    sortModel={sortModel}
+                    onSortModelChange={handleSortModelChange}
                     sortingOrder={["asc", "desc"]}
-                    // QQ: Needs sortConfig to sort by postcodeSortKey
-                    columns={deliveryAreasColumns}
                     editMode="row"
                     onCellDoubleClick={(params, event) => {
                         event.defaultMuiPrevented = true;

--- a/src/app/admin/deliveryAreasTable/DeliveryAreasTable.tsx
+++ b/src/app/admin/deliveryAreasTable/DeliveryAreasTable.tsx
@@ -42,6 +42,7 @@ interface EditToolbarProps {
 export interface DeliveryAreasRow {
     id: string;
     postcode: string;
+    postcodeSortKey: string;
     isNew: boolean;
 }
 
@@ -291,10 +292,11 @@ const DeliveryAreasTable: React.FC = () => {
                     aria-label="Delivery Areas Table"
                     initialState={{
                         sorting: {
-                            sortModel: [{ field: "postcode", sort: "asc" }],
+                            sortModel: [{ field: "postcodeSortKey", sort: "asc" }],
                         },
                     }}
                     sortingOrder={["asc", "desc"]}
+                    // QQ: Needs sortConfig to sort by postcodeSortKey
                     columns={deliveryAreasColumns}
                     editMode="row"
                     onCellDoubleClick={(params, event) => {

--- a/src/databaseTypesFile.ts
+++ b/src/databaseTypesFile.ts
@@ -110,6 +110,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "audit_log_delivery_areas_id_fkey"
+            columns: ["delivery_areas_id"]
+            isOneToOne: false
+            referencedRelation: "delivery_areas_plus"
+            referencedColumns: ["delivery_area_id"]
+          },
+          {
             foreignKeyName: "audit_log_event_id_fkey"
             columns: ["event_id"]
             isOneToOne: false
@@ -965,6 +972,24 @@ export type Database = {
         }
         Relationships: []
       }
+      delivery_areas_plus: {
+        Row: {
+          delivery_area_id: string | null
+          postcode: string | null
+          postcode_sort_key: string | null
+        }
+        Insert: {
+          delivery_area_id?: string | null
+          postcode?: string | null
+          postcode_sort_key?: never
+        }
+        Update: {
+          delivery_area_id?: string | null
+          postcode?: string | null
+          postcode_sort_key?: never
+        }
+        Relationships: []
+      }
       dietary_requirements_plus: {
         Row: {
           dairy_free: Database["public"]["Enums"]["item_dietary_status"] | null
@@ -1080,80 +1105,51 @@ export type Database = {
       }
     }
     Functions: {
-      create_postcode_sort_key: {
-        Args: {
-          pc: string
-        }
-        Returns: string
-      }
-      deactivateClient: {
-        Args: {
-          clientid: string
-        }
-        Returns: undefined
-      }
+      create_postcode_sort_key: { Args: { pc: string }; Returns: string }
+      deactivateClient: { Args: { clientid: string }; Returns: undefined }
       insert_client_and_family: {
-        Args: {
-          clientrecord: Json
-          familymembers: Json
-        }
+        Args: { clientrecord: Json; familymembers: Json }
         Returns: string
       }
       insert_parcel_with_delivery_instructions: {
-        Args: {
-          parcel_record: Json
-          delivery_instructions: string
-        }
+        Args: { delivery_instructions: string; parcel_record: Json }
         Returns: {
           parcel_primary_key: string
           rows_inserted: number
         }[]
       }
       packing_slot_order_swap: {
-        Args: {
-          id1: string
-          id2: string
-        }
+        Args: { id1: string; id2: string }
         Returns: undefined
       }
       swap_two_wiki_rows: {
-        Args: {
-          key1: string
-          key2: string
-        }
+        Args: { key1: string; key2: string }
         Returns: undefined
       }
       update_client_and_family: {
-        Args: {
-          clientrecord: Json
-          clientid: string
-          familymembers: Json
-        }
+        Args: { clientid: string; clientrecord: Json; familymembers: Json }
         Returns: Database["public"]["CompositeTypes"]["update_client_result"]
+        SetofOptions: {
+          from: "*"
+          to: "update_client_result"
+          isOneToOne: true
+          isSetofReturn: false
+        }
       }
       update_parcel_with_delivery_instructions: {
         Args: {
-          parcel_record: Json
           delivery_instructions: string
           parcel_primary_key: string
+          parcel_record: Json
         }
         Returns: {
           returned_parcel_primary_key: string
           rows_updated: number
         }[]
       }
-      user_is_admin: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
-      user_is_admin_or_manager: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
-      user_is_admin_or_manager_or_staff: {
-        Args: Record<PropertyKey, never>
-        Returns: boolean
-      }
+      user_is_admin: { Args: never; Returns: boolean }
+      user_is_admin_or_manager: { Args: never; Returns: boolean }
+      user_is_admin_or_manager_or_staff: { Args: never; Returns: boolean }
     }
     Enums: {
       day_of_week:
@@ -1186,27 +1182,33 @@ export type Database = {
   }
 }
 
-type PublicSchema = Database[Extract<keyof Database, "public">]
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -1214,20 +1216,24 @@ export type Tables<
     : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -1235,20 +1241,24 @@ export type TablesInsert<
     : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -1256,30 +1266,56 @@ export type TablesUpdate<
     : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
-    | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof PublicSchema["CompositeTypes"]
-    | { schema: keyof Database },
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof Database
+    schema: keyof DatabaseWithoutInternals
   }
-    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
-> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
-    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
+
+export const Constants = {
+  public: {
+    Enums: {
+      day_of_week: [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday",
+      ],
+      gender: ["male", "female", "other"],
+      item_dietary_status: ["included", "excluded", "not_specified"],
+      list_type: ["regular", "hotel"],
+      role: ["volunteer", "admin", "manager", "staff"],
+    },
+  },
+} as const
 

--- a/supabase/migrations/20260329230432_add_delivery_areas_plus.sql
+++ b/supabase/migrations/20260329230432_add_delivery_areas_plus.sql
@@ -1,0 +1,10 @@
+create or replace view
+  public.delivery_areas_plus with (security_invoker = true) as
+select
+    delivery_areas.id as delivery_area_id,
+    delivery_areas.postcode,
+    create_postcode_sort_key(delivery_areas.postcode) as postcode_sort_key
+from
+    delivery_areas
+order by
+    postcode_sort_key;


### PR DESCRIPTION
## What's changed
The Delivery Areas grid on the Admin page now sorts postcodes using the key generated by the DB function for that purpose. Many of the changes in databaseFileTypes.ts because the previous commit on the intern-dev branch included a significant update to Supabase CLI which hadn't done its own regeneration of the file types.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [X] I have self-reviewed this PR
- [X] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`

If you have made any changes to the database...
  - [x] The migration files are up-to-date with my final set up (`npx supabase db diff -f <name_of_migration>` should create nothing at this point)
  - [X] I have updated the typescript definitions for the database with `npm run generate_types:local`
  - [-] I have modified the seed in `supabase/seed/seed.ts` if appropriate
  - [-] If I have modified the seed, I have also generated the seed with `npm run db:generate_seed` 
  - [ ] With my final set up, I can run `npm run reset_supabase` without any errors.
  - [x] (Just before merging the ticket) I have updated the timestamps of the new migration files so that they are after all existing migration files.
  - [ ] I have taken reasonable measures to ensure constraint violations do not happen when the migration occurs, e.g.:
    - audit_log FK constraints that could be violated
    - any constraints that I have added, e.g. `set not null`
  - [ ] I have checked that migration can happen successfully without resetting the database, doing the following.
    - Make sure you have rebased your branch onto dev or merged dev into your branch.
    - Checkout the dev branch
    - Run `npm run post_checkout` to reset the database, including the seed data.
    - Checkout your branch
    - Run `npx supabase migrations up --include-all --local` to run all outstanding migration files
    - Check that the resulting database is what you expect, bar any seed data changes.

