### PR TITLE
VFB-540: Edit Client submit opens latest Parcel Edit form

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ have been delivered to clients.
     sudo apt-get install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
     ```
 
+-   Run `npx @snaplet/seed sync` to synchronise the seed files with the local database - otherwise doing a local production
+    build will fail
+
 ### Running locally
 
 -   Run website locally (`npm run dev`) and log in with one of the dev user credentials

--- a/package-lock.json
+++ b/package-lock.json
@@ -11643,7 +11643,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/src/app/clients/edit/[id]/page.tsx
+++ b/src/app/clients/edit/[id]/page.tsx
@@ -8,7 +8,7 @@ import { returnPathQueryParam } from "@/common/constants";
 import ClientForm, { ClientErrors } from "@/app/clients/form/ClientForm";
 import { Errors } from "@/components/Form/formFunctions";
 import autofill from "@/app/clients/edit/[id]/autofill";
-import { fetchClient, fetchFamily } from "@/common/fetch";
+import { fetchClient, fetchFamily, fetchLatestParcelIdForClient } from "@/common/fetch";
 import { Schema } from "@/databaseUtils";
 import { ErrorSecondaryText } from "@/app/errorStylingandMessages";
 
@@ -23,6 +23,7 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
 
     const [clientData, setClientData] = useState<Schema["clients"] | null>(null);
     const [familyData, setFamilyData] = useState<Schema["families"][] | null>(null);
+    const [latestParcelId, setLatestParcelId] = useState<string | null>(null);
     const [error, setError] = useState<string | null>();
     const [returnPath, setReturnPath] = useState<string | null>(null);
 
@@ -66,6 +67,20 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
                 return;
             }
             setFamilyData(familyData);
+
+            const { data: latestParcelId, error: latestParcelIdError } =
+                await fetchLatestParcelIdForClient(params.id, supabase);
+            if (latestParcelIdError) {
+                switch (latestParcelIdError.type) {
+                    case "failedToFetchLatestParcelIdForClient":
+                        setError(
+                            `Unable to fetch latest parcel ID for client. Log ID: ${latestParcelIdError.logId}`
+                        );
+                        break;
+                }
+                return;
+            }
+            setLatestParcelId(latestParcelId);
         })();
     }, [params.id, searchParams]);
 
@@ -93,7 +108,11 @@ const EditClients: ({ params }: EditClientsParameters) => React.ReactElement = (
                     <ClientForm
                         initialFields={initialFields}
                         initialFormErrors={initialFormErrors}
-                        editConfig={{ clientID: params.id, editMode: true }}
+                        editConfig={{
+                            clientID: params.id,
+                            editMode: true,
+                            latestParcelId: latestParcelId,
+                        }}
                         returnPath={returnPath}
                     />
                 )

--- a/src/app/clients/form/ClientForm.tsx
+++ b/src/app/clients/form/ClientForm.tsx
@@ -48,7 +48,9 @@ interface Props {
     returnPath?: string | null;
 }
 
-type EditConfig = { editMode: true; clientID: string } | { editMode: false };
+type EditConfig =
+    | { editMode: true; clientID: string; latestParcelId: string | null }
+    | { editMode: false };
 
 export interface ClientFields extends Fields {
     fullName: string;
@@ -131,6 +133,11 @@ const ClientForm: React.FC<Props> = ({
     const fieldSetter = createSetter(setFields, fields);
     const errorSetter = createSetter(setFormErrors, formErrors);
 
+    const submitLabel =
+        editConfig.editMode && editConfig.latestParcelId
+            ? "Submit and Edit Latest Parcel"
+            : "Submit and Add Parcel";
+
     const submitForm = async (): Promise<void> => {
         setSubmitDisabled(true);
 
@@ -163,10 +170,10 @@ const ClientForm: React.FC<Props> = ({
                 return;
             }
 
-            if (returnPath) {
-                router.push(decodeURIComponent(returnPath));
+            if (editConfig.latestParcelId) {
+                router.push(appendReturnPathToUrl(`/parcels/edit/${editConfig.latestParcelId}`));
             } else {
-                router.push(`/clients?clientId=${clientId}`);
+                router.push(appendReturnPathToUrl(`/parcels/add/${clientId}`));
             }
         } else {
             const { clientId, error: addClientError } = await submitAddClientForm(fields);
@@ -182,14 +189,17 @@ const ClientForm: React.FC<Props> = ({
                 return;
             }
 
-            let targetUrl = `/parcels/add/${clientId}`;
-            if (returnPath) {
-                const paramsRecord: Record<string, string> = {};
-                paramsRecord[returnPathQueryParam] = returnPath;
-                targetUrl += `?${stringifyQueryParams(paramsRecord)}`;
-            }
-            router.push(targetUrl);
+            router.push(appendReturnPathToUrl(`/parcels/add/${clientId}`));
         }
+    };
+
+    const appendReturnPathToUrl = (url: string): string => {
+        if (returnPath) {
+            const paramsRecord: Record<string, string> = {};
+            paramsRecord[returnPathQueryParam] = returnPath;
+            return (url += `?${stringifyQueryParams(paramsRecord)}`);
+        }
+        return url;
     };
 
     return (
@@ -213,7 +223,7 @@ const ClientForm: React.FC<Props> = ({
                 })}
                 <CenterComponent>
                     <Button variant="contained" onClick={submitForm} disabled={submitDisabled}>
-                        Submit
+                        {submitLabel}
                     </Button>
                 </CenterComponent>
                 <FormErrorText>{submitErrorMessage || submitError}</FormErrorText>

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -321,6 +321,44 @@ export const fetchFamily = async (
     return { data: data, error: null };
 };
 
+type FetchLatestParcelIdForClientResponse =
+    | {
+          data: string | null;
+          error: null;
+      }
+    | {
+          data: null;
+          error: { type: FetchLatestParcelIdForClientErrorType; logId: string };
+      };
+
+export type FetchLatestParcelIdForClientErrorType = "failedToFetchLatestParcelIdForClient";
+
+export const fetchLatestParcelIdForClient = async (
+    clientID: string,
+    supabase: Supabase
+): Promise<FetchLatestParcelIdForClientResponse> => {
+    const { data, error } = await supabase
+        .from("parcels")
+        .select("primary_key")
+        .eq("client_id", clientID)
+        .order("packing_date", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+    if (error) {
+        const logId = await logErrorReturnLogId(
+            "Error with fetch: Latest parcel ID for client",
+            error
+        );
+        return {
+            data: null,
+            error: { type: "failedToFetchLatestParcelIdForClient", logId: logId },
+        };
+    }
+
+    return { data: data?.primary_key ?? null, error: null };
+};
+
 type FetchListsReponse =
     | {
           data: Schema["lists"][];


### PR DESCRIPTION
## What's changed
On submitting the Edit Client form, the Edit Parcel form is opened for the client's latest-packing-date parcel, or Add Parcel if they don't have any parcels.

## Checklist
- [X] The ticket is up-to-date - Please document any deviations from the original approach if there is any.
- [x] I have documented the testing steps for QA
- [x] I have self-reviewed this PR
- [X] I have checked that any E2E tests do not assume that the database contains specific data, unless set by migration
- [X] Make sure you've verified it works via `npm run dev`
- [X] Make sure you've verified it works via `npm run build` and `npm run start`
- [X] Make sure you've fixed all linting problems with `npm run lint_fix`
- [x] Make sure you've tested via `npm run test`
