### PR TITLE
VFB-537: Temporarily hide dietary requirements panel on admin page

### DIFF
--- a/src/app/admin/AdminPage.tsx
+++ b/src/app/admin/AdminPage.tsx
@@ -23,8 +23,6 @@ import PackingSlotsTable from "@/app/admin/packingSlotsTable/PackingSlotsTable";
 import WebsiteDataTable from "./websiteDataTable/WebsiteDataTable";
 import AuditLogTable from "./auditLogTable/AuditLogTable";
 import DeliveryAreasTable from "@/app/admin/deliveryAreasTable/DeliveryAreasTable";
-import { faBowlFood } from "@fortawesome/free-solid-svg-icons/faBowlFood";
-import DietaryRequirementsTable from "@/app/admin/dietaryRequirementsTable/DietaryRequirementsTable";
 
 const PanelTitle = styled.h2`
     text-transform: uppercase;
@@ -59,11 +57,6 @@ const AdminPage: React.FC = () => {
             panelTitle: "Modify Packing Slots",
             panelIcon: faBoxOpen,
             panelContent: <PackingSlotsTable />,
-        },
-        {
-            panelTitle: "Dietary Requirements",
-            panelIcon: faBowlFood,
-            panelContent: <DietaryRequirementsTable />,
         },
         {
             panelTitle: "Edit Delivery Areas",


### PR DESCRIPTION
## What's changed
The dietary requirements functionality is not ready for use, so hiding the panel for the current release.


## Checklist
- [ ] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [ ] I have documented the testing steps for QA
- [ ] I have self-reviewed this PR
- [ ] I have checked that any E2E tests do not assume that the database contains specific data, unless set by migration
- [ ] Make sure you've verified it works via `npm run dev`
- [ ] Make sure you've verified it works via `npm run build` and `npm run start`
- [ ] Make sure you've fixed all linting problems with `npm run lint_fix`
- [ ] Make sure you've tested via `npm run test`
