### PR TITLE
VFB-538: Fix parcel form collection centre error logic

### DIFF
--- a/src/app/parcels/form/ParcelForm.tsx
+++ b/src/app/parcels/form/ParcelForm.tsx
@@ -331,6 +331,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
                 collectionCentre: switchErrorForCollectionCentre(
                     fields,
                     collectionCentreIsActive,
+                    initialFields.collectionCentre !== null,
                     deliveryPrimaryKey
                 ),
                 collectionDate: switchErrorForCollectionDate(
@@ -356,6 +357,7 @@ const ParcelForm: React.FC<ParcelFormProps> = ({
         fields.collectionDate,
         fields.collectionSlot,
         fields.shippingMethod,
+        initialFields.collectionCentre,
     ]);
 
     const formSections =

--- a/src/app/parcels/form/formSections/CollectionCentreCard.tsx
+++ b/src/app/parcels/form/formSections/CollectionCentreCard.tsx
@@ -16,7 +16,6 @@ import {
 import GenericFormCard from "@/components/Form/GenericFormCard";
 import { ParcelCardProps, ParcelFields } from "../ParcelForm";
 import { StyledAlert } from "../../ActionBar/DuplicateDownloadWarning";
-import { switchErrorForCollectionCentre } from "@/app/parcels/form/submitFormHelpers";
 
 interface CollectionCentreCardProps extends ParcelCardProps {
     collectionCentresLabelsAndValues: CollectionCentresLabelsAndValues;
@@ -36,8 +35,6 @@ const CollectionCentreCard: React.FC<CollectionCentreCardProps> = ({
     errorSetter,
     formErrors,
     fields,
-    deliveryPrimaryKey,
-    collectionCentreIsActive,
     collectionCentresLabelsAndValues,
     collectionAvailableDays,
     availableDaysForSelectedCentre,
@@ -79,8 +76,8 @@ const CollectionCentreCard: React.FC<CollectionCentreCardProps> = ({
 
     const isUnavailableCentre = (): boolean => {
         return (
-            switchErrorForCollectionCentre(fields, collectionCentreIsActive, deliveryPrimaryKey) ===
-                Errors.none &&
+            fields.collectionCentre !== null &&
+            formErrors.collectionCentre === Errors.none &&
             availableDaysForSelectedCentre &&
             !availableDaysForSelectedCentre.some((day) => day.is_active)
         );

--- a/src/app/parcels/form/submitFormHelpers.ts
+++ b/src/app/parcels/form/submitFormHelpers.ts
@@ -27,9 +27,10 @@ type InsertParcel = (
 export function switchErrorForCollectionCentre(
     fields: ParcelFields,
     collectionCentreIsActive: boolean,
+    formHasInitialCollectionCentre: boolean,
     deliveryPrimaryKey: string
 ): Errors {
-    if (!collectionCentreIsActive) {
+    if (formHasInitialCollectionCentre && !collectionCentreIsActive) {
         return Errors.invalidCollectionCentre;
     }
 


### PR DESCRIPTION
## What's changed
On the Add Parcel form, the Collection Centre field used to show "previous collection centre is no longer available" because it wasn't checking if there was an actual initial CC.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [x] I have checked that any E2E tests do not assume that the database contains specific data, unless set by migration
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
