### PR TITLE
VFB-448: restore previous logic on submitting fields with optional text

### DIFF
--- a/src/app/clients/form/submitFormHelpers.ts
+++ b/src/app/clients/form/submitFormHelpers.ts
@@ -49,13 +49,12 @@ export const formatClientRecord = (
             fields.dietaryRequirements !== null
                 ? checkboxGroupToArray(fields.dietaryRequirements)
                 : null,
-        hygiene_tampons:
-            fields.hygieneProductsTampons !== null ? fields.hygieneProductsTampons : "",
-        hygiene_pads: fields.hygieneProductsPads !== null ? fields.hygieneProductsPads : "",
+        hygiene_tampons: fields.hygieneProductsTampons,
+        hygiene_pads: fields.hygieneProductsPads,
         hygiene_other_items: checkboxGroupToArray(fields.hygieneOtherItems),
-        baby_food: fields.babyFood !== null ? fields.babyFood : "",
-        baby_formula: fields.babyFormula !== null ? fields.babyFormula : "",
-        baby_nappies: fields.babyNappies !== null ? fields.babyNappies : "",
+        baby_food: fields.babyFood,
+        baby_formula: fields.babyFormula,
+        baby_nappies: fields.babyNappies,
         baby_other_items: checkboxGroupToArray(fields.babyOtherItems),
         pet_food: checkboxGroupToArray(fields.petFood),
         other_items: checkboxGroupToArray(fields.otherItems),


### PR DESCRIPTION
## What's changed
The previous fix (see [here](https://github.com/LambethFoodbank/foodbankapp/pull/793) caused a bug, where these checkboxes couldn't be turned off, because the database stored an empty string. The checkbox being off is represented by null.
A proper fix will have to be thought through later.

## Checklist
- [x] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] I have checked that any E2E tests do not assume that the database contains specific data, unless set by migration
- [x] Make sure you've verified it works via `npm run dev`
- [x] Make sure you've verified it works via `npm run build` and `npm run start`
- [x] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`


